### PR TITLE
test(e2e): fix all failing functional tests in none/internal/oidc modes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -46,7 +46,7 @@ fi
 # ── Secret scanning (always, all file types) ──────────────────────────────────
 echo "  [Security] Running gitleaks (secret scan)..."
 git diff --cached | podman run --rm -i \
-  -v "$PWD/.gitleaks.toml:/repo/.gitleaks.toml:ro" \
+  -v "$PWD/.gitleaks.toml:/repo/.gitleaks.toml:ro,z" \
   zricethezav/gitleaks:latest detect --pipe --redact -c /repo/.gitleaks.toml
 
 echo "✅ All pre-commit checks passed."

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -168,8 +168,8 @@ func NewRouter(
 	// Rate limiters:
 	//   writeRL  — 30 req/min per IP for all mutating operations
 	//   pollRL   — 1 req/5s  per IP for /poll (matches the minimum client poll interval)
-	writeRL := rateLimiter(0.5, 10) // 0.5 req/s = 30/min, burst 10
-	pollRL := rateLimiter(0.2, 2)   // 0.2 req/s = 1/5s, burst 2
+	writeRL := rateLimiter(0.5, 10)            // 0.5 req/s = 30/min, burst 10
+	pollRL := rateLimiter(pollRLRate, pollRLBurst) // prod: 0.2 req/s = 1/5s, burst 2 (relaxed in e2e builds)
 
 	requireAuth := auth.RequireAuth(authProvider)
 

--- a/backend/internal/api/testing_routes_e2e.go
+++ b/backend/internal/api/testing_routes_e2e.go
@@ -8,8 +8,16 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"golang.org/x/time/rate"
 	"github.com/kj187/jarvis/backend/internal/alertmanager"
 	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+// Poll rate limit for POST /api/v1/poll in e2e builds: effectively unlimited so
+// deterministic tests can force immediate polls without hitting 429.
+const (
+	pollRLRate  rate.Limit = rate.Inf
+	pollRLBurst int        = 1000
 )
 
 // registerTestRoutes wires the e2e-only seed/reset endpoints. These are gated

--- a/backend/internal/api/testing_routes_e2e.go
+++ b/backend/internal/api/testing_routes_e2e.go
@@ -188,10 +188,17 @@ func (s *Server) testSetClaim(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "claimedBy is required")
 	}
 
-	_, err := s.store.SetClaim(req.Fingerprint, nil, req.ClaimedBy, req.Note)
+	claim, err := s.store.SetClaim(req.Fingerprint, nil, req.ClaimedBy, req.Note)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
+
+	// Mirror the production claim handler so WS-driven UI updates work in e2e.
+	s.alertStore.SetActiveClaim(req.Fingerprint, claim)
+	s.hub.BroadcastJSON(models.WSTypeClaimSet, map[string]interface{}{
+		"fingerprint": req.Fingerprint,
+		"claim":       claim,
+	})
 
 	return c.NoContent(http.StatusNoContent)
 }

--- a/backend/internal/api/testing_routes_noe2e.go
+++ b/backend/internal/api/testing_routes_noe2e.go
@@ -2,8 +2,17 @@
 
 package api
 
-import "github.com/labstack/echo/v4"
+import (
+	"github.com/labstack/echo/v4"
+	"golang.org/x/time/rate"
+)
 
 // registerTestRoutes is a no-op in production builds. The e2e seed/reset
 // endpoints are only compiled in when built with the "e2e" build tag.
 func (s *Server) registerTestRoutes(_ *echo.Group) {}
+
+// Poll rate limit for POST /api/v1/poll in production builds: 0.2 req/s (1/5s), burst 2.
+const (
+	pollRLRate  rate.Limit = 0.2
+	pollRLBurst int        = 2
+)

--- a/frontend/e2e/fixtures/alerts.ts
+++ b/frontend/e2e/fixtures/alerts.ts
@@ -220,3 +220,24 @@ export const manyAlerts: AlertInput[] = [
     },
   },
 ]
+
+/**
+ * Five firing instances of a single alertname (different pods) so a single
+ * AlertCard group exceeds the card page size and renders pagination.
+ */
+export const crashLoopBurst: AlertInput[] = Array.from({ length: 5 }, (_, i) => ({
+  labels: {
+    alertname: 'KubePodCrashLooping',
+    severity: 'critical',
+    namespace: 'prod',
+    pod: `payment-api-7d9f6b8c4-pod${i}`,
+    container: 'payment-api',
+    cluster: 'e2e',
+    team: 'platform',
+    runbook: `${RUNBOOKS}/KubePodCrashLooping`,
+  },
+  annotations: {
+    summary: `Pod payment-api-7d9f6b8c4-pod${i} is crash looping`,
+    description: 'Pod has restarted repeatedly in the last 15 minutes. Exit code: 137 (OOMKilled).',
+  },
+}))

--- a/frontend/e2e/functional/none/alerts-views.spec.ts
+++ b/frontend/e2e/functional/none/alerts-views.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, waitForActiveAlerts, JARVIS_BASE_URL } from '../../support/fixtures'
 import { dismissNoAuthNotice } from '../../support/auth'
-import { kubernetesAlerts, manyAlerts } from '../../fixtures/alerts'
+import { kubernetesAlerts, manyAlerts, crashLoopBurst } from '../../fixtures/alerts'
 
 test('B2/B3 list<->card toggle persists', async ({ page, am, jarvis }) => {
   await dismissNoAuthNotice(page)
@@ -25,17 +25,18 @@ test('B4 severity ordering starts with critical section', async ({ page, am, jar
   await am.fire(manyAlerts)
   await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, manyAlerts.length)
 
-  await page.goto('/?state=active&viewMode=list')
+  await page.goto('/?state=active')
+  await page.getByTitle('List View').click()
   const firstSeverityHeader = page.locator('tbody tr td span.text-xs.font-bold.uppercase').first()
   await expect(firstSeverityHeader).toHaveText(/critical/i)
 })
 
 test('B5 card pagination shows "x-y of n" and +/- boundaries', async ({ page, am, jarvis }) => {
   await dismissNoAuthNotice(page)
-  await am.fire(manyAlerts)
-  await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, manyAlerts.length)
+  await am.fire(crashLoopBurst)
+  await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, crashLoopBurst.length)
 
-  await page.goto('/?state=active&viewMode=card')
+  await page.goto('/?state=active')
   await expect(page.getByText(/\d+–\d+ of \d+/).first()).toBeVisible()
 
   const minus = page.getByRole('button', { name: '−' }).first()
@@ -68,6 +69,11 @@ test('B9 resolved mode uses flat list and page size controls', async ({ page, ja
       fingerprint: `resolved-${i}`,
       alertname: `ResolvedAlert${i}`,
       cluster: 'e2e',
+      labels: {
+        alertname: `ResolvedAlert${i}`,
+        severity: 'warning',
+        cluster: 'e2e',
+      },
       startsAt: '2025-01-15T10:00:00Z',
       resolvedAt: '2025-01-15T11:00:00Z',
     })),
@@ -76,9 +82,9 @@ test('B9 resolved mode uses flat list and page size controls', async ({ page, ja
   await page.goto('/?state=resolved')
   await expect(page.getByRole('columnheader', { name: 'Alert Name' })).toBeVisible()
   await expect(page.getByText('Per page:')).toBeVisible()
-  await expect(page.getByRole('button', { name: '10' })).toBeVisible()
-  await expect(page.getByRole('button', { name: '25' })).toBeVisible()
-  await expect(page.getByRole('button', { name: '50' })).toBeVisible()
-  await expect(page.getByRole('button', { name: '100' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '10', exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: '25', exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: '50', exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: '100', exact: true })).toBeVisible()
   await expect(page.getByText(/\d+–\d+ of 35/).first()).toBeVisible()
 })

--- a/frontend/e2e/functional/none/detail-panel.spec.ts
+++ b/frontend/e2e/functional/none/detail-panel.spec.ts
@@ -93,28 +93,41 @@ test.describe('D2: Labels & annotations rendered', () => {
     expect(labelTexts.join('').toLowerCase()).toContain('alertname')
   })
 
-  test('detail panel shows all annotations', async ({ page, am, jarvis }) => {
+  test('detail panel shows summary and extra annotations', async ({ page, am, jarvis }) => {
     await dismissNoAuthNotice(page)
-    await am.fire(kubernetesAlerts)
-    await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, kubernetesAlerts.length)
+    // summary/description render in their own "Summary" section; only extra
+    // annotations (not summary/description/links) appear in the annotations section.
+    await am.fire([
+      {
+        labels: { alertname: 'AnnotatedAlert', severity: 'warning', cluster: 'e2e' },
+        annotations: {
+          summary: 'A concise summary of the alert',
+          description: 'A longer description of the alert',
+          impact: 'Customer-facing latency increase',
+        },
+      },
+    ])
+    await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, 1)
 
     await page.goto('/?state=active')
-    
+
     // Open detail
     const firstCard = page.getByTestId('alert-card').first()
     await firstCard.click()
     await page.waitForTimeout(500)
-    
-    // Verify annotations section
+
+    // Summary section renders the summary text
+    await expect(page.getByTestId('detail-panel').getByText('A concise summary of the alert')).toBeVisible()
+
+    // Extra (non-summary/description) annotations appear in the annotations section
     const annotationsSection = page.getByTestId('detail-annotations-section')
     await expect(annotationsSection).toBeVisible()
-    
-    // Verify annotation items
+
     const annotationItems = page.getByTestId('detail-annotation-item')
     const annotationTexts = await annotationItems.allTextContents()
-    
+
     expect(annotationTexts.length).toBeGreaterThan(0)
-    expect(annotationTexts.join('').toLowerCase()).toContain('summary')
+    expect(annotationTexts.join('').toLowerCase()).toContain('impact')
   })
 
   test('annotation links are clickable (dashboard, runbook)', async ({ page, am, jarvis }) => {
@@ -215,7 +228,7 @@ test.describe('D5: Stats & timeline', () => {
   test('detail panel shows duration (when resolved)', async ({ page, jarvis }) => {
     await dismissNoAuthNotice(page)
     
-    // Seed a resolved alert
+    // Seed a resolved alert (labels required, else backend returns labels:null and the row fails to render)
     await jarvis.seedResolved([
       {
         fingerprint: 'resolved-alert',
@@ -223,6 +236,7 @@ test.describe('D5: Stats & timeline', () => {
         cluster: 'e2e',
         startsAt: '2025-01-15T10:00:00Z',
         resolvedAt: '2025-01-15T10:30:00Z',
+        labels: { alertname: 'ResolvedAlert', severity: 'warning', cluster: 'e2e' },
       },
     ])
     
@@ -485,13 +499,15 @@ test.describe('D9: Add comment', () => {
     // Find comment input
     const commentInput = page.getByTestId('detail-comment-input')
     if (await commentInput.isVisible()) {
+      // In 'none' auth mode an author name is required before the submit enables.
+      await page.getByPlaceholder('Your name').fill('e2e-tester')
       await commentInput.fill('New comment from form')
-      
+
       const submitButton = page.getByTestId('detail-comment-submit')
       await submitButton.click()
-      
+
       await page.waitForTimeout(500)
-      
+
       // Verify comment appears
       const commentTexts = await page.getByTestId('detail-comment-item').allTextContents()
       expect(commentTexts.join('\n')).toContain('New comment from form')
@@ -530,33 +546,12 @@ test.describe('D10: Delete comment (author only)', () => {
     }
   })
 
-  test('different user cannot delete others comments', async ({ page, am, jarvis }) => {
-    await dismissNoAuthNotice(page)
-    await am.fire(kubernetesAlerts)
-    await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, kubernetesAlerts.length)
-
-    // Get a fingerprint
-    const res = await fetch(`${JARVIS_BASE_URL}/api/v1/alerts`)
-    const alerts: any[] = await res.json()
-    const fingerprint = alerts[0].fingerprint
-    
-    // Add comment from user1
-    await jarvis.addComment(fingerprint, 'User1 comment', 'user-one')
-    
-    // Open detail (as user2)
-    await page.goto(`/?state=active&alert=${fingerprint}`)
-    await page.waitForTimeout(500)
-    
-    // Verify delete button NOT visible for other users comment
-    const deleteButtons = page.getByTestId('detail-comment-delete')
-    const count = await deleteButtons.count()
-    
-    // Either 0 delete buttons or none match this comment
-    if (count > 0) {
-      const firstDeleteParent = await deleteButtons.first().locator('xpath=ancestor::*[@data-testid="detail-comment-item"]')
-      const commentText = await firstDeleteParent.textContent()
-      expect(commentText).not.toContain('User1 comment')
-    }
+  test('different user cannot delete others comments', async () => {
+    // Author-only delete enforcement requires a user identity. In 'none' auth
+    // mode there is no current user, so every comment is deletable by design
+    // (AlertComments: canDelete === true when authMode === 'none'). This case is
+    // only meaningful with auth enabled — covered in the internal/oidc suites.
+    test.skip()
   })
 
   test('admin/mod can delete any comment', async ({ page, am, jarvis }) => {

--- a/frontend/e2e/functional/none/filters.spec.ts
+++ b/frontend/e2e/functional/none/filters.spec.ts
@@ -31,17 +31,23 @@ test('C10 matcher state is restored from URL', async ({ page, am, jarvis }) => {
   const matchers = encodeURIComponent(JSON.stringify([{ name: 'severity', operator: '=', value: 'critical' }]))
   await page.goto(`/?state=active&matchers=${matchers}`)
 
-  await expect(page.getByText('severity')).toBeVisible()
-  await expect(page.getByText('critical')).toBeVisible()
+  await expect(page.getByText('severity', { exact: true })).toBeVisible()
+  await expect(page.getByText('critical', { exact: true })).toBeVisible()
 })
 
-test('C11 search via q filters by alertname/labels', async ({ page, am, jarvis }) => {
+test('C11 search via ?q= filters by alertname/labels', async ({ page, am, jarvis }) => {
   await dismissNoAuthNotice(page)
   await am.fire(kubernetesAlerts)
   await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, kubernetesAlerts.length)
 
   await page.goto('/?state=active&q=kubepod')
-  await expect(page.getByText(/KubePodCrashLooping/i)).toBeVisible()
+  await expect(page.getByText('KubePodCrashLooping', { exact: true })).toBeVisible()
+})
+
+test('C11 search via the toggle input filters by label value', async ({ page, am, jarvis }) => {
+  await dismissNoAuthNotice(page)
+  await am.fire(kubernetesAlerts)
+  await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, kubernetesAlerts.length)
 
   await page.goto('/?state=active')
   await page.getByLabel('Toggle search').click()


### PR DESCRIPTION
## Summary

Fixes all 10 failing E2E tests in the `functional/none` suite. The `internal` and `oidc` suites were already green.

**Before:** 20 passed / 10 failed  
**After:** 30 passed / 2 skipped (all 3 auth modes green)

---

## Changes

### `fix(docker)`: Relabel gitleaks config mount for SELinux
The pre-commit hook was failing with "permission denied" on SELinux hosts. Changed the gitleaks container volume mount from `:ro` to `:ro,z`.

### `test(api)`: Relax poll rate limit in e2e builds
All ~13 failures were caused by `429 Too Many Requests` from the poll rate limiter. Extracted `pollRLRate`/`pollRLBurst` as build-tag constants — production keeps `0.2`/`2`, the `e2e` tag gets `rate.Inf`/`1000`.

### `test(api)`: Broadcast claim over WS in e2e test endpoint
The `/api/v1/test/claim` endpoint only persisted to the DB but didn't update the in-memory snapshot or broadcast via WebSocket. Now mirrors the production handler (`alertStore.SetActiveClaim` + `hub.BroadcastJSON`), so the WS-claim test (D6) passes.

> ⚠️ Both backend changes are behind `//go:build e2e` — the production binary is unaffected.

### `test(e2e)`: Fix alerts-views specs B4/B5/B9
- **B4**: `viewMode` comes from localStorage/uiStore, not URL params → click the List View toggle instead of navigating with `?viewMode=`
- **B5**: Card pagination is per-alertname group → added `crashLoopBurst` fixture (5 alerts sharing one alertname)
- **B9**: `seedResolved` without `labels` → backend returns `labels:null` → resolved row crashes; added `labels`. Per-page buttons need `exact:true` (`'10'` was matching `'100'`).

### `test(e2e)`: Fix filters specs C10/C11
- **C10**: `exact:true` on severity/critical matcher chip text (strict mode violation)
- **C11**: `uiStore` persists `filters.search` in localStorage, causing bleed between tests → split into two tests with fresh context each

### `test(e2e)`: Fix detail-panel specs D2/D5/D9/D10
- **D2**: `summary`/`description` render in their own "Summary" section, not in `detail-annotations-section`. Test now seeds an alert with an extra `impact` annotation.
- **D5**: `seedResolved` without `labels` → resolved row never rendered → timeout. Added `labels`.
- **D9**: In `none` auth mode the submit button stays disabled until the "Your name" field is filled. Test now fills `getByPlaceholder('Your name')` before the body.
- **D10**: "different user cannot delete" is meaningless in `none` mode (`canDelete === true` for all comments without a user identity). Marked as `test.skip()` — belongs in the auth suites.
