### PR TITLE
docs: define project scope, add scope gate and issue-triage command

### DIFF
--- a/.agents/add-feature.md
+++ b/.agents/add-feature.md
@@ -7,6 +7,15 @@ surface, and component tree, load `.agents/architecture.md`.
 
 ---
 
+## Step 0 — Scope Gate (before any code)
+
+Check the feature against `docs/scope.md` (litmus test: *"does this help
+someone sitting in front of a list of active alerts who has to decide what
+to do?"*). Out of scope or borderline → tell the user why and stop until
+they decide (AGENTS.md → Workflow Rules #11).
+
+---
+
 ## Backend — New Endpoint
 
 ```

--- a/.agents/scope-triage.md
+++ b/.agents/scope-triage.md
@@ -1,0 +1,59 @@
+# Jarvis — Feature Request Scope Triage
+
+Given a GitHub issue (feature request), decide whether it fits the project
+scope defined in `docs/scope.md` and draft a reply the maintainer can
+copy/paste into the issue. This workflow is read-only towards GitHub: it
+never posts comments, sets labels, or closes issues — the maintainer does
+that manually with the drafted text.
+
+## Workflow
+
+1. **Load the scope**: read `docs/scope.md` (definition, in/out-of-scope
+   lists, litmus test).
+2. **Fetch the issue**: the user passes an issue number or URL.
+
+   ```bash
+   gh issue view <number-or-url> --json number,title,body,labels,comments
+   ```
+
+   Read the body *and* the comments — requesters often sharpen their actual
+   need in the discussion.
+3. **Classify** against the litmus test (*"does this help someone sitting in
+   front of a list of active alerts who has to decide what to do?"*):
+   - **In scope** — clearly inside the alert-handling workflow
+   - **Out of scope** — belongs before the alert (rules, measuring), after
+     the alert (automation, ticketing, escalation), or to an adjacent tool
+   - **Borderline** — partially fits, or the underlying need is unclear
+4. **Report to the maintainer** (chat output, not the draft): one-line
+   verdict + short rationale referencing the specific scope bullet that
+   applies. If borderline, say what tips the scale in each direction.
+5. **Draft the reply** in a fenced code block for copy/paste. English,
+   friendly, maintainer voice, GitHub-flavored markdown. Always link the
+   scope document:
+   `https://github.com/kj187/jarvis/blob/main/docs/scope.md`
+
+## Reply Guidelines per Verdict
+
+- **In scope**: thank the requester, confirm the fit and *why* (tie it to
+  the workflow it improves), mention open design questions if any. Make no
+  promises about timelines.
+- **Out of scope**: thank the requester, explain the boundary using the
+  matching out-of-scope bullet (before/after-the-alert rule of thumb),
+  suggest concrete alternatives or workarounds where they exist (e.g.
+  Prometheus rule files, Alertmanager receivers, a dedicated incident tool),
+  and invite them to reply if they think the need was misread. Never make
+  the requester feel dismissed — the scope is the reason, not a lack of
+  interest.
+- **Borderline**: state which part fits and which does not, then ask 1–3
+  targeted questions that would settle the verdict (usually: what problem
+  are you solving *while handling an alert*?).
+
+## Hard Rules
+
+- Verdict is a recommendation — the maintainer decides. Never post to
+  GitHub, never label, never close.
+- Judge the *need* behind the request, not just the proposed solution: a
+  request phrased as an out-of-scope feature may hide an in-scope need.
+  If so, say that and address the need in the draft.
+- If the issue is not a feature request (bug report, question), say so and
+  skip the scope verdict.

--- a/.claude/commands/scope-triage.md
+++ b/.claude/commands/scope-triage.md
@@ -1,0 +1,7 @@
+---
+description: Triage a GitHub feature request against the project scope (docs/scope.md) and draft a copy/paste reply
+---
+
+@.agents/scope-triage.md
+
+Issue to triage: $ARGUMENTS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Repository layout:
 - `backend/` — Go backend (`internal/api`, `internal/history`, `internal/alertmanager`, `internal/auth`, `internal/ws`, …)
 - `frontend/` — React app (`src/components`, `src/hooks`, `src/lib`, `src/store`, `e2e/`)
 - `charts/jarvis/` — Helm chart (+ helm-unittest tests under `tests/`)
-- `docs/` — user-facing documentation (not AI context, except `docs/testing-e2e.md`)
+- `docs/` — user-facing documentation (not AI context, except `docs/testing-e2e.md` and `docs/scope.md`)
 - `scripts/` — E2E runner, mock-OIDC config, manual test-alert/silence fixtures
 - `.agents/` — task-specific AI reference files (routed below)
 - `Makefile` — canonical entry for dev stack, tests, security scans, fixtures (`make help`)
@@ -41,6 +41,8 @@ details that these files own.
 |---|---|
 | Data model, DB schema, API endpoints, component tree, stores, WS events, auth, config env vars, alert state machine, technology decisions | `.agents/architecture.md` |
 | Adding a feature: new endpoint, new component, new WS event, new cluster parameter (TDD checklist) | `.agents/add-feature.md` |
+| Judging whether a feature idea fits the project scope (scope gate) | `docs/scope.md` |
+| Triaging a GitHub feature-request issue against the scope, drafting a reply | `.agents/scope-triage.md` |
 | Writing or running tests, test matrix, test utilities, CI pipeline | `.agents/testing.md` |
 | E2E / screenshot stack: Playwright specs, fixtures, auth modes, `compose.e2e.yml` | `docs/testing-e2e.md` |
 | Cutting a release — **only when the user explicitly asks** | `.agents/release.md` |
@@ -51,7 +53,8 @@ Tool-specific entry points map to the same files (no duplicated content):
 
 - **Claude Code**: `CLAUDE.md` includes this file; `/project:architecture`,
   `/project:add-feature`, `/project:testing`, `/project:release`,
-  `/project:security-check` include the corresponding `.agents/` file.
+  `/project:security-check`, `/project:scope-triage` include the
+  corresponding `.agents/` file.
 - **GitHub Copilot**: `.github/copilot-instructions.md` is a symlink to this file.
 - **Codex**: reads `AGENTS.md` natively.
 
@@ -119,6 +122,8 @@ Tool-specific entry points map to the same files (no duplicated content):
    | Security tooling, checklists, auth/origin behavior | `.agents/security.md` |
    | Feature-workflow conventions (validation rules, type-sync, checklists) | `.agents/add-feature.md` |
    | Release process, workflows in `release.yml`, versioning | `.agents/release.md` |
+   | Scope definition, in/out-of-scope boundaries, litmus test | `docs/scope.md` |
+   | Issue-triage workflow, reply guidelines | `.agents/scope-triage.md` |
    | Project description, invariants, workflow rules, commit format, repo layout | `AGENTS.md` itself |
    | E2E stack, specs, fixtures, auth modes | `docs/testing-e2e.md` |
    | Hard-won debugging insight or non-obvious gotcha | `.agents/lessons.md` |
@@ -146,6 +151,13 @@ Tool-specific entry points map to the same files (no duplicated content):
     green → merge (`required_approving_review_count` is 0, so self-merge
     without approval works). This applies to AI-driven changes and the
     release prep commit alike (`.agents/release.md`).
+11. **Scope gate — check every new feature against `docs/scope.md` before
+    building it.** Applies to user-requested and self-proposed features
+    alike. If the feature is out of scope or borderline, say so and explain
+    why (litmus test + the matching in/out-of-scope bullet) **before writing
+    any code** — the user decides whether to proceed anyway. Never silently
+    build an out-of-scope feature. Bug fixes, refactorings, and docs need no
+    scope check.
 
 ## Commit Format — Conventional Commits
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Most Alertmanager UIs are read-only dashboards. Jarvis is built for teams that n
 - **Single binary** — Go backend embeds the Vite build; one container
 - **User authentication** — optional UI login, three modes: `none` (open), `internal` (built-in user management with admin panel), `oidc` (Keycloak, Authentik, Dex, any OIDC provider)
 
+Worried about feature creep? Jarvis has a deliberately focused scope — what it is and what it will never become is written down in **[docs/scope.md](docs/scope.md)**.
+
 ### Built with AI
 > Jarvis was developed entirely using AI coding assistants. This is an intentional workflow choice, not a shortcut: the codebase follows established Go and React best practices, enforces security standards through automated tooling (gosec, govulncheck, golangci-lint, pnpm audit) on every commit and in CI, and applies defense-in-depth measures (strict CSP, read-only container filesystem, no-new-privileges). See [SECURITY.md](SECURITY.md) for details.
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,0 +1,86 @@
+# Project Scope
+
+This document defines what Jarvis is — and, just as importantly, what it is
+not. It exists so that feature decisions stay consistent over time and so
+users can trust that the project will not sprawl into a do-everything tool.
+
+## Definition
+
+> **Jarvis is the working surface for the lifecycle of an alert — from the
+> moment it fires, through investigation and handling, until it resolves.
+> Nothing more, nothing less.**
+
+Monitoring systems detect problems and fire alerts. Alertmanager collects
+those alerts and routes notifications. But the moment a human sits down to
+*work* with those alerts — understand them, coordinate on them, silence them,
+learn from their history — the standard tooling is thin. That moment is
+Jarvis. It is the cockpit you open when an alert comes in and you need to act
+on it.
+
+## In Scope
+
+Everything that answers the question *"an alert is here — now what?"*:
+
+- **Seeing alerts** — realtime view of all alerts across one or more
+  Alertmanager clusters, without page reloads
+- **Understanding alerts** — full lifecycle history that survives restarts,
+  occurrence counts, firing patterns, labels, annotations, context
+- **Organizing alerts** — grouping, sorting, filtering, and searching so a
+  wall of alerts stays navigable
+- **Coordinating on alerts** — claiming (who is handling this?) and
+  persistent comments (what do we know about this?)
+- **Muting alerts** — silence management for maintenance windows, including
+  reusable templates for recurring maintenance
+- **Multiple sources under one roof** — several Alertmanager clusters in a
+  single view, including authentication against protected upstreams
+
+Supporting concerns that any in-scope feature may need — user authentication,
+persistence, theming, deployment packaging — are in scope as *enablers*, not
+as products of their own.
+
+## Out of Scope
+
+Jarvis deliberately does **not**:
+
+- **Create alerts or define alerting rules** — detecting problems is the
+  monitoring system's job (Prometheus rules, etc.)
+- **Measure or graph anything** — Jarvis is not a metrics dashboard and not a
+  Grafana replacement; it shows alerts, not time series
+- **Send notifications** — paging, mail, and push stay with Alertmanager and
+  its receivers
+- **Remediate automatically** — Jarvis is a tool for humans making decisions,
+  not an automation or runbook-execution platform
+- **Manage incidents or tickets** — an alert is not a ticket; once something
+  needs long-lived planning, ownership workflows, or postmortems, it belongs
+  in a dedicated system
+
+As a rule of thumb: **everything before the alert (measuring, rules,
+triggering) and everything after the alert (escalation, ticketing,
+automation) is not Jarvis. Jarvis is the part in between — the moment a human
+works with an alert.**
+
+## The Litmus Test
+
+A feature fits the scope if the answer to this question is *yes*:
+
+> *"Does this help someone who is sitting in front of a list of active alerts
+> and has to decide what to do?"*
+
+Examples:
+
+| Feature idea | Verdict |
+|---|---|
+| Comments on alerts | ✅ in scope |
+| Silence templates for recurring maintenance | ✅ in scope |
+| Per-cluster upstream authentication | ✅ in scope (enabler) |
+| Editor for Prometheus alerting rules | ❌ out of scope (before the alert) |
+| CPU/memory graphs per host | ❌ out of scope (metrics, not alerts) |
+| Auto-restart a service when an alert fires | ❌ out of scope (after the alert) |
+| On-call schedule management | ❌ out of scope (incident tooling) |
+
+## Depth over Breadth
+
+The scope is not *small* — it is *focused*. Jarvis is meant to grow **deep**
+(making the alert-handling workflow ever better) rather than **broad**
+(rebuilding adjacent tools). A steady stream of releases should mean a
+sharper tool, not a wider one.


### PR DESCRIPTION
## What

- **docs/scope.md** — written scope definition: what Jarvis is, what it is not, the litmus test for new features, depth-over-breadth principle
- **Scope gate** (AGENTS.md Workflow Rule 11 + Step 0 in `.agents/add-feature.md`) — AI agents must check every new feature against the scope before writing code and flag out-of-scope/borderline ideas to the user first
- **`/project:scope-triage`** (+ `.agents/scope-triage.md`) — triage a GitHub feature-request issue against the scope and draft a copy/paste reply; read-only towards GitHub
- README: link to the scope doc for users worried about feature creep

## Why

A potential user raised the concern that features get added without a defined scope. This writes the scope down and wires it into the AI workflow so it is enforced going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)