### PR TITLE
fix(ws): register clients synchronously to stop losing events after connect

### DIFF
--- a/.agents/lessons.md
+++ b/.agents/lessons.md
@@ -9,6 +9,22 @@ instead of duplicating.
 
 ---
 
+## WS clients must be registered synchronously in ServeWS, not via the hub loop
+
+**Symptom**: J3 e2e tests (`claim_set` badge in open detail panel) flaky —
+fail on first run, pass on retry. The browser shows "WebSocket connected",
+but a WS event fired right after connect never arrives.
+**Cause**: The browser fires `onopen` when the 101 handshake completes, but
+registration went through a buffered `register` channel processed by the hub
+loop. A broadcast racing that registration iterated an empty client set —
+and the loop's `select` gives no ordering guarantee between a pending
+registration and a pending broadcast. Lost event = lost forever: claim/comment
+queries only refetch on WS invalidation.
+**Rule**: `ServeWS` adds the client to the map under the mutex *before*
+starting the pumps. Anything a client must be guaranteed to see after its
+handshake must not depend on event-loop scheduling. Regression test:
+`TestHub_ServeWSRegistersSynchronously` (runs without `hub.Run()`).
+
 ## E2E Playwright image pin must match `@playwright/test` version
 
 **Symptom**: Every E2E test fails in ~2ms with

--- a/backend/internal/ws/hub.go
+++ b/backend/internal/ws/hub.go
@@ -25,7 +25,6 @@ type Hub struct {
 	mu         sync.RWMutex
 	clients    map[*Client]struct{}
 	broadcast  chan []byte
-	register   chan *Client
 	unregister chan *Client
 	logger     *slog.Logger
 	upgrader   websocket.Upgrader
@@ -42,7 +41,6 @@ func NewHub(allowedOrigins []string, logger *slog.Logger, m *metrics.Metrics) *H
 	h := &Hub{
 		clients:    make(map[*Client]struct{}),
 		broadcast:  make(chan []byte, 256),
-		register:   make(chan *Client, 16),
 		unregister: make(chan *Client, 16),
 		logger:     logger,
 		metrics:    m,
@@ -71,11 +69,6 @@ func NewHub(allowedOrigins []string, logger *slog.Logger, m *metrics.Metrics) *H
 func (h *Hub) Run() {
 	for {
 		select {
-		case client := <-h.register:
-			h.mu.Lock()
-			h.clients[client] = struct{}{}
-			h.mu.Unlock()
-
 		case client := <-h.unregister:
 			h.mu.Lock()
 			if _, ok := h.clients[client]; ok {
@@ -126,7 +119,14 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	client := &Client{hub: h, conn: conn, send: make(chan []byte, clientBuffer)}
-	h.register <- client
+	// Register synchronously: the browser considers the socket open as soon as
+	// the 101 handshake completes, so a broadcast fired right after connect
+	// (e.g. claim_set) must already see this client. Routing registration
+	// through the hub loop loses such events — the loop's select gives no
+	// ordering guarantee between a pending registration and a broadcast.
+	h.mu.Lock()
+	h.clients[client] = struct{}{}
+	h.mu.Unlock()
 	go client.writePump()
 	go client.readPump()
 }

--- a/backend/internal/ws/hub_test.go
+++ b/backend/internal/ws/hub_test.go
@@ -57,6 +57,39 @@ func TestHub_BroadcastToClients(t *testing.T) {
 	}
 }
 
+// Registration must complete inside ServeWS, independent of the hub event
+// loop. If it goes through the loop, a broadcast racing the registration can
+// be delivered to an empty client set and the event is lost — the browser
+// already sees the socket as open (101 handshake) before the loop runs.
+// Regression test for the flaky J3 e2e case (claim_set arriving right after
+// connect). The hub loop is intentionally NOT started here.
+func TestHub_ServeWSRegistersSynchronously(t *testing.T) {
+	hub := NewHub([]string{"http://localhost:5173"}, slog.Default(), nil) // no hub.Run()
+
+	srv := httptest.NewServer(hub.upgraderHandler())
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Allow the server goroutine to finish ServeWS, but never the (stopped)
+	// hub loop — asynchronous registration keeps the count at 0 forever.
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.ClientCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := hub.ClientCount(); got != 1 {
+		t.Errorf("ClientCount = %d, want 1 (registration must not depend on the hub loop)", got)
+	}
+}
+
 func TestHub_ClientCountAfterDisconnect(t *testing.T) {
 	hub := newTestHub(t)
 

--- a/docs/testing-e2e.md
+++ b/docs/testing-e2e.md
@@ -245,4 +245,6 @@ Partially covered / known caveats:
 - **D3** — annotation link interaction tested; full dynamic link-button matrix not exhaustive.
 - **D10** — own-comment delete green; two role-based delete cases are skipped.
 - **I6/I7** — setup+login happy path green; setup validation details and logout assertion not asserted.
-- **J3** — `claim_set`/`claim_released` live-patch is flaky (passes on retry).
+- **J3** — was flaky (WS event lost when a broadcast raced the client
+  registration in the hub loop); fixed by registering clients synchronously
+  in `ServeWS` — see `.agents/lessons.md`.


### PR DESCRIPTION
## Problem

The J3 e2e tests (`claim_set` badge in an open detail panel) were flaky — failing on first run, passing on retry (documented as a known caveat in `docs/testing-e2e.md`).

Root cause: the browser fires `onopen` as soon as the 101 handshake completes, but the hub registered clients asynchronously via a buffered `register` channel processed by the hub event loop. A broadcast fired right after connect could iterate an empty client set — and the loop's `select` gives no ordering guarantee between a pending registration and a pending broadcast. A lost `claim_set`/`comment_added` event is lost for good, because those queries only refetch on WS invalidation.

## Fix

`ServeWS` now adds the client to the map under the mutex before starting the read/write pumps; the `register` channel is removed. Registration no longer depends on event-loop scheduling.

## Testing

- New regression test `TestHub_ServeWSRegistersSynchronously` (hub loop intentionally not started) — fails deterministically on the old code, green now
- `go test -race ./...` green, `go build -tags e2e` green
- Functional e2e suite (mode `none`): 121 passed incl. both J3 specs

## Doc sync

- `.agents/lessons.md`: new entry on synchronous WS registration
- `docs/testing-e2e.md`: J3 caveat updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)