### PR TITLE
feat(alerts): support Alertmanager HA gossip clusters with fingerprint dedup

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -42,6 +42,7 @@ type EnrichedAlert struct {
     ClusterName     string            `json:"clusterName"`
     AlertmanagerURL string            `json:"alertmanagerUrl"`
     ActiveClaim     *Claim            `json:"activeClaim,omitempty"`
+    SeenOn          []string          `json:"seenOn,omitempty"` // HA member names that reported this fingerprint; omitted for single-member clusters
 }
 
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -163,11 +164,17 @@ type SilenceTemplate struct {
 
 // ── Cluster ───────────────────────────────────────────────────────────────────
 type ClusterInfo struct {
-    Name            string `json:"name"`
-    AlertmanagerURL string `json:"alertmanagerUrl"`
-    PrometheusURL   string `json:"prometheusUrl"`
-    Healthy         bool   `json:"healthy"`
-    AlertCount      int    `json:"alertCount"`
+    Name            string       `json:"name"`
+    AlertmanagerURL string       `json:"alertmanagerUrl"` // first member's browser-visible URL
+    PrometheusURL   string       `json:"prometheusUrl"`
+    Healthy         bool         `json:"healthy"` // true when >=1 member is up
+    AlertCount      int          `json:"alertCount"`
+    Members         []MemberInfo `json:"members,omitempty"` // HA clusters only (2+ members); omitted for single-member clusters
+}
+type MemberInfo struct {
+    Name    string `json:"name"` // host:port
+    URL     string `json:"url"`  // browser-visible URL (HOST_ALIAS-rewritten)
+    Healthy bool   `json:"healthy"`
 }
 
 // ── AlertGroup ────────────────────────────────────────────────────────────────
@@ -393,9 +400,11 @@ collectors and `jarvis_build_info`. `Metrics.Handler()` serves `GET /metrics`.
 
 - `collector.go` — `storeCollector` (`prometheus.Collector`): computes
   `jarvis_alerts`, `jarvis_alerts_by_severity`, `jarvis_ws_clients`,
-  `jarvis_clusters_configured`, and `jarvis_alertmanager_up` at scrape time
-  from the in-memory `AlertStore`, the WS `Hub`, and the recorder's cached
-  `ClusterUpStates()` — `Collect()` never makes an upstream HTTP call itself.
+  `jarvis_clusters_configured`, and `jarvis_alertmanager_up` (labeled
+  `cluster`, `member`) at scrape time from the in-memory `AlertStore`, the WS
+  `Hub`, and the recorder's cached `ClusterUpStates() map[string]map[string]bool`
+  (cluster → member → up, sourced from each `cluster.Cluster.MemberUpStates()`)
+  — `Collect()` never makes an upstream HTTP call itself.
 - `echo.go` — `Metrics.EchoMiddleware()`: records `jarvis_http_requests_total`
   / `jarvis_http_request_duration_seconds`, labeled by Echo route pattern
   (`c.Path()`, never the raw URL) to keep cardinality bounded. Skips
@@ -410,12 +419,16 @@ collectors and `jarvis_build_info`. `Metrics.Handler()` serves `GET /metrics`.
   Recorder/Hub via other paths and don't need to pass one.
 - Every metric that can meaningfully be attributed to one Alertmanager cluster
   carries a `cluster` label (`jarvis_poll_cycles_total`, `_errors_total`,
-  `_alert_events_total`, `_cluster_fetch_duration_seconds`, `jarvis_alerts*`,
-  `jarvis_alertmanager_up`). `jarvis_poll_duration_seconds` is the one
-  deliberate exception — it measures the *whole* poll cycle (all clusters in
+  `_alert_events_total`, `jarvis_alerts*`). `jarvis_alertmanager_up` and
+  `jarvis_cluster_fetch_duration_seconds` additionally carry a `member` label
+  (HA-cluster support) — single-member clusters emit their one member, so
+  existing `sum by (cluster) (...)` queries are unaffected; only queries
+  asserting the exact label set need updating (see `docs/metrics.md`).
+  `jarvis_poll_duration_seconds` is the one deliberate exception with no
+  per-cluster label — it measures the *whole* poll cycle (all clusters in
   parallel + the shared DB write in `applyPollResults`), so a per-cluster
   label would misrepresent it; `jarvis_cluster_fetch_duration_seconds` is the
-  per-cluster counterpart for isolating a slow upstream Alertmanager.
+  per-member counterpart for isolating a slow upstream Alertmanager member.
 - Full metric reference for operators: `docs/metrics.md`.
 
 ---
@@ -609,10 +622,64 @@ interface UserSettings {
 | `JARVIS_SECRET_KEY` | JWT HMAC key, hex-decoded if valid hex, else raw bytes; **≥32 bytes required** when provider ≠ none |
 | `JARVIS_AUTH_OIDC_ISSUER` `…_CLIENT_ID` `…_CLIENT_SECRET` `…_REDIRECT_URL` `…_SCOPES` | OIDC (scopes default `openid,profile,email`) |
 | `JARVIS_OIDC_ADMIN_CLAIM` `JARVIS_OIDC_ADMIN_VALUE` | OIDC → admin role mapping |
-| `JARVIS_CLUSTER_N_NAME` `…_ALERTMANAGER_URL` `…_PROMETHEUS_URL` `…_HOST_ALIAS` | per-cluster; N iterated from 1 until NAME empty; HOST_ALIAS rewrites the browser-visible AM link URL |
+| `JARVIS_CLUSTER_N_NAME` `…_ALERTMANAGER_URL` `…_PROMETHEUS_URL` `…_HOST_ALIAS` | per-cluster; N iterated from 1 until NAME empty; `ALERTMANAGER_URL` accepts a comma-separated HA member list; `HOST_ALIAS` rewrites the browser-visible AM link URL — one value for all members, or a comma list index-matched to `ALERTMANAGER_URL` |
 | `JARVIS_CLUSTER_N_BASIC_AUTH_USER` `…_BASIC_AUTH_PASSWORD` `…_BEARER_TOKEN` | per-cluster upstream auth |
 | `JARVIS_CLUSTER_N_HEADER_<Name>` | arbitrary custom HTTP header sent with every upstream request (header name taken verbatim after `HEADER_`) |
 | `JARVIS_CLUSTER_N_OAUTH2_CLIENT_ID` `…_OAUTH2_CLIENT_SECRET` `…_OAUTH2_TOKEN_URL` `…_OAUTH2_SCOPES` | per-cluster OAuth2 client-credentials (takes priority over bearer/basic/headers) |
+
+---
+
+## Alertmanager HA Clusters (member deduplication)
+
+`JARVIS_CLUSTER_N_ALERTMANAGER_URL` accepts a **comma-separated list** of
+member URLs — one Jarvis cluster maps to N Alertmanager HA members (a gossip
+cluster). A single URL is exactly today's one-member behavior; existing
+single-URL configs and their API/WS payloads are unchanged (`members` /
+`seenOn` fields stay `omitempty`).
+
+**Config layer** (`internal/config/config.go`): `ClusterConfig.Members
+[]MemberConfig` holds one `{Name, URL, LinkURL}` per member (`Name` = the
+URL's `host:port`, via `DeriveMemberName`). `AlertmanagerURL` /
+`AlertmanagerLinkURL` on `ClusterConfig` always mirror `Members[0]` for
+single-member call sites. Duplicate member URLs within one cluster → startup
+error. Auth (`BASIC_AUTH`, `BEARER_TOKEN`, `HEADER_*`, `OAUTH2_*`) lives on
+`ClusterConfig` (not per-member) and applies to all members alike — HA
+members share auth setup in practice. `HOST_ALIAS` (`splitHostAliases` in
+`config.go`) is either one value (applies to all members) or a
+comma-separated list index-matched to `ALERTMANAGER_URL`, one alias per
+member — a count that is neither 1 nor exactly the member count is a
+startup error.
+
+**Cluster layer** (`internal/cluster/`): `Cluster.Members []*Member` (each
+with its own `*alertmanager.Client`); `Cluster.AlertmanagerURL` /
+`AlertmanagerLinkURL` / `Client` mirror `Members[0]` for back-compat.
+
+- `Cluster.FetchAlerts(ctx, onDuration)` polls all members in parallel,
+  merges by fingerprint via `mergeAlerts` (`merge.go`) — union semantics
+  (alert kept if ANY member reports it), freshest `UpdatedAt` wins on
+  conflict, `SeenOn` lists members in config order. Returns an error only
+  when **all** members fail (single-member failure ≠ cluster failure).
+  `SeenOn` is cleared when the cluster has exactly one configured member, so
+  single-member JSON payloads stay byte-identical.
+- `Cluster.FetchSilences(ctx, onDuration)` mirrors this for silences, merging
+  by ID via `mergeSilences` (freshest `UpdatedAt` wins); no `SeenOn` tracking
+  for silences.
+- `Cluster.PingAll(ctx)` live-pings every member in parallel (used by
+  `GET /api/v1/clusters`); cluster `Healthy` = any member healthy (UI shows
+  e.g. "2/2 members up", amber when degraded).
+- `Cluster.CreateSilence` / `DeleteSilence` send to the first healthy member
+  (config order, from the cached up-state set by the last `FetchAlerts`),
+  retrying once against the next member on transport failure — never to all
+  members, since gossip already replicates and posting to every member would
+  create duplicates.
+- Enrichment (`cluster/enrich.go`, `enrichMerged`) — moved here from
+  `history` — builds `EnrichedAlert` (incl. `@receiver` label) from merged
+  alerts; lives in `cluster` because `history` imports `cluster` (not the
+  reverse).
+- History recorder keying is untouched: events stay keyed by
+  `(fingerprint, cluster_name)`, since the merge happens *before* the
+  recorder sees the snapshot — grace period and occurrence counting
+  (Critical Invariants #1, #2) are unaffected by member count.
 
 ---
 

--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,16 @@ JARVIS_AUTH_PROVIDER=none
 # ── Cluster 1 ────────────────────────────────────────────────
 JARVIS_CLUSTER_1_NAME=homelab
 JARVIS_CLUSTER_1_ALERTMANAGER_URL=http://alertmanager:9093
+# HA gossip cluster: comma-separated member list instead of one URL — dedups
+# alerts by fingerprint across members, stays healthy if any member is up.
+# Local testing pair: `make up-alertmanager-ha` (compose.dev-dependencies.yml)
+# JARVIS_CLUSTER_1_ALERTMANAGER_URL=http://test-alertmanager:9093,http://test-alertmanager-2:9093
 # HOST_ALIAS: Optional — overrides host/scheme for browser links
 # Useful when internal API URL ≠ browser URL (e.g. localhost vs. hostname)
 JARVIS_CLUSTER_1_HOST_ALIAS=https://alertmanager.lan.example.com
+# HA cluster: one alias applies to all members, or a comma-separated list
+# index-matched to ALERTMANAGER_URL (e.g. each member on its own localhost port):
+# JARVIS_CLUSTER_1_HOST_ALIAS=http://localhost:9094,http://localhost:9095
 JARVIS_CLUSTER_1_PROMETHEUS_URL=http://prometheus:9090
 # Upstream Alertmanager auth (optional) — see docs/authentication-alertmanager.md
 # Priority: OAuth2 > BEARER_TOKEN > BASIC_AUTH > HEADER_*

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ FRONTEND_CONTAINER = jarvis_frontend_1
         setup \
         up up-build down logs ps \
         up-alertmanager down-alertmanager \
+        up-alertmanager-ha down-alertmanager-ha \
         up-postgres down-postgres \
         test-all test-backend test-frontend fuzz-backend \
         helm-lint helm-test \
@@ -48,6 +49,13 @@ up-alertmanager: ## Start test Alertmanager (port 9094) — auto-creates network
 
 down-alertmanager: ## Stop test Alertmanager
 	$(COMPOSE_TEST_DEPS) stop test-alertmanager
+
+up-alertmanager-ha: ## Start a 2-member Alertmanager HA gossip pair (ports 9094 + 9095)
+	podman network create jarvis_default 2>/dev/null || true
+	$(COMPOSE_TEST_DEPS) --profile ha up -d test-alertmanager test-alertmanager-2
+
+down-alertmanager-ha: ## Stop the HA Alertmanager pair
+	$(COMPOSE_TEST_DEPS) --profile ha stop test-alertmanager test-alertmanager-2
 
 up-postgres: ## Start test PostgreSQL (port 5432, jarvis/jarvis/jarvis) — auto-creates network if needed
 	podman network create jarvis_default 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Most Alertmanager UIs are read-only dashboards. Jarvis is built for teams that n
 - **Alert search** — full-text search across alert names and label values; results update as you type
 - **Dark / Light theme** — toggle between dark and light mode; preference is persisted in localStorage
 - **Multi-cluster** — poll multiple Alertmanager instances simultaneously
+- **Alertmanager HA** — point one cluster at all members of an Alertmanager HA gossip cluster; alerts are deduplicated by fingerprint and the cluster stays healthy as long as any member responds
 - **Per-cluster upstream auth** — authenticate against protected Alertmanagers via OAuth2 client credentials (auto-refresh), bearer token, basic auth or custom headers
 - **Grace period** — 60s ghost-resolve prevention
 - **Single binary** — Go backend embeds the Vite build; one container
@@ -134,9 +135,9 @@ See [.env.example](.env.example) for all options. Key settings:
 | Variable | Default | Description |
 |---|---|---|
 | `JARVIS_CLUSTER_1_NAME` | — | Cluster display name (**required**) |
-| `JARVIS_CLUSTER_1_ALERTMANAGER_URL` | — | Internal Alertmanager URL (**required**) |
+| `JARVIS_CLUSTER_1_ALERTMANAGER_URL` | — | Internal Alertmanager URL (**required**). Comma-separated list of member URLs for an Alertmanager HA gossip cluster — see [HA clusters](#ha-alertmanager-clusters) below |
 | `JARVIS_CLUSTER_1_PROMETHEUS_URL` | — | Internal Prometheus URL (optional) |
-| `JARVIS_CLUSTER_1_HOST_ALIAS` | — | Browser-visible AM URL when different from internal (optional) |
+| `JARVIS_CLUSTER_1_HOST_ALIAS` | — | Browser-visible AM URL when different from internal (optional). One value applies to all members; a comma-separated list matching the member count sets one alias per member (index-matched) |
 | `JARVIS_CLUSTER_1_OAUTH2_CLIENT_ID` | — | OAuth2 client ID (client_credentials grant — auto token refresh, optional) |
 | `JARVIS_CLUSTER_1_OAUTH2_CLIENT_SECRET` | — | OAuth2 client secret (never logged, required with `OAUTH2_CLIENT_ID`) |
 | `JARVIS_CLUSTER_1_OAUTH2_TOKEN_URL` | — | OAuth2 token endpoint URL (required with `OAUTH2_CLIENT_ID`) |
@@ -149,6 +150,39 @@ See [.env.example](.env.example) for all options. Key settings:
 Add additional clusters with `JARVIS_CLUSTER_2_*`, `JARVIS_CLUSTER_3_*`, etc.
 
 When Alertmanager sits behind an authentication proxy (e.g. oauth2-proxy), use `OAUTH2_*` for dynamic token management (recommended) or `BEARER_TOKEN` / `BASIC_AUTH_*` for static credentials. Priority: `OAuth2 > BEARER_TOKEN > BASIC_AUTH > HEADER_*`. For full details and Keycloak setup see [docs/authentication-alertmanager.md](docs/authentication-alertmanager.md).
+
+#### HA Alertmanager clusters
+
+Alertmanager's HA mode runs 2+ instances in a gossip cluster: Prometheus sends every alert to all members, and silences replicate between members via gossip. Point one Jarvis cluster at all members by passing a comma-separated list in `ALERTMANAGER_URL` — Jarvis polls every member, deduplicates alerts by fingerprint (freshest `updatedAt` wins), and keeps the cluster healthy as long as at least one member responds:
+
+```env
+# Cluster 1 — dev, single member (exactly today's syntax, unchanged)
+JARVIS_CLUSTER_1_NAME=dev
+JARVIS_CLUSTER_1_ALERTMANAGER_URL=http://am-dev.example.com:9093
+JARVIS_CLUSTER_1_PROMETHEUS_URL=http://prom-dev.example.com:9090
+
+# Cluster 2 — prod, HA cluster with 3 members (comma-separated list)
+JARVIS_CLUSTER_2_NAME=prod
+JARVIS_CLUSTER_2_ALERTMANAGER_URL=http://am1.prod.example.com:9093,http://am2.prod.example.com:9093,http://am3.prod.example.com:9093
+JARVIS_CLUSTER_2_PROMETHEUS_URL=http://prom.prod.example.com:9090
+JARVIS_CLUSTER_2_OAUTH2_CLIENT_ID=jarvis
+JARVIS_CLUSTER_2_OAUTH2_CLIENT_SECRET=<secret>
+JARVIS_CLUSTER_2_OAUTH2_TOKEN_URL=https://keycloak.example.com/realms/prod/protocol/openid-connect/token
+JARVIS_CLUSTER_2_OAUTH2_SCOPES=alertmanager.read alertmanager.write
+```
+
+Notes:
+
+- Auth (`OAUTH2_*`, `BEARER_TOKEN`, `BASIC_AUTH_*`, `HEADER_*`) is per **cluster** and applies to all members alike — HA members share the same auth setup in practice. OAuth2 settings describe the IdP, not the members: Jarvis fetches one token from `OAUTH2_TOKEN_URL` and presents it to every member, so all members must accept tokens from that IdP (true by default for real HA replicas behind the same ingress/proxy). Members with genuinely different auth are not supported in v1 — align the auth, or configure such a member as its own separate cluster (which reintroduces duplicate alerts).
+- `HOST_ALIAS` can be a single value (applies to all members — e.g. one shared load balancer/ingress URL) or a comma-separated list matching the member count, one alias per member in the same order as `ALERTMANAGER_URL`. Useful for local testing where each member is reachable on a different `localhost` port:
+  ```env
+  JARVIS_CLUSTER_2_ALERTMANAGER_URL=http://test-alertmanager:9093,http://test-alertmanager-2:9093
+  JARVIS_CLUSTER_2_HOST_ALIAS=http://localhost:9094,http://localhost:9095
+  ```
+  A mismatched count (not 1, not exactly the member count) is a startup error.
+- A member is identified by its `host:port` in the UI, metrics, and the alert's `seenOn` list.
+- Silence writes go to the first healthy member (config order), retrying once against the next member on transport failure — never to all members, since gossip already replicates and posting to every member would create duplicate silences.
+- Duplicate member URLs within one cluster are a startup error.
 
 ### Database
 

--- a/backend/internal/api/clusters.go
+++ b/backend/internal/api/clusters.go
@@ -34,14 +34,28 @@ func (s *Server) getClusters(c echo.Context) error {
 	clusters := s.registry.All()
 	result := make([]models.ClusterInfo, 0, len(clusters))
 	for _, cl := range clusters {
-		healthy := cl.Client.Ping(ctx) == nil
-		result = append(result, models.ClusterInfo{
+		statuses := cl.PingAll(ctx)
+		healthy := false
+		members := make([]models.MemberInfo, 0, len(statuses))
+		for _, st := range statuses {
+			if st.Healthy {
+				healthy = true
+			}
+			members = append(members, models.MemberInfo{Name: st.Name, URL: st.URL, Healthy: st.Healthy})
+		}
+		info := models.ClusterInfo{
 			Name:            cl.Name,
 			AlertmanagerURL: cl.AlertmanagerLinkURL,
 			PrometheusURL:   cl.PrometheusURL,
 			Healthy:         healthy,
 			AlertCount:      clusterAlertCount[cl.Name],
-		})
+		}
+		// Members is only populated for HA clusters — single-member clusters
+		// keep the payload byte-identical to before.
+		if len(cl.Members) > 1 {
+			info.Members = members
+		}
+		result = append(result, info)
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/backend/internal/api/clusters_test.go
+++ b/backend/internal/api/clusters_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/kj187/jarvis/backend/internal/auth"
+	"github.com/kj187/jarvis/backend/internal/cluster"
+	"github.com/kj187/jarvis/backend/internal/config"
+	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/history"
+	"github.com/kj187/jarvis/backend/internal/metrics"
+	"github.com/kj187/jarvis/backend/internal/models"
+	"github.com/kj187/jarvis/backend/internal/users"
+	"github.com/kj187/jarvis/backend/internal/ws"
+)
+
+func newTestServerWithRegistry(t *testing.T, registry *cluster.Registry) *Server {
+	t.Helper()
+	database, dialect, err := idb.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := idb.Migrate(database, dialect); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	alertStore := &history.AlertStore{}
+	store := history.NewStore(database, dialect)
+	userStore := users.NewStore(database, dialect)
+	hub := ws.NewHub(nil, nil, metrics.New("test"))
+	go hub.Run()
+
+	return NewServer(alertStore, store, hub, registry, &config.Config{}, nil, auth.NoneProvider{}, userStore)
+}
+
+func TestGetClusters_SingleMember_MembersFieldOmitted(t *testing.T) {
+	am := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	}))
+	defer am.Close()
+
+	registry := cluster.NewRegistry([]config.ClusterConfig{
+		{Name: "homelab", AlertmanagerURL: am.URL, AlertmanagerLinkURL: am.URL},
+	})
+	srv := newTestServerWithRegistry(t, registry)
+
+	e := echo.New()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/clusters", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := srv.getClusters(c); err != nil {
+		t.Fatalf("getClusters: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var got []models.ClusterInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Members != nil {
+		t.Errorf("Members = %+v, want nil for single-member cluster (byte-identical payload guarantee)", got[0].Members)
+	}
+	if !got[0].Healthy {
+		t.Error("Healthy = false, want true")
+	}
+}
+
+func TestGetClusters_MultiMember_DegradedButHealthy(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	}))
+	defer up.Close()
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer down.Close()
+
+	registry := cluster.NewRegistry([]config.ClusterConfig{
+		{
+			Name: "prod",
+			Members: []config.MemberConfig{
+				{Name: config.DeriveMemberName(up.URL), URL: up.URL, LinkURL: up.URL},
+				{Name: config.DeriveMemberName(down.URL), URL: down.URL, LinkURL: down.URL},
+			},
+		},
+	})
+	srv := newTestServerWithRegistry(t, registry)
+
+	e := echo.New()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/clusters", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := srv.getClusters(c); err != nil {
+		t.Fatalf("getClusters: %v", err)
+	}
+	var got []models.ClusterInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if !got[0].Healthy {
+		t.Error("Healthy = false, want true (cluster is healthy when >=1 member is up)")
+	}
+	if len(got[0].Members) != 2 {
+		t.Fatalf("len(Members) = %d, want 2", len(got[0].Members))
+	}
+	healthyCount := 0
+	for _, m := range got[0].Members {
+		if m.Healthy {
+			healthyCount++
+		}
+	}
+	if healthyCount != 1 {
+		t.Errorf("healthy members = %d, want 1 (degraded: 1/2 up)", healthyCount)
+	}
+}
+
+func TestGetClusters_AllMembersDown_Unhealthy(t *testing.T) {
+	down1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer down1.Close()
+	down2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer down2.Close()
+
+	registry := cluster.NewRegistry([]config.ClusterConfig{
+		{
+			Name: "prod",
+			Members: []config.MemberConfig{
+				{Name: config.DeriveMemberName(down1.URL), URL: down1.URL, LinkURL: down1.URL},
+				{Name: config.DeriveMemberName(down2.URL), URL: down2.URL, LinkURL: down2.URL},
+			},
+		},
+	})
+	srv := newTestServerWithRegistry(t, registry)
+
+	e := echo.New()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/clusters", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := srv.getClusters(c); err != nil {
+		t.Fatalf("getClusters: %v", err)
+	}
+	var got []models.ClusterInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got[0].Healthy {
+		t.Error("Healthy = true, want false (all members down)")
+	}
+}

--- a/backend/internal/api/silences.go
+++ b/backend/internal/api/silences.go
@@ -25,7 +25,7 @@ func (s *Server) getSilences(c echo.Context) error {
 		if clusterFilter != "" && cl.Name != clusterFilter {
 			continue
 		}
-		raw, err := cl.Client.GetSilences(ctx)
+		raw, err := cl.FetchSilences(ctx, nil)
 		if err != nil {
 			continue // best-effort
 		}
@@ -95,7 +95,7 @@ func (s *Server) createSilence(c echo.Context) error {
 		CreatedBy: createdBy,
 		Comment:   body.Comment,
 	}
-	id, err := cl.Client.CreateSilence(ctx, postable)
+	id, err := cl.CreateSilence(ctx, postable)
 	if err != nil {
 		slog.Error("create silence failed", "cluster", body.Cluster, "err", err)
 		return echo.NewHTTPError(http.StatusBadGateway, "alertmanager request failed")
@@ -104,7 +104,7 @@ func (s *Server) createSilence(c echo.Context) error {
 	// Alertmanager may return a new ID instead of updating in-place.
 	// Expire the old silence to prevent duplicates.
 	if body.ID != "" && id != body.ID {
-		_ = cl.Client.DeleteSilence(ctx, body.ID)
+		_ = cl.DeleteSilence(ctx, body.ID)
 	}
 
 	if body.Fingerprint != "" {
@@ -143,7 +143,7 @@ func (s *Server) deleteSilence(c echo.Context) error {
 	ctx, cancel := context.WithTimeout(c.Request().Context(), 10*time.Second)
 	defer cancel()
 
-	if err := cl.Client.DeleteSilence(ctx, silenceID); err != nil {
+	if err := cl.DeleteSilence(ctx, silenceID); err != nil {
 		slog.Error("delete silence failed", "cluster", clusterName, "id", silenceID, "err", err)
 		return echo.NewHTTPError(http.StatusBadGateway, "alertmanager request failed")
 	}

--- a/backend/internal/api/testing_routes_e2e.go
+++ b/backend/internal/api/testing_routes_e2e.go
@@ -143,7 +143,7 @@ func (s *Server) testCreateSilence(c echo.Context) error {
 		Comment:   req.Comment,
 	}
 
-	silenceID, err := cl.Client.CreateSilence(c.Request().Context(), postable)
+	silenceID, err := cl.CreateSilence(c.Request().Context(), postable)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/backend/internal/cluster/enrich.go
+++ b/backend/internal/cluster/enrich.go
@@ -1,0 +1,68 @@
+package cluster
+
+import (
+	"strings"
+
+	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+// enrichMerged maps deduplicated alerts to EnrichedAlert, injecting the
+// cluster metadata, the synthetic "@receiver" label (comma-separated list of
+// receiver names) used for filtering, the winning member's link URL, and
+// SeenOn. It is a pure function so it can be unit tested and benchmarked
+// without an HTTP round-trip.
+//
+// The receiver names are gathered in a single pass that builds both the
+// Receivers slice and the "@receiver" join string, avoiding a second loop and
+// a throwaway slice per alert — this matters when enriching large alert sets.
+func enrichMerged(merged []mergedAlert, clusterName string, linkURLByMember map[string]string) []models.EnrichedAlert {
+	enriched := make([]models.EnrichedAlert, 0, len(merged))
+	for i := range merged {
+		m := &merged[i]
+		a := &m.alert
+
+		receivers := make([]models.Receiver, len(a.Receivers))
+		var receiverList strings.Builder
+		for j, rcv := range a.Receivers {
+			receivers[j] = models.Receiver{Name: rcv.Name}
+			if j > 0 {
+				receiverList.WriteByte(',')
+			}
+			receiverList.WriteString(rcv.Name)
+		}
+
+		labelCount := len(a.Labels)
+		if len(a.Receivers) > 0 {
+			labelCount++
+		}
+		labels := make(map[string]string, labelCount)
+		for k, v := range a.Labels {
+			labels[k] = v
+		}
+		// Store all receivers as comma-separated list for filtering.
+		// This allows filters to match any receiver that handles this alert.
+		if len(a.Receivers) > 0 {
+			labels["@receiver"] = receiverList.String()
+		}
+
+		enriched = append(enriched, models.EnrichedAlert{
+			Fingerprint: a.Fingerprint,
+			Status: models.AlertStatus{
+				InhibitedBy: a.Status.InhibitedBy,
+				SilencedBy:  a.Status.SilencedBy,
+				State:       a.Status.State,
+			},
+			Labels:          labels,
+			Annotations:     a.Annotations,
+			StartsAt:        a.StartsAt,
+			EndsAt:          a.EndsAt,
+			UpdatedAt:       a.UpdatedAt,
+			GeneratorURL:    a.GeneratorURL,
+			Receivers:       receivers,
+			ClusterName:     clusterName,
+			AlertmanagerURL: linkURLByMember[m.source],
+			SeenOn:          m.seenOn,
+		})
+	}
+	return enriched
+}

--- a/backend/internal/cluster/enrich_test.go
+++ b/backend/internal/cluster/enrich_test.go
@@ -1,4 +1,4 @@
-package history
+package cluster
 
 import (
 	"fmt"
@@ -18,7 +18,8 @@ func TestEnrichAlerts_SingleReceiver(t *testing.T) {
 		},
 	}
 
-	got := enrichAlerts(raw, "prod", "http://am.example")
+	merged := mergeAlerts(map[string][]alertmanager.GettableAlert{"m1": raw}, []string{"m1"})
+	got := enrichMerged(merged, "prod", map[string]string{"m1": "http://am.example"})
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
@@ -49,7 +50,8 @@ func TestEnrichAlerts_MultipleReceiversJoinedInOrder(t *testing.T) {
 		},
 	}
 
-	got := enrichAlerts(raw, "prod", "http://am.example")
+	merged := mergeAlerts(map[string][]alertmanager.GettableAlert{"m1": raw}, []string{"m1"})
+	got := enrichMerged(merged, "prod", map[string]string{"m1": "http://am.example"})
 	if got[0].Labels["@receiver"] != "pagerduty,email,slack" {
 		t.Errorf("@receiver = %q, want pagerduty,email,slack", got[0].Labels["@receiver"])
 	}
@@ -72,7 +74,8 @@ func TestEnrichAlerts_NoReceiverLabelWhenEmpty(t *testing.T) {
 		},
 	}
 
-	got := enrichAlerts(raw, "prod", "http://am.example")
+	merged := mergeAlerts(map[string][]alertmanager.GettableAlert{"m1": raw}, []string{"m1"})
+	got := enrichMerged(merged, "prod", map[string]string{"m1": "http://am.example"})
 	if _, ok := got[0].Labels["@receiver"]; ok {
 		t.Errorf("@receiver label should be absent when there are no receivers")
 	}
@@ -91,9 +94,10 @@ func TestEnrichAlerts_DoesNotMutateSourceLabels(t *testing.T) {
 		},
 	}
 
-	_ = enrichAlerts(raw, "prod", "http://am.example")
+	merged := mergeAlerts(map[string][]alertmanager.GettableAlert{"m1": raw}, []string{"m1"})
+	_ = enrichMerged(merged, "prod", map[string]string{"m1": "http://am.example"})
 	if _, ok := srcLabels["@receiver"]; ok {
-		t.Errorf("enrichAlerts must not mutate the source labels map")
+		t.Errorf("enrichMerged must not mutate the source labels map")
 	}
 }
 
@@ -112,7 +116,8 @@ func TestEnrichAlerts_PreservesStatusAndTimes(t *testing.T) {
 		},
 	}
 
-	got := enrichAlerts(raw, "prod", "http://am.example")[0]
+	merged := mergeAlerts(map[string][]alertmanager.GettableAlert{"m1": raw}, []string{"m1"})
+	got := enrichMerged(merged, "prod", map[string]string{"m1": "http://am.example"})[0]
 	if got.Status.State != "suppressed" {
 		t.Errorf("State = %q", got.Status.State)
 	}
@@ -133,6 +138,35 @@ func TestEnrichAlerts_PreservesStatusAndTimes(t *testing.T) {
 	}
 }
 
+func TestEnrichAlerts_SingleMember_SeenOnAbsent(t *testing.T) {
+	raw := []alertmanager.GettableAlert{{Fingerprint: "abc123", Labels: map[string]string{"alertname": "TestAlert"}}}
+	merged := mergeAlerts(map[string][]alertmanager.GettableAlert{"am1:9093": raw}, []string{"am1:9093"})
+	// Single-member clusters must clear SeenOn for byte-identical JSON — this
+	// is done by the caller (Cluster.FetchAlerts), not enrichMerged itself, so
+	// simulate that here.
+	merged[0].seenOn = nil
+	got := enrichMerged(merged, "prod", map[string]string{"am1:9093": "http://am.example"})
+	if got[0].SeenOn != nil {
+		t.Errorf("SeenOn = %v, want nil for single-member cluster", got[0].SeenOn)
+	}
+}
+
+func TestEnrichAlerts_MultiMember_SeenOnListsAllReportingMembers(t *testing.T) {
+	t0 := time.Now().UTC()
+	raw := map[string][]alertmanager.GettableAlert{
+		"am1:9093": {{Fingerprint: "abc123", UpdatedAt: t0}},
+		"am2:9093": {{Fingerprint: "abc123", UpdatedAt: t0}},
+	}
+	merged := mergeAlerts(raw, []string{"am1:9093", "am2:9093"})
+	got := enrichMerged(merged, "prod", map[string]string{"am1:9093": "http://am1", "am2:9093": "http://am2"})
+	if len(got[0].SeenOn) != 2 {
+		t.Fatalf("SeenOn = %v, want 2 members", got[0].SeenOn)
+	}
+	if got[0].AlertmanagerURL != "http://am1" {
+		t.Errorf("AlertmanagerURL = %q, want http://am1 (winning member's link URL)", got[0].AlertmanagerURL)
+	}
+}
+
 func BenchmarkEnrichAlerts(b *testing.B) {
 	raw := make([]alertmanager.GettableAlert, 2000)
 	for i := range raw {
@@ -150,10 +184,13 @@ func BenchmarkEnrichAlerts(b *testing.B) {
 			Receivers:   []alertmanager.AMReceiver{{Name: "email"}, {Name: "slack"}},
 		}
 	}
+	byMember := map[string][]alertmanager.GettableAlert{"m1": raw}
+	linkURLs := map[string]string{"m1": "http://am.example"}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = enrichAlerts(raw, "prod", "http://am.example")
+		merged := mergeAlerts(byMember, []string{"m1"})
+		_ = enrichMerged(merged, "prod", linkURLs)
 	}
 }

--- a/backend/internal/cluster/merge.go
+++ b/backend/internal/cluster/merge.go
@@ -1,0 +1,59 @@
+package cluster
+
+import "github.com/kj187/jarvis/backend/internal/alertmanager"
+
+// mergedAlert is one deduplicated alert produced by mergeAlerts: the freshest
+// copy across all members that reported it, plus which members saw it.
+type mergedAlert struct {
+	alert  alertmanager.GettableAlert
+	source string   // member name that provided alert (newest UpdatedAt)
+	seenOn []string // member names that reported this fingerprint, config order
+}
+
+// mergeAlerts deduplicates alerts fetched from multiple HA members by
+// fingerprint. Union semantics: an alert reported by any member is kept —
+// there is no intersection/quorum requirement. When a fingerprint is reported
+// by more than one member, the copy with the newest UpdatedAt wins (freshest
+// state wins, covers gossip lag on silence state). order controls both the
+// output ordering (first-seen-by-fingerprint, config order) and SeenOn
+// ordering.
+func mergeAlerts(byMember map[string][]alertmanager.GettableAlert, order []string) []mergedAlert {
+	index := make(map[string]int, 16)
+	var result []mergedAlert
+	for _, memberName := range order {
+		for _, a := range byMember[memberName] {
+			if idx, ok := index[a.Fingerprint]; ok {
+				result[idx].seenOn = append(result[idx].seenOn, memberName)
+				if a.UpdatedAt.After(result[idx].alert.UpdatedAt) {
+					result[idx].alert = a
+					result[idx].source = memberName
+				}
+				continue
+			}
+			index[a.Fingerprint] = len(result)
+			result = append(result, mergedAlert{alert: a, source: memberName, seenOn: []string{memberName}})
+		}
+	}
+	return result
+}
+
+// mergeSilences deduplicates silences fetched from multiple HA members by ID
+// (gossip replicates silences between members, so IDs agree). Union
+// semantics, like mergeAlerts; the copy with the newest UpdatedAt wins.
+func mergeSilences(byMember map[string][]alertmanager.GettableSilence, order []string) []alertmanager.GettableSilence {
+	index := make(map[string]int, 16)
+	var result []alertmanager.GettableSilence
+	for _, memberName := range order {
+		for _, s := range byMember[memberName] {
+			if idx, ok := index[s.ID]; ok {
+				if s.UpdatedAt.After(result[idx].UpdatedAt) {
+					result[idx] = s
+				}
+				continue
+			}
+			index[s.ID] = len(result)
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/backend/internal/cluster/merge_test.go
+++ b/backend/internal/cluster/merge_test.go
@@ -1,0 +1,124 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kj187/jarvis/backend/internal/alertmanager"
+)
+
+func TestMergeAlerts_UnionSemantics_OnlyOneMemberReports(t *testing.T) {
+	byMember := map[string][]alertmanager.GettableAlert{
+		"am1:9093": {{Fingerprint: "fp1", Status: alertmanager.GettableAlertStatus{State: "active"}}},
+		"am2:9093": {},
+	}
+	got := mergeAlerts(byMember, []string{"am1:9093", "am2:9093"})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (alert real if ANY member reports it)", len(got))
+	}
+	if got[0].alert.Fingerprint != "fp1" {
+		t.Errorf("Fingerprint = %q", got[0].alert.Fingerprint)
+	}
+	if len(got[0].seenOn) != 1 || got[0].seenOn[0] != "am1:9093" {
+		t.Errorf("SeenOn = %v, want [am1:9093]", got[0].seenOn)
+	}
+}
+
+func TestMergeAlerts_SameFingerprintOnBothMembers_NewestUpdatedAtWins(t *testing.T) {
+	older := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Minute)
+
+	byMember := map[string][]alertmanager.GettableAlert{
+		"am1:9093": {{Fingerprint: "fp1", Status: alertmanager.GettableAlertStatus{State: "active"}, UpdatedAt: older}},
+		"am2:9093": {{Fingerprint: "fp1", Status: alertmanager.GettableAlertStatus{State: "suppressed"}, UpdatedAt: newer}},
+	}
+	got := mergeAlerts(byMember, []string{"am1:9093", "am2:9093"})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].alert.Status.State != "suppressed" {
+		t.Errorf("State = %q, want suppressed (newer copy must win)", got[0].alert.Status.State)
+	}
+	if got[0].source != "am2:9093" {
+		t.Errorf("source = %q, want am2:9093", got[0].source)
+	}
+}
+
+func TestMergeAlerts_SeenOnOrderingFollowsConfigOrder(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	byMember := map[string][]alertmanager.GettableAlert{
+		"am1:9093": {{Fingerprint: "fp1", UpdatedAt: t0}},
+		"am2:9093": {{Fingerprint: "fp1", UpdatedAt: t0}},
+		"am3:9093": {{Fingerprint: "fp1", UpdatedAt: t0}},
+	}
+	got := mergeAlerts(byMember, []string{"am1:9093", "am2:9093", "am3:9093"})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	want := []string{"am1:9093", "am2:9093", "am3:9093"}
+	if len(got[0].seenOn) != len(want) {
+		t.Fatalf("SeenOn = %v, want %v", got[0].seenOn, want)
+	}
+	for i, w := range want {
+		if got[0].seenOn[i] != w {
+			t.Errorf("SeenOn[%d] = %q, want %q", i, got[0].seenOn[i], w)
+		}
+	}
+}
+
+func TestMergeAlerts_EqualUpdatedAt_FirstInConfigOrderWins(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	byMember := map[string][]alertmanager.GettableAlert{
+		"am1:9093": {{Fingerprint: "fp1", Status: alertmanager.GettableAlertStatus{State: "active"}, UpdatedAt: t0}},
+		"am2:9093": {{Fingerprint: "fp1", Status: alertmanager.GettableAlertStatus{State: "suppressed"}, UpdatedAt: t0}},
+	}
+	got := mergeAlerts(byMember, []string{"am1:9093", "am2:9093"})
+	if got[0].source != "am1:9093" {
+		t.Errorf("source = %q, want am1:9093 (equal timestamp keeps first-seen copy)", got[0].source)
+	}
+}
+
+func TestMergeAlerts_DistinctFingerprintsAllKept(t *testing.T) {
+	byMember := map[string][]alertmanager.GettableAlert{
+		"am1:9093": {{Fingerprint: "fp1"}, {Fingerprint: "fp2"}},
+		"am2:9093": {{Fingerprint: "fp3"}},
+	}
+	got := mergeAlerts(byMember, []string{"am1:9093", "am2:9093"})
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+}
+
+func TestMergeAlerts_Empty(t *testing.T) {
+	got := mergeAlerts(map[string][]alertmanager.GettableAlert{}, nil)
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+func TestMergeSilences_UnionByID(t *testing.T) {
+	byMember := map[string][]alertmanager.GettableSilence{
+		"am1:9093": {{ID: "s1"}},
+		"am2:9093": {{ID: "s2"}},
+	}
+	got := mergeSilences(byMember, []string{"am1:9093", "am2:9093"})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+}
+
+func TestMergeSilences_SameID_NewestUpdatedAtWins(t *testing.T) {
+	older := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Minute)
+	byMember := map[string][]alertmanager.GettableSilence{
+		"am1:9093": {{ID: "s1", Comment: "old", UpdatedAt: older}},
+		"am2:9093": {{ID: "s1", Comment: "new", UpdatedAt: newer}},
+	}
+	got := mergeSilences(byMember, []string{"am1:9093", "am2:9093"})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Comment != "new" {
+		t.Errorf("Comment = %q, want new (newest UpdatedAt must win)", got[0].Comment)
+	}
+}

--- a/backend/internal/cluster/poll.go
+++ b/backend/internal/cluster/poll.go
@@ -1,0 +1,232 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/kj187/jarvis/backend/internal/alertmanager"
+	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+// FetchDurationFunc receives the observed fetch duration for one member —
+// used by the caller to record a per-member fetch-duration metric. May be nil.
+type FetchDurationFunc func(member string, seconds float64)
+
+// MemberStatus is the live ping result for one member.
+type MemberStatus struct {
+	Name    string
+	URL     string
+	Healthy bool
+}
+
+// FetchAlerts polls all members in parallel and returns the deduplicated,
+// enriched alert set for this cluster (see mergeAlerts). Returns an error
+// only when ALL members failed — a single member's failure does not fail the
+// whole cluster; an alert is real if ANY member reports it (union
+// semantics). Updates the cached per-member up-state read by MemberUpStates.
+func (c *Cluster) FetchAlerts(ctx context.Context, onDuration FetchDurationFunc) ([]models.EnrichedAlert, error) {
+	if len(c.Members) == 0 {
+		return nil, nil
+	}
+
+	type result struct {
+		member *Member
+		alerts []alertmanager.GettableAlert
+		err    error
+	}
+	results := make([]result, len(c.Members))
+	var wg sync.WaitGroup
+	for i, m := range c.Members {
+		wg.Add(1)
+		go func(idx int, m *Member) {
+			defer wg.Done()
+			start := time.Now()
+			alerts, err := m.Client.GetAlerts(ctx)
+			if onDuration != nil {
+				onDuration(m.Name, time.Since(start).Seconds())
+			}
+			results[idx] = result{member: m, alerts: alerts, err: err}
+		}(i, m)
+	}
+	wg.Wait()
+
+	byMember := make(map[string][]alertmanager.GettableAlert, len(c.Members))
+	linkURLByMember := make(map[string]string, len(c.Members))
+	order := make([]string, 0, len(c.Members))
+	var lastErr error
+	anyOK := false
+	for _, res := range results {
+		c.setMemberUp(res.member.Name, res.err == nil)
+		linkURLByMember[res.member.Name] = res.member.LinkURL
+		if res.err != nil {
+			lastErr = res.err
+			continue
+		}
+		anyOK = true
+		byMember[res.member.Name] = res.alerts
+		order = append(order, res.member.Name)
+	}
+	if !anyOK {
+		return nil, fmt.Errorf("all members of cluster %q failed: %w", c.Name, lastErr)
+	}
+
+	merged := mergeAlerts(byMember, order)
+	// Single-member clusters keep SeenOn empty so existing payloads stay byte-identical.
+	if len(c.Members) <= 1 {
+		for i := range merged {
+			merged[i].seenOn = nil
+		}
+	}
+	return enrichMerged(merged, c.Name, linkURLByMember), nil
+}
+
+// FetchSilences polls all members in parallel and returns the deduplicated
+// silence set (union by ID, newest UpdatedAt wins). Returns an error only
+// when ALL members failed.
+func (c *Cluster) FetchSilences(ctx context.Context, onDuration FetchDurationFunc) ([]alertmanager.GettableSilence, error) {
+	if len(c.Members) == 0 {
+		return nil, nil
+	}
+
+	type result struct {
+		member   *Member
+		silences []alertmanager.GettableSilence
+		err      error
+	}
+	results := make([]result, len(c.Members))
+	var wg sync.WaitGroup
+	for i, m := range c.Members {
+		wg.Add(1)
+		go func(idx int, m *Member) {
+			defer wg.Done()
+			start := time.Now()
+			silences, err := m.Client.GetSilences(ctx)
+			if onDuration != nil {
+				onDuration(m.Name, time.Since(start).Seconds())
+			}
+			results[idx] = result{member: m, silences: silences, err: err}
+		}(i, m)
+	}
+	wg.Wait()
+
+	byMember := make(map[string][]alertmanager.GettableSilence, len(c.Members))
+	order := make([]string, 0, len(c.Members))
+	var lastErr error
+	anyOK := false
+	for _, res := range results {
+		if res.err != nil {
+			lastErr = res.err
+			continue
+		}
+		anyOK = true
+		byMember[res.member.Name] = res.silences
+		order = append(order, res.member.Name)
+	}
+	if !anyOK {
+		return nil, lastErr
+	}
+	return mergeSilences(byMember, order), nil
+}
+
+// PingAll pings every member in parallel and returns its live health.
+func (c *Cluster) PingAll(ctx context.Context) []MemberStatus {
+	statuses := make([]MemberStatus, len(c.Members))
+	var wg sync.WaitGroup
+	for i, m := range c.Members {
+		wg.Add(1)
+		go func(idx int, m *Member) {
+			defer wg.Done()
+			statuses[idx] = MemberStatus{Name: m.Name, URL: m.LinkURL, Healthy: m.Client.Ping(ctx) == nil}
+		}(i, m)
+	}
+	wg.Wait()
+	return statuses
+}
+
+// CreateSilence sends the silence to the first healthy member (config
+// order); on transport failure, retries once against the next healthy
+// member. Never sent to all members — gossip replicates silences between
+// real HA members, so posting to every member would create duplicates.
+func (c *Cluster) CreateSilence(ctx context.Context, s alertmanager.PostableSilence) (string, error) {
+	members := c.writeOrder()
+	if len(members) == 0 {
+		return "", fmt.Errorf("cluster %q has no members", c.Name)
+	}
+	var lastErr error
+	for i := 0; i < attemptCount(members); i++ {
+		id, err := members[i].Client.CreateSilence(ctx, s)
+		if err == nil {
+			return id, nil
+		}
+		lastErr = err
+	}
+	return "", lastErr
+}
+
+// DeleteSilence mirrors CreateSilence's member-selection and retry behavior.
+func (c *Cluster) DeleteSilence(ctx context.Context, id string) error {
+	members := c.writeOrder()
+	if len(members) == 0 {
+		return fmt.Errorf("cluster %q has no members", c.Name)
+	}
+	var lastErr error
+	for i := 0; i < attemptCount(members); i++ {
+		err := members[i].Client.DeleteSilence(ctx, id)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+	}
+	return lastErr
+}
+
+// attemptCount caps write retries at 2: the first healthy member, plus one retry.
+func attemptCount(members []*Member) int {
+	if len(members) > 2 {
+		return 2
+	}
+	return len(members)
+}
+
+// writeOrder returns members ordered healthy-first (config order preserved
+// within each group), based on the cached up-state from the last
+// FetchAlerts. Members with unknown state (no poll yet) count as healthy so
+// writes work before the first poll completes.
+func (c *Cluster) writeOrder() []*Member {
+	c.upMu.Lock()
+	defer c.upMu.Unlock()
+	healthy := make([]*Member, 0, len(c.Members))
+	var unhealthy []*Member
+	for _, m := range c.Members {
+		if up, known := c.up[m.Name]; known && !up {
+			unhealthy = append(unhealthy, m)
+			continue
+		}
+		healthy = append(healthy, m)
+	}
+	return append(healthy, unhealthy...)
+}
+
+func (c *Cluster) setMemberUp(name string, up bool) {
+	c.upMu.Lock()
+	if c.up == nil {
+		c.up = make(map[string]bool)
+	}
+	c.up[name] = up
+	c.upMu.Unlock()
+}
+
+// MemberUpStates returns a copy of the last-poll-success flag per member.
+// Read at scrape time by the metrics collector — never performs an upstream
+// HTTP call itself.
+func (c *Cluster) MemberUpStates() map[string]bool {
+	c.upMu.Lock()
+	defer c.upMu.Unlock()
+	out := make(map[string]bool, len(c.up))
+	for k, v := range c.up {
+		out[k] = v
+	}
+	return out
+}

--- a/backend/internal/cluster/poll_test.go
+++ b/backend/internal/cluster/poll_test.go
@@ -1,0 +1,300 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/kj187/jarvis/backend/internal/alertmanager"
+	"github.com/kj187/jarvis/backend/internal/config"
+)
+
+func alertsServer(t *testing.T, alerts []alertmanager.GettableAlert) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/alerts":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(alerts)
+		case "/api/v2/silences":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]alertmanager.GettableSilence{})
+		case "/api/v2/status":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(alertmanager.AMStatus{Status: "ready"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func downServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func twoMemberCluster(name string, urls ...string) *Cluster {
+	members := make([]config.MemberConfig, len(urls))
+	for i, u := range urls {
+		members[i] = config.MemberConfig{Name: config.DeriveMemberName(u), URL: u, LinkURL: u}
+	}
+	return buildCluster(config.ClusterConfig{Name: name, Members: members})
+}
+
+func TestFetchAlerts_MemberDown_OtherMemberStillServesAlerts(t *testing.T) {
+	up := alertsServer(t, []alertmanager.GettableAlert{{Fingerprint: "fp1", Status: alertmanager.GettableAlertStatus{State: "active"}}})
+	down := downServer(t)
+
+	cl := twoMemberCluster("prod", up.URL, down.URL)
+	alerts, err := cl.FetchAlerts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchAlerts: %v (must not fail when only one member is down)", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("len(alerts) = %d, want 1", len(alerts))
+	}
+
+	upStates := cl.MemberUpStates()
+	if !upStates[config.DeriveMemberName(up.URL)] {
+		t.Error("up member must be marked up")
+	}
+	if upStates[config.DeriveMemberName(down.URL)] {
+		t.Error("down member must be marked down")
+	}
+}
+
+func TestFetchAlerts_AllMembersDown_ReturnsError(t *testing.T) {
+	down1 := downServer(t)
+	down2 := downServer(t)
+
+	cl := twoMemberCluster("prod", down1.URL, down2.URL)
+	_, err := cl.FetchAlerts(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when all members are down")
+	}
+}
+
+func TestFetchAlerts_SingleMember_NoSeenOn(t *testing.T) {
+	srv := alertsServer(t, []alertmanager.GettableAlert{{Fingerprint: "fp1"}})
+	cl := twoMemberCluster("dev", srv.URL)
+
+	alerts, err := cl.FetchAlerts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchAlerts: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("len(alerts) = %d, want 1", len(alerts))
+	}
+	if alerts[0].SeenOn != nil {
+		t.Errorf("SeenOn = %v, want nil for single-member cluster (byte-identical payload guarantee)", alerts[0].SeenOn)
+	}
+}
+
+func TestFetchAlerts_MultiMember_SeenOnPopulated(t *testing.T) {
+	srv1 := alertsServer(t, []alertmanager.GettableAlert{{Fingerprint: "fp1"}})
+	srv2 := alertsServer(t, []alertmanager.GettableAlert{{Fingerprint: "fp1"}})
+	cl := twoMemberCluster("prod", srv1.URL, srv2.URL)
+
+	alerts, err := cl.FetchAlerts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchAlerts: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("len(alerts) = %d, want 1 (deduplicated)", len(alerts))
+	}
+	if len(alerts[0].SeenOn) != 2 {
+		t.Errorf("SeenOn = %v, want 2 members", alerts[0].SeenOn)
+	}
+}
+
+func TestFetchAlerts_ObservesPerMemberDuration(t *testing.T) {
+	srv1 := alertsServer(t, nil)
+	srv2 := alertsServer(t, nil)
+	cl := twoMemberCluster("prod", srv1.URL, srv2.URL)
+
+	var mu sync.Mutex
+	observed := make(map[string]bool)
+	_, err := cl.FetchAlerts(context.Background(), func(member string, seconds float64) {
+		mu.Lock()
+		observed[member] = true
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("FetchAlerts: %v", err)
+	}
+	if len(observed) != 2 {
+		t.Errorf("observed durations for %d members, want 2: %v", len(observed), observed)
+	}
+}
+
+func TestFetchSilences_MergesAcrossMembers(t *testing.T) {
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]alertmanager.GettableSilence{{ID: "s1"}})
+	}))
+	defer srv1.Close()
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]alertmanager.GettableSilence{{ID: "s2"}})
+	}))
+	defer srv2.Close()
+
+	cl := twoMemberCluster("prod", srv1.URL, srv2.URL)
+	silences, err := cl.FetchSilences(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchSilences: %v", err)
+	}
+	if len(silences) != 2 {
+		t.Fatalf("len(silences) = %d, want 2", len(silences))
+	}
+}
+
+func TestFetchSilences_AllMembersDown_ReturnsError(t *testing.T) {
+	down1 := downServer(t)
+	down2 := downServer(t)
+	cl := twoMemberCluster("prod", down1.URL, down2.URL)
+
+	_, err := cl.FetchSilences(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when all members are down")
+	}
+}
+
+func TestPingAll_ReportsPerMemberHealth(t *testing.T) {
+	up := alertsServer(t, nil)
+	down := downServer(t)
+	cl := twoMemberCluster("prod", up.URL, down.URL)
+
+	statuses := cl.PingAll(context.Background())
+	if len(statuses) != 2 {
+		t.Fatalf("len(statuses) = %d, want 2", len(statuses))
+	}
+	byName := map[string]bool{}
+	for _, s := range statuses {
+		byName[s.Name] = s.Healthy
+	}
+	if !byName[config.DeriveMemberName(up.URL)] {
+		t.Error("up member must be healthy")
+	}
+	if byName[config.DeriveMemberName(down.URL)] {
+		t.Error("down member must be unhealthy")
+	}
+}
+
+func TestCreateSilence_FirstMemberSucceeds(t *testing.T) {
+	var hit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = r.Host
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(alertmanager.PostSilenceResponse{SilenceID: "new-id"})
+	}))
+	defer srv.Close()
+	down := downServer(t)
+
+	cl := twoMemberCluster("prod", srv.URL, down.URL)
+	id, err := cl.CreateSilence(context.Background(), alertmanager.PostableSilence{Comment: "x"})
+	if err != nil {
+		t.Fatalf("CreateSilence: %v", err)
+	}
+	if id != "new-id" {
+		t.Errorf("id = %q, want new-id", id)
+	}
+	if hit == "" {
+		t.Error("expected the healthy member to receive the request")
+	}
+}
+
+func TestCreateSilence_FirstMemberDown_RetriesSecondMember(t *testing.T) {
+	down := downServer(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(alertmanager.PostSilenceResponse{SilenceID: "new-id"})
+	}))
+	defer srv.Close()
+
+	cl := twoMemberCluster("prod", down.URL, srv.URL)
+	id, err := cl.CreateSilence(context.Background(), alertmanager.PostableSilence{Comment: "x"})
+	if err != nil {
+		t.Fatalf("CreateSilence: %v (must retry against the next member on transport failure)", err)
+	}
+	if id != "new-id" {
+		t.Errorf("id = %q, want new-id", id)
+	}
+}
+
+func TestCreateSilence_AllMembersDown_ReturnsError(t *testing.T) {
+	down1 := downServer(t)
+	down2 := downServer(t)
+	cl := twoMemberCluster("prod", down1.URL, down2.URL)
+
+	_, err := cl.CreateSilence(context.Background(), alertmanager.PostableSilence{Comment: "x"})
+	if err == nil {
+		t.Fatal("expected error when all members are down")
+	}
+}
+
+func TestCreateSilence_PrefersKnownHealthyMemberFirst(t *testing.T) {
+	// Prime the cluster's cached health state: member 1 down, member 2 up.
+	down := downServer(t)
+	var hit bool
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v2/alerts" {
+			_ = json.NewEncoder(w).Encode([]alertmanager.GettableAlert{})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(alertmanager.PostSilenceResponse{SilenceID: "id"})
+	}))
+	defer up.Close()
+
+	cl := twoMemberCluster("prod", down.URL, up.URL)
+	if _, err := cl.FetchAlerts(context.Background(), nil); err != nil {
+		t.Fatalf("priming FetchAlerts: %v", err)
+	}
+
+	hit = false
+	if _, err := cl.CreateSilence(context.Background(), alertmanager.PostableSilence{}); err != nil {
+		t.Fatalf("CreateSilence: %v", err)
+	}
+	if !hit {
+		t.Error("expected the known-healthy member (2nd in config order) to be tried first")
+	}
+}
+
+func TestDeleteSilence_FirstMemberDown_RetriesSecondMember(t *testing.T) {
+	down := downServer(t)
+	var deleted bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleted = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cl := twoMemberCluster("prod", down.URL, srv.URL)
+	if err := cl.DeleteSilence(context.Background(), "id1"); err != nil {
+		t.Fatalf("DeleteSilence: %v", err)
+	}
+	if !deleted {
+		t.Error("expected the next member to receive the delete")
+	}
+}
+
+func TestDeleteSilence_AllMembersDown_ReturnsError(t *testing.T) {
+	down1 := downServer(t)
+	down2 := downServer(t)
+	cl := twoMemberCluster("prod", down1.URL, down2.URL)
+
+	if err := cl.DeleteSilence(context.Background(), "id1"); err == nil {
+		t.Fatal("expected error when all members are down")
+	}
+}

--- a/backend/internal/cluster/registry.go
+++ b/backend/internal/cluster/registry.go
@@ -1,17 +1,35 @@
 package cluster
 
 import (
+	"sync"
+
 	"github.com/kj187/jarvis/backend/internal/alertmanager"
 	"github.com/kj187/jarvis/backend/internal/config"
 )
 
-// Cluster holds a configured Alertmanager cluster.
+// Member is one Alertmanager HA-cluster member.
+type Member struct {
+	Name    string // host:port, used for display/metrics/tags
+	URL     string // internal polling URL
+	LinkURL string // browser-visible URL (HOST_ALIAS-rewritten)
+	Client  *alertmanager.Client
+}
+
+// Cluster holds a configured Alertmanager cluster — one or more HA members
+// polled and merged into one logical alert/silence set.
 type Cluster struct {
-	Name                string
+	Name          string
+	PrometheusURL string
+	Members       []*Member
+
+	// AlertmanagerURL / AlertmanagerLinkURL / Client mirror the first member —
+	// back-compat convenience for single-member call sites and tests.
 	AlertmanagerURL     string
 	AlertmanagerLinkURL string
-	PrometheusURL       string
 	Client              *alertmanager.Client
+
+	upMu sync.Mutex
+	up   map[string]bool // member name -> last known up/down, from the last FetchAlerts
 }
 
 // Registry holds all configured clusters.
@@ -26,17 +44,50 @@ func NewRegistry(cfgs []config.ClusterConfig) *Registry {
 		byName: make(map[string]*Cluster, len(cfgs)),
 	}
 	for _, c := range cfgs {
-		cl := &Cluster{
-			Name:                c.Name,
-			AlertmanagerURL:     c.AlertmanagerURL,
-			AlertmanagerLinkURL: c.AlertmanagerLinkURL,
-			PrometheusURL:       c.PrometheusURL,
-			Client: alertmanager.NewClientWithAuth(c.AlertmanagerURL, buildAuth(c.Auth)),
-		}
+		cl := buildCluster(c)
 		r.clusters = append(r.clusters, cl)
 		r.byName[c.Name] = cl
 	}
 	return r
+}
+
+func buildCluster(c config.ClusterConfig) *Cluster {
+	memberCfgs := c.Members
+	if len(memberCfgs) == 0 && c.AlertmanagerURL != "" {
+		linkURL := c.AlertmanagerLinkURL
+		if linkURL == "" {
+			linkURL = c.AlertmanagerURL
+		}
+		memberCfgs = []config.MemberConfig{{
+			Name:    config.DeriveMemberName(c.AlertmanagerURL),
+			URL:     c.AlertmanagerURL,
+			LinkURL: linkURL,
+		}}
+	}
+
+	auth := buildAuth(c.Auth)
+	members := make([]*Member, 0, len(memberCfgs))
+	for _, mc := range memberCfgs {
+		members = append(members, &Member{
+			Name:    mc.Name,
+			URL:     mc.URL,
+			LinkURL: mc.LinkURL,
+			Client:  alertmanager.NewClientWithAuth(mc.URL, auth),
+		})
+	}
+
+	cl := &Cluster{
+		Name:          c.Name,
+		PrometheusURL: c.PrometheusURL,
+		Members:       members,
+		up:            make(map[string]bool),
+	}
+	if len(members) > 0 {
+		cl.AlertmanagerURL = members[0].URL
+		cl.AlertmanagerLinkURL = members[0].LinkURL
+		cl.Client = members[0].Client
+	}
+	return cl
 }
 
 // buildAuth maps a config.ClusterAuth to an alertmanager.Auth.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -59,15 +59,28 @@ type ClusterAuth struct {
 	OAuth2 *OAuth2Config
 }
 
-// ClusterConfig holds configuration for a single Alertmanager cluster.
+// MemberConfig holds one Alertmanager HA-cluster member. A ClusterConfig
+// with a single member is exactly today's one-cluster-one-URL setup.
+type MemberConfig struct {
+	Name    string // host:port, used for display/metrics/tags
+	URL     string // internal polling URL
+	LinkURL string // browser-visible URL (HOST_ALIAS-rewritten)
+}
+
+// ClusterConfig holds configuration for a single Alertmanager cluster. A
+// cluster may have multiple Members when it is an Alertmanager HA gossip
+// cluster — see Members.
 type ClusterConfig struct {
-	Name            string
-	AlertmanagerURL string
-	// AlertmanagerLinkURL is the browser-visible URL (may differ from AlertmanagerURL
-	// when HOST_ALIAS is set).
+	Name string
+	// AlertmanagerURL / AlertmanagerLinkURL mirror the first member (Members[0])
+	// for single-member back-compat call sites. Always set when Members is set.
+	AlertmanagerURL     string
 	AlertmanagerLinkURL string
 	PrometheusURL       string
 	Auth                ClusterAuth
+	// Members holds every HA member parsed from a comma-separated
+	// ALERTMANAGER_URL. Len 1 for a classic single-URL cluster.
+	Members []MemberConfig
 }
 
 // Load reads configuration from environment variables, optionally loading a
@@ -168,12 +181,15 @@ func parseClusters() ([]ClusterConfig, error) {
 		if name == "" {
 			break
 		}
-		amURL := os.Getenv(prefix + "ALERTMANAGER_URL")
-		if amURL == "" {
+		amURLRaw := os.Getenv(prefix + "ALERTMANAGER_URL")
+		if amURLRaw == "" {
 			return nil, fmt.Errorf("JARVIS_CLUSTER_%d_ALERTMANAGER_URL is required when NAME is set", i)
 		}
 		hostAlias := os.Getenv(prefix + "HOST_ALIAS")
-		linkURL := resolveAlertmanagerLinkURL(amURL, hostAlias)
+		members, err := parseMembers(amURLRaw, hostAlias, i)
+		if err != nil {
+			return nil, err
+		}
 
 		auth := ClusterAuth{
 			BearerToken: os.Getenv(prefix + "BEARER_TOKEN"),
@@ -204,13 +220,92 @@ func parseClusters() ([]ClusterConfig, error) {
 
 		clusters = append(clusters, ClusterConfig{
 			Name:                name,
-			AlertmanagerURL:     amURL,
-			AlertmanagerLinkURL: linkURL,
+			AlertmanagerURL:     members[0].URL,
+			AlertmanagerLinkURL: members[0].LinkURL,
 			PrometheusURL:       os.Getenv(prefix + "PROMETHEUS_URL"),
 			Auth:                auth,
+			Members:             members,
 		})
 	}
 	return clusters, nil
+}
+
+// parseMembers splits a (possibly comma-separated) ALERTMANAGER_URL into one
+// MemberConfig per HA member. A single URL (no comma) produces exactly one
+// member — today's behavior, unchanged. Whitespace around each URL is
+// trimmed; empty parts are skipped. Duplicate member URLs are a startup error.
+func parseMembers(rawURLs, rawHostAliases string, clusterIdx int) ([]MemberConfig, error) {
+	seen := make(map[string]bool)
+	var urls []string
+	for _, part := range strings.Split(rawURLs, ",") {
+		u := strings.TrimSpace(part)
+		if u == "" {
+			continue
+		}
+		if seen[u] {
+			return nil, fmt.Errorf("JARVIS_CLUSTER_%d_ALERTMANAGER_URL: duplicate member URL %q", clusterIdx, u)
+		}
+		seen[u] = true
+		urls = append(urls, u)
+	}
+	if len(urls) == 0 {
+		return nil, fmt.Errorf("JARVIS_CLUSTER_%d_ALERTMANAGER_URL is required when NAME is set", clusterIdx)
+	}
+
+	aliases, err := splitHostAliases(rawHostAliases, len(urls), clusterIdx)
+	if err != nil {
+		return nil, err
+	}
+
+	members := make([]MemberConfig, len(urls))
+	for i, u := range urls {
+		members[i] = MemberConfig{
+			Name:    DeriveMemberName(u),
+			URL:     u,
+			LinkURL: resolveAlertmanagerLinkURL(u, aliases[i]),
+		}
+	}
+	return members, nil
+}
+
+// splitHostAliases parses HOST_ALIAS into one alias per member. Empty input
+// means no alias for any member. A single value applies to every member —
+// today's single-member behavior, and a convenient default for an HA
+// cluster fronted by one shared alias/load balancer. A comma-separated list
+// must match the member count exactly, index for index, so each member can
+// get its own browser-visible URL (e.g. distinct ports on localhost).
+func splitHostAliases(raw string, memberCount, clusterIdx int) ([]string, error) {
+	if raw == "" {
+		return make([]string, memberCount), nil
+	}
+	var aliases []string
+	for _, part := range strings.Split(raw, ",") {
+		aliases = append(aliases, strings.TrimSpace(part))
+	}
+	if len(aliases) == 1 {
+		out := make([]string, memberCount)
+		for i := range out {
+			out[i] = aliases[0]
+		}
+		return out, nil
+	}
+	if len(aliases) != memberCount {
+		return nil, fmt.Errorf(
+			"JARVIS_CLUSTER_%d_HOST_ALIAS: %d alias(es) for %d member(s) — must be 1 (applies to all) or exactly %d (one per member)",
+			clusterIdx, len(aliases), memberCount, memberCount,
+		)
+	}
+	return aliases, nil
+}
+
+// DeriveMemberName returns the display name for an Alertmanager member URL —
+// its host:port. Falls back to the raw URL if it fails to parse.
+func DeriveMemberName(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL
+	}
+	return u.Host
 }
 
 // parseClusterHeaders scans os.Environ for JARVIS_CLUSTER_N_HEADER_<name>=<value> entries

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -103,6 +103,160 @@ func TestLoad_HostAlias(t *testing.T) {
 	}
 }
 
+func TestLoad_ClusterSingleMember(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "homelab")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", "http://am:9093")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	members := cfg.Clusters[0].Members
+	if len(members) != 1 {
+		t.Fatalf("len(Members) = %d, want 1", len(members))
+	}
+	if members[0].Name != "am:9093" {
+		t.Errorf("Members[0].Name = %q, want am:9093", members[0].Name)
+	}
+	if members[0].URL != "http://am:9093" {
+		t.Errorf("Members[0].URL = %q", members[0].URL)
+	}
+	if members[0].LinkURL != "http://am:9093" {
+		t.Errorf("Members[0].LinkURL = %q", members[0].LinkURL)
+	}
+}
+
+func TestLoad_ClusterMultipleMembers(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "prod")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", "http://am1:9093,http://am2:9093,http://am3:9093")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	c := cfg.Clusters[0]
+	if len(c.Members) != 3 {
+		t.Fatalf("len(Members) = %d, want 3", len(c.Members))
+	}
+	wantNames := []string{"am1:9093", "am2:9093", "am3:9093"}
+	for i, want := range wantNames {
+		if c.Members[i].Name != want {
+			t.Errorf("Members[%d].Name = %q, want %q", i, c.Members[i].Name, want)
+		}
+	}
+	// Back-compat single-URL fields mirror the first member.
+	if c.AlertmanagerURL != "http://am1:9093" {
+		t.Errorf("AlertmanagerURL = %q, want http://am1:9093 (first member)", c.AlertmanagerURL)
+	}
+}
+
+func TestLoad_ClusterMultipleMembers_WhitespaceTolerant(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "prod")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", " http://am1:9093 , http://am2:9093 ")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	c := cfg.Clusters[0]
+	if len(c.Members) != 2 {
+		t.Fatalf("len(Members) = %d, want 2", len(c.Members))
+	}
+	if c.Members[0].URL != "http://am1:9093" || c.Members[1].URL != "http://am2:9093" {
+		t.Errorf("Members URLs not trimmed: %+v", c.Members)
+	}
+}
+
+func TestLoad_ClusterMultipleMembers_HostAliasAppliesToAll(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "prod")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", "http://am1:9093,http://am2:9093")
+	t.Setenv("JARVIS_CLUSTER_1_HOST_ALIAS", "https://am.example.com")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	c := cfg.Clusters[0]
+	for i, m := range c.Members {
+		if m.LinkURL != "https://am.example.com" {
+			t.Errorf("Members[%d].LinkURL = %q, want https://am.example.com", i, m.LinkURL)
+		}
+	}
+}
+
+func TestLoad_ClusterMultipleMembers_HostAliasPerMember(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "prod")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", "http://test-alertmanager:9093,http://test-alertmanager-2:9093")
+	t.Setenv("JARVIS_CLUSTER_1_HOST_ALIAS", "http://localhost:9094,http://localhost:9095")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	c := cfg.Clusters[0]
+	if len(c.Members) != 2 {
+		t.Fatalf("len(Members) = %d, want 2", len(c.Members))
+	}
+	if c.Members[0].LinkURL != "http://localhost:9094" {
+		t.Errorf("Members[0].LinkURL = %q, want http://localhost:9094", c.Members[0].LinkURL)
+	}
+	if c.Members[1].LinkURL != "http://localhost:9095" {
+		t.Errorf("Members[1].LinkURL = %q, want http://localhost:9095", c.Members[1].LinkURL)
+	}
+}
+
+func TestLoad_ClusterMultipleMembers_HostAliasCountMismatch(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "prod")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", "http://am1:9093,http://am2:9093,http://am3:9093")
+	t.Setenv("JARVIS_CLUSTER_1_HOST_ALIAS", "http://localhost:9094,http://localhost:9095")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Error("expected error when HOST_ALIAS count matches neither 1 nor member count")
+	}
+}
+
+func TestLoad_ClusterDuplicateMemberURL(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "prod")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", "http://am1:9093,http://am1:9093")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Error("expected error for duplicate member URL, got nil")
+	}
+}
+
+func TestLoad_ClusterAuthAppliesToAllMembers(t *testing.T) {
+	t.Setenv("JARVIS_CLUSTER_1_NAME", "prod")
+	t.Setenv("JARVIS_CLUSTER_1_ALERTMANAGER_URL", "http://am1:9093,http://am2:9093")
+	t.Setenv("JARVIS_CLUSTER_1_BEARER_TOKEN", "tok")
+	t.Setenv("JARVIS_CLUSTER_2_NAME", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	// Auth lives on ClusterConfig, not per-member — applies to all members alike.
+	if cfg.Clusters[0].Auth.BearerToken != "tok" {
+		t.Errorf("BearerToken = %q, want tok", cfg.Clusters[0].Auth.BearerToken)
+	}
+	if len(cfg.Clusters[0].Members) != 2 {
+		t.Fatalf("len(Members) = %d, want 2", len(cfg.Clusters[0].Members))
+	}
+}
+
 func TestLoad_InvalidPollInterval(t *testing.T) {
 	t.Setenv("JARVIS_POLL_INTERVAL", "notaduration")
 	_, err := Load()

--- a/backend/internal/history/recorder.go
+++ b/backend/internal/history/recorder.go
@@ -37,12 +37,6 @@ type Recorder struct {
 	prevSilenceInfo   map[string]silenceInfoEntry // cluster+silenceID → {state, cluster, comment}
 	prevAlertSilences map[string][]string         // fingerprint+cluster → []cluster+silenceID
 
-	// clusterUpMu guards clusterUp, the last-poll-success flag per cluster.
-	// Read at scrape time by the metrics collector — never issues an upstream
-	// HTTP call itself, so a slow/unreachable Alertmanager cannot stall a scrape.
-	clusterUpMu sync.Mutex
-	clusterUp   map[string]bool
-
 	// claimReleaseDelay is how long to wait after detecting a resolution before
 	// releasing claims. Must exceed the 60s grace period so grace-period re-fires
 	// can cancel the release before it runs.
@@ -112,28 +106,20 @@ func NewRecorder(
 		prevSnapshot:      make(map[string]string),
 		prevSilenceInfo:   make(map[string]silenceInfoEntry),
 		prevAlertSilences: make(map[string][]string),
-		clusterUp:         make(map[string]bool),
 		claimReleaseDelay: 20 * time.Minute,
 	}
 }
 
-// ClusterUpStates returns a copy of the last-poll-success flag per cluster.
-// Used by the metrics collector at scrape time — reads cached state only,
-// never performs an upstream HTTP call.
-func (r *Recorder) ClusterUpStates() map[string]bool {
-	r.clusterUpMu.Lock()
-	defer r.clusterUpMu.Unlock()
-	out := make(map[string]bool, len(r.clusterUp))
-	for k, v := range r.clusterUp {
-		out[k] = v
+// ClusterUpStates returns the last-poll-success flag per cluster and member
+// (cluster name -> member name -> up). Used by the metrics collector at
+// scrape time — reads each cluster's cached state only, never performs an
+// upstream HTTP call.
+func (r *Recorder) ClusterUpStates() map[string]map[string]bool {
+	out := make(map[string]map[string]bool, len(r.registry.All()))
+	for _, cl := range r.registry.All() {
+		out[cl.Name] = cl.MemberUpStates()
 	}
 	return out
-}
-
-func (r *Recorder) setClusterUp(clusterName string, up bool) {
-	r.clusterUpMu.Lock()
-	r.clusterUp[clusterName] = up
-	r.clusterUpMu.Unlock()
 }
 
 // Trigger signals the recorder to run an immediate poll.
@@ -194,19 +180,19 @@ func (r *Recorder) poll(ctx context.Context) {
 		wg.Add(1)
 		go func(idx int, cl *cluster.Cluster) {
 			defer wg.Done()
+			var onDuration cluster.FetchDurationFunc
 			if r.metrics != nil {
 				r.metrics.PollCyclesTotal.WithLabelValues(cl.Name).Inc()
-				fetchStart := time.Now()
-				defer func() {
-					r.metrics.ClusterFetchDurationSeconds.WithLabelValues(cl.Name).Observe(time.Since(fetchStart).Seconds())
-				}()
+				onDuration = func(member string, seconds float64) {
+					r.metrics.ClusterFetchDurationSeconds.WithLabelValues(cl.Name, member).Observe(seconds)
+				}
 			}
-			alerts, err := r.fetchCluster(ctx, cl)
+			alerts, err := cl.FetchAlerts(ctx, onDuration)
 			if err != nil {
 				results[idx] = clusterResult{name: cl.Name, err: err}
 				return
 			}
-			silences, serr := cl.Client.GetSilences(ctx)
+			silences, serr := cl.FetchSilences(ctx, onDuration)
 			if serr != nil {
 				r.logger.Warn("fetch silences failed", "cluster", cl.Name, "err", serr)
 			}
@@ -220,13 +206,11 @@ func (r *Recorder) poll(ctx context.Context) {
 	for _, res := range results {
 		if res.err != nil {
 			r.logger.Error("poll cluster failed", "cluster", res.name, "err", res.err)
-			r.setClusterUp(res.name, false)
 			if r.metrics != nil {
 				r.metrics.PollErrorsTotal.WithLabelValues(res.name, "alerts").Inc()
 			}
 			continue
 		}
-		r.setClusterUp(res.name, true)
 		if res.silencesErr != nil && r.metrics != nil {
 			r.metrics.PollErrorsTotal.WithLabelValues(res.name, "silences").Inc()
 		}
@@ -458,71 +442,11 @@ func (r *Recorder) broadcastAlertsIfChanged() {
 	r.hub.BroadcastJSON(models.WSTypeAlertsUpdate, json.RawMessage(data))
 }
 
-// fetchCluster fetches and enriches alerts for a single cluster.
+// fetchCluster fetches and enriches (deduplicated, merged) alerts for a
+// single cluster. Thin wrapper around cluster.Cluster.FetchAlerts, kept so
+// tests can drive a single cluster fetch directly without going through poll().
 func (r *Recorder) fetchCluster(ctx context.Context, cl *cluster.Cluster) ([]models.EnrichedAlert, error) {
-	rawAlerts, err := cl.Client.GetAlerts(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return enrichAlerts(rawAlerts, cl.Name, cl.AlertmanagerLinkURL), nil
-}
-
-// enrichAlerts maps raw Alertmanager alerts to EnrichedAlert, injecting the
-// cluster metadata and the synthetic "@receiver" label (comma-separated list of
-// receiver names) used for filtering. It is a pure function so it can be unit
-// tested and benchmarked without an HTTP round-trip.
-//
-// The receiver names are gathered in a single pass that builds both the
-// Receivers slice and the "@receiver" join string, avoiding a second loop and a
-// throwaway slice per alert — this matters when enriching large alert sets.
-func enrichAlerts(rawAlerts []alertmanager.GettableAlert, clusterName, alertmanagerLinkURL string) []models.EnrichedAlert {
-	enriched := make([]models.EnrichedAlert, 0, len(rawAlerts))
-	for i := range rawAlerts {
-		a := &rawAlerts[i]
-
-		receivers := make([]models.Receiver, len(a.Receivers))
-		var receiverList strings.Builder
-		for j, rcv := range a.Receivers {
-			receivers[j] = models.Receiver{Name: rcv.Name}
-			if j > 0 {
-				receiverList.WriteByte(',')
-			}
-			receiverList.WriteString(rcv.Name)
-		}
-
-		labelCount := len(a.Labels)
-		if len(a.Receivers) > 0 {
-			labelCount++
-		}
-		labels := make(map[string]string, labelCount)
-		for k, v := range a.Labels {
-			labels[k] = v
-		}
-		// Store all receivers as comma-separated list for filtering.
-		// This allows filters to match any receiver that handles this alert.
-		if len(a.Receivers) > 0 {
-			labels["@receiver"] = receiverList.String()
-		}
-
-		enriched = append(enriched, models.EnrichedAlert{
-			Fingerprint: a.Fingerprint,
-			Status: models.AlertStatus{
-				InhibitedBy: a.Status.InhibitedBy,
-				SilencedBy:  a.Status.SilencedBy,
-				State:       a.Status.State,
-			},
-			Labels:          labels,
-			Annotations:     a.Annotations,
-			StartsAt:        a.StartsAt,
-			EndsAt:          a.EndsAt,
-			UpdatedAt:       a.UpdatedAt,
-			GeneratorURL:    a.GeneratorURL,
-			Receivers:       receivers,
-			ClusterName:     clusterName,
-			AlertmanagerURL: alertmanagerLinkURL,
-		})
-	}
-	return enriched
+	return cl.FetchAlerts(ctx, nil)
 }
 
 // buildWSPayload marshals a typed WS event payload (helper used in tests).

--- a/backend/internal/history/recorder_test.go
+++ b/backend/internal/history/recorder_test.go
@@ -57,8 +57,8 @@ func newTestRecorder(t *testing.T) (*Recorder, *mockHub) {
 		prevSnapshot:      make(map[string]string),
 		prevSilenceInfo:   make(map[string]silenceInfoEntry),
 		prevAlertSilences: make(map[string][]string),
-		clusterUp:         make(map[string]bool),
 		claimReleaseDelay: 10 * time.Millisecond,
+		registry:          cluster.NewRegistry(nil),
 	}
 	return rec, hub
 }
@@ -250,6 +250,9 @@ func TestFetchCluster_InjectsReceiverLabel(t *testing.T) {
 		AlertmanagerURL:     srv.URL,
 		AlertmanagerLinkURL: srv.URL,
 		Client:              alertmanager.NewClient(srv.URL),
+		Members: []*cluster.Member{
+			{Name: "test-member", URL: srv.URL, LinkURL: srv.URL, Client: alertmanager.NewClient(srv.URL)},
+		},
 	}
 
 	enriched, err := rec.fetchCluster(context.Background(), cl)
@@ -293,6 +296,9 @@ func TestFetchCluster_NoReceiverLabelWhenReceiversEmpty(t *testing.T) {
 		AlertmanagerURL:     srv.URL,
 		AlertmanagerLinkURL: srv.URL,
 		Client:              alertmanager.NewClient(srv.URL),
+		Members: []*cluster.Member{
+			{Name: "test-member", URL: srv.URL, LinkURL: srv.URL, Client: alertmanager.NewClient(srv.URL)},
+		},
 	}
 
 	enriched, err := rec.fetchCluster(context.Background(), cl)
@@ -425,11 +431,11 @@ func TestRecorder_Poll_InstrumentsMetrics(t *testing.T) {
 	}
 
 	up := rec.ClusterUpStates()
-	if !up["good"] {
-		t.Error("ClusterUpStates()[good] = false, want true")
+	if !up["good"][config.DeriveMemberName(healthy.URL)] {
+		t.Error("ClusterUpStates()[good][member] = false, want true")
 	}
-	if up["bad"] {
-		t.Error("ClusterUpStates()[bad] = true, want false")
+	if up["bad"][config.DeriveMemberName(failing.URL)] {
+		t.Error("ClusterUpStates()[bad][member] = true, want false")
 	}
 
 	if n := testutil.CollectAndCount(rec.metrics.PollDurationSeconds); n != 1 {
@@ -479,6 +485,66 @@ func TestRecorder_Metrics_CountsRefireAfterSilenceExpiry(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(rec.metrics.AlertEventsTotal.WithLabelValues("homelab", models.EventStatusFiring)); got != 2 {
 		t.Errorf("AlertEventsTotal[homelab,firing] = %v, want 2 (initial firing + re-fire after expiry)", got)
+	}
+}
+
+// TestRecorder_Poll_HACluster_NoDoubledHistoryEvents drives a full poll()
+// across a 2-member HA cluster where both members report the same
+// fingerprint. The merge in cluster.Cluster.FetchAlerts must collapse this to
+// one alert *before* the recorder ever sees the snapshot, so history stays
+// keyed by exactly (fingerprint, cluster) — one event row, not two.
+func TestRecorder_Poll_HACluster_NoDoubledHistoryEvents(t *testing.T) {
+	member := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v2/alerts":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode([]alertmanager.GettableAlert{
+					{
+						Fingerprint: "fp1",
+						Status:      alertmanager.GettableAlertStatus{State: "active"},
+						Labels:      map[string]string{"alertname": "TestAlert"},
+						Annotations: map[string]string{},
+						StartsAt:    time.Now().UTC(),
+						UpdatedAt:   time.Now().UTC(),
+					},
+				})
+			case "/api/v2/silences":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode([]alertmanager.GettableSilence{})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	}
+	am1 := member()
+	defer am1.Close()
+	am2 := member()
+	defer am2.Close()
+
+	rec, _ := newTestRecorder(t)
+	rec.registry = cluster.NewRegistry([]config.ClusterConfig{
+		{
+			Name: "homelab",
+			Members: []config.MemberConfig{
+				{Name: config.DeriveMemberName(am1.URL), URL: am1.URL, LinkURL: am1.URL},
+				{Name: config.DeriveMemberName(am2.URL), URL: am2.URL, LinkURL: am2.URL},
+			},
+		},
+	})
+
+	rec.poll(context.Background())
+	rec.poll(context.Background())
+
+	events, total, err := rec.store.GetHistoryForCluster("fp1", "homelab", 100, 0)
+	if err != nil {
+		t.Fatalf("GetHistoryForCluster: %v", err)
+	}
+	if total != 1 || len(events) != 1 {
+		t.Fatalf("total = %d, len(events) = %d, want 1 (both members report the same alert — merge must collapse it before the recorder sees it)", total, len(events))
+	}
+	if got := testutil.ToFloat64(rec.metrics.AlertEventsTotal.WithLabelValues("homelab", models.EventStatusFiring)); got != 1 {
+		t.Errorf("AlertEventsTotal[homelab,firing] = %v, want 1 (second poll of the same merged alert must not double-count)", got)
 	}
 }
 

--- a/backend/internal/metrics/collector.go
+++ b/backend/internal/metrics/collector.go
@@ -24,8 +24,8 @@ var (
 		"jarvis_alerts_by_severity", "Number of alerts, by cluster and severity.",
 		[]string{"cluster", "severity"}, nil)
 	alertmanagerUpDesc = prometheus.NewDesc(
-		"jarvis_alertmanager_up", "Whether the last poll of a cluster succeeded (1) or failed (0).",
-		[]string{"cluster"}, nil)
+		"jarvis_alertmanager_up", "Whether the last poll of a cluster member succeeded (1) or failed (0).",
+		[]string{"cluster", "member"}, nil)
 	wsClientsDesc = prometheus.NewDesc(
 		"jarvis_ws_clients", "Number of currently connected WebSocket clients.", nil, nil)
 	clustersConfiguredDesc = prometheus.NewDesc(
@@ -40,13 +40,14 @@ var (
 type storeCollector struct {
 	alerts      alertSource
 	clients     clientCounter
-	clusterUp   func() map[string]bool
+	clusterUp   func() map[string]map[string]bool
 	numClusters int
 }
 
 // NewCollector creates the scrape-time collector. clusterUp may be nil (no
 // jarvis_alertmanager_up samples emitted) until the recorder wires it in.
-func NewCollector(alerts alertSource, clients clientCounter, clusterUp func() map[string]bool, numClusters int) prometheus.Collector {
+// clusterUp maps cluster name -> member name -> up.
+func NewCollector(alerts alertSource, clients clientCounter, clusterUp func() map[string]map[string]bool, numClusters int) prometheus.Collector {
 	return &storeCollector{alerts: alerts, clients: clients, clusterUp: clusterUp, numClusters: numClusters}
 }
 
@@ -80,12 +81,14 @@ func (c *storeCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	if c.clusterUp != nil {
-		for cluster, up := range c.clusterUp() {
-			value := 0.0
-			if up {
-				value = 1.0
+		for cluster, members := range c.clusterUp() {
+			for member, up := range members {
+				value := 0.0
+				if up {
+					value = 1.0
+				}
+				ch <- prometheus.MustNewConstMetric(alertmanagerUpDesc, prometheus.GaugeValue, value, cluster, member)
 			}
-			ch <- prometheus.MustNewConstMetric(alertmanagerUpDesc, prometheus.GaugeValue, value, cluster)
 		}
 	}
 

--- a/backend/internal/metrics/collector_test.go
+++ b/backend/internal/metrics/collector_test.go
@@ -24,7 +24,12 @@ func TestStoreCollector_Collect(t *testing.T) {
 		{ClusterName: "prod", Status: models.AlertStatus{State: "suppressed"}, Labels: map[string]string{}},
 	}}
 	clients := fakeClientCounter{count: 3}
-	clusterUp := func() map[string]bool { return map[string]bool{"prod": true, "staging": false} }
+	clusterUp := func() map[string]map[string]bool {
+		return map[string]map[string]bool{
+			"prod":    {"am1:9093": true},
+			"staging": {"am2:9093": false},
+		}
+	}
 
 	c := NewCollector(alerts, clients, clusterUp, 2)
 
@@ -37,10 +42,10 @@ func TestStoreCollector_Collect(t *testing.T) {
 		# TYPE jarvis_alerts_by_severity gauge
 		jarvis_alerts_by_severity{cluster="prod",severity="critical"} 2
 		jarvis_alerts_by_severity{cluster="prod",severity="none"} 1
-		# HELP jarvis_alertmanager_up Whether the last poll of a cluster succeeded (1) or failed (0).
+		# HELP jarvis_alertmanager_up Whether the last poll of a cluster member succeeded (1) or failed (0).
 		# TYPE jarvis_alertmanager_up gauge
-		jarvis_alertmanager_up{cluster="prod"} 1
-		jarvis_alertmanager_up{cluster="staging"} 0
+		jarvis_alertmanager_up{cluster="prod",member="am1:9093"} 1
+		jarvis_alertmanager_up{cluster="staging",member="am2:9093"} 0
 		# HELP jarvis_clusters_configured Number of configured Alertmanager clusters.
 		# TYPE jarvis_clusters_configured gauge
 		jarvis_clusters_configured 2
@@ -59,7 +64,7 @@ func TestStoreCollector_NilClusterUp(t *testing.T) {
 	c := NewCollector(fakeAlertSource{}, fakeClientCounter{}, nil, 0)
 
 	if err := testutil.CollectAndCompare(c, strings.NewReader(`
-		# HELP jarvis_alertmanager_up Whether the last poll of a cluster succeeded (1) or failed (0).
+		# HELP jarvis_alertmanager_up Whether the last poll of a cluster member succeeded (1) or failed (0).
 		# TYPE jarvis_alertmanager_up gauge
 	`), "jarvis_alertmanager_up"); err != nil {
 		t.Fatalf("expected no jarvis_alertmanager_up samples when clusterUp is nil: %v", err)

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -61,9 +61,9 @@ func New(version string) *Metrics {
 		}),
 		ClusterFetchDurationSeconds: f.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "jarvis_cluster_fetch_duration_seconds",
-			Help:    "Duration of fetching alerts and silences from a single cluster's Alertmanager.",
+			Help:    "Duration of fetching alerts or silences from a single Alertmanager member.",
 			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
-		}, []string{"cluster"}),
+		}, []string{"cluster", "member"}),
 		AlertEventsTotal: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "jarvis_alert_events_total",
 			Help: "Total number of alert lifecycle events recorded, by cluster and status.",

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -30,6 +30,10 @@ type EnrichedAlert struct {
 	ClusterName     string            `json:"clusterName"`
 	AlertmanagerURL string            `json:"alertmanagerUrl"` // Browser link URL
 	ActiveClaim     *Claim            `json:"activeClaim,omitempty"`
+	// SeenOn lists the HA member names (host:port) that reported this
+	// fingerprint in the last poll. Omitted for single-member clusters so
+	// existing payloads stay byte-identical.
+	SeenOn []string `json:"seenOn,omitempty"`
 }
 
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -190,6 +194,16 @@ type ClusterInfo struct {
 	PrometheusURL   string `json:"prometheusUrl"`
 	Healthy         bool   `json:"healthy"`
 	AlertCount      int    `json:"alertCount"`
+	// Members lists per-member health for HA clusters. Omitted for
+	// single-member clusters so existing payloads stay byte-identical.
+	Members []MemberInfo `json:"members,omitempty"`
+}
+
+// MemberInfo describes one Alertmanager HA-cluster member.
+type MemberInfo struct {
+	Name    string `json:"name"` // host:port
+	URL     string `json:"url"`  // browser-visible URL (HOST_ALIAS-rewritten)
+	Healthy bool   `json:"healthy"`
 }
 
 // ── AlertGroup ───────────────────────────────────────────────────────────────

--- a/compose.dev-dependencies.yml
+++ b/compose.dev-dependencies.yml
@@ -3,15 +3,18 @@
 #
 # Usage (via Makefile):
 #   make up-alertmanager / make down-alertmanager
+#   make up-alertmanager-ha / make down-alertmanager-ha   (2-member HA gossip pair)
 #   make up-postgres / make down-postgres
 #
 # Reachable from backend container:
-#   Alertmanager: http://test-alertmanager:9093
-#   PostgreSQL:   postgres://jarvis:jarvis@test-postgres:5432/jarvis?sslmode=disable
+#   Alertmanager:    http://test-alertmanager:9093
+#   Alertmanager HA: http://test-alertmanager:9093,http://test-alertmanager-2:9093
+#   PostgreSQL:      postgres://jarvis:jarvis@test-postgres:5432/jarvis?sslmode=disable
 #
 # Reachable from host:
-#   Alertmanager: http://localhost:9094
-#   PostgreSQL:   postgres://jarvis:jarvis@localhost:5432/jarvis?sslmode=disable
+#   Alertmanager:      http://localhost:9094
+#   Alertmanager HA-2: http://localhost:9095
+#   PostgreSQL:        postgres://jarvis:jarvis@localhost:5432/jarvis?sslmode=disable
 #
 # NOTE: sslmode=disable is intentional here — this is a local ephemeral test
 # container with no TLS configured. Never use sslmode=disable in production.
@@ -24,11 +27,32 @@ services:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--storage.path=/alertmanager'
       - '--web.listen-address=0.0.0.0:9093'
+      - '--cluster.listen-address=0.0.0.0:9094'
+      - '--cluster.peer=test-alertmanager-2:9094'
     ports:
       - "9094:9093"
     volumes:
       - ./scripts/test-alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro,z
     restart: unless-stopped
+
+  # Second HA gossip member — same config, peers with test-alertmanager over
+  # Alertmanager's mesh protocol so silences created against either instance
+  # replicate to both. Started only via `make up-alertmanager-ha`.
+  test-alertmanager-2:
+    image: docker.io/prom/alertmanager:latest
+    container_name: jarvis_test_alertmanager_2
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+      - '--web.listen-address=0.0.0.0:9093'
+      - '--cluster.listen-address=0.0.0.0:9094'
+      - '--cluster.peer=test-alertmanager:9094'
+    ports:
+      - "9095:9093"
+    volumes:
+      - ./scripts/test-alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro,z
+    restart: unless-stopped
+    profiles: ["ha"]
 
   test-postgres:
     image: docker.io/postgres:16-alpine

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,6 +6,12 @@ stack it fronts can also monitor Jarvis itself. The endpoint is **public**
 only aggregate counts and configured cluster names, never alert names,
 labels, or annotations.
 
+> **Breaking label change**: `jarvis_alertmanager_up` and
+> `jarvis_cluster_fetch_duration_seconds` gained a `member` label (HA-cluster
+> support). Existing dashboards/alerts that group only by `cluster` still
+> work with `sum by (cluster) (...)`; ones that assert on the exact label set
+> need the `member` label added.
+
 ## Scrape-time gauges
 
 Computed from the in-memory alert store, the WebSocket hub, and the poller's
@@ -17,7 +23,7 @@ sync with reality.
 | `jarvis_build_info` | `version` | Always `1`; join on `version` to track which build is running |
 | `jarvis_alerts` | `cluster`, `state` | Current alert count by state (`active`, `suppressed`, `unprocessed`, `resolved`) |
 | `jarvis_alerts_by_severity` | `cluster`, `severity` | Current alert count by severity label (`none` when unset) |
-| `jarvis_alertmanager_up` | `cluster` | `1` if the last poll of that cluster succeeded, else `0` |
+| `jarvis_alertmanager_up` | `cluster`, `member` | `1` if the last poll of that Alertmanager HA member succeeded, else `0`. Single-member clusters emit their one member; a cluster stays healthy overall as long as at least one member is up |
 | `jarvis_ws_clients` | — | Number of currently connected WebSocket clients |
 | `jarvis_clusters_configured` | — | Number of configured Alertmanager clusters |
 
@@ -28,7 +34,7 @@ sync with reality.
 | `jarvis_poll_cycles_total` | `cluster` | Every poll attempt of a cluster |
 | `jarvis_poll_errors_total` | `cluster`, `endpoint` (`alerts`/`silences`) | A poll of a cluster's alerts or silences endpoint fails |
 | `jarvis_poll_duration_seconds` | — | Histogram of the full poll cycle across all clusters, including DB persistence — use this to see whether Jarvis overall is keeping up with its poll interval |
-| `jarvis_cluster_fetch_duration_seconds` | `cluster` | Histogram of a single cluster's Alertmanager response time (alerts + silences) — use this to find *which* cluster is slow |
+| `jarvis_cluster_fetch_duration_seconds` | `cluster`, `member` | Histogram of a single Alertmanager HA member's response time (alerts or silences) — use this to find *which* member is slow |
 | `jarvis_alert_events_total` | `cluster`, `status` (`firing`/`suppressed`/`expired`/`resolved`) | A genuine alert lifecycle transition is recorded |
 | `jarvis_ws_broadcasts_total` | `type` | A WebSocket event is broadcast to clients |
 | `jarvis_http_requests_total` | `method`, `path`, `status` | Every HTTP request (labeled by route pattern, not raw URL) |
@@ -78,8 +84,8 @@ rate(jarvis_poll_errors_total[5m]) > 0
 # Alert volume by cluster and state
 sum by (cluster, state) (jarvis_alerts)
 
-# Which cluster's Alertmanager is slow
-histogram_quantile(0.95, sum by (le, cluster) (rate(jarvis_cluster_fetch_duration_seconds_bucket[5m])))
+# Which Alertmanager member is slow
+histogram_quantile(0.95, sum by (le, cluster, member) (rate(jarvis_cluster_fetch_duration_seconds_bucket[5m])))
 
 # API latency p95
 histogram_quantile(0.95, sum by (le, path) (rate(jarvis_http_request_duration_seconds_bucket[5m])))

--- a/frontend/src/components/alerts/AlertDetailPanel.tsx
+++ b/frontend/src/components/alerts/AlertDetailPanel.tsx
@@ -874,6 +874,16 @@ export function AlertDetailPanel({
             <div className="space-y-2">{renderLabelColumn(leftLabels)}</div>
             <div className="space-y-2">{renderLabelColumn(rightLabels)}</div>
           </div>
+          {alert.seenOn && alert.seenOn.length > 0 && (
+            <div className="mt-3 flex flex-wrap items-center gap-1.5 border-t border-border pt-3" data-testid="detail-seen-on">
+              <span className="text-xs text-muted-foreground">seen on:</span>
+              {alert.seenOn.map((member) => (
+                <span key={member} className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+                  {member}
+                </span>
+              ))}
+            </div>
+          )}
         </AlertDetailSection>
 
         {/* History */}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -205,7 +205,18 @@ export function Header() {
                       </div>
                       <span className="text-xs text-muted-foreground whitespace-nowrap">{c.alertCount} Alerts</span>
                     </div>
-                    <div className="mt-1 pl-[1.375rem] text-[10px] text-muted-foreground/60 break-all">{c.alertmanagerUrl}</div>
+                    {c.members && c.members.length > 0 ? (
+                      <div className="mt-1 pl-[1.375rem] space-y-0.5">
+                        {c.members.map((m) => (
+                          <div key={m.name} className="flex items-center gap-1.5 text-[10px]">
+                            <div className={`h-1.5 w-1.5 rounded-full shrink-0 ${m.healthy ? 'bg-green-500' : 'bg-red-500'}`} />
+                            <span className="break-all text-muted-foreground/60">{m.url}</span>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="mt-1 pl-[1.375rem] text-[10px] text-muted-foreground/60 break-all">{c.alertmanagerUrl}</div>
+                    )}
                   </div>
                 ))}
               </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,6 +23,8 @@ export interface EnrichedAlert {
   clusterName: string
   alertmanagerUrl: string
   activeClaim?: Claim
+  /** HA member names (host:port) that reported this fingerprint in the last poll. Absent for single-member clusters. */
+  seenOn?: string[]
 }
 
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -134,6 +136,14 @@ export interface ClusterInfo {
   prometheusUrl: string
   healthy: boolean
   alertCount: number
+  /** Per-member health for HA clusters. Absent for single-member clusters. */
+  members?: MemberInfo[]
+}
+
+export interface MemberInfo {
+  name: string
+  url: string
+  healthy: boolean
 }
 
 // ── AlertGroup ───────────────────────────────────────────────────────────────

--- a/scripts/resolve-test-alerts.sh
+++ b/scripts/resolve-test-alerts.sh
@@ -236,5 +236,88 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=rate(coredns_dns_responses_total%7Brcode%3D%22SERVFAIL%22%7D%5B5m%5D)"
 }]'
 
+printf " [13/17] LinkRichAlert..."
+resolve '[{
+  "labels": {
+    "alertname": "LinkRichAlert",
+    "severity": "warning",
+    "namespace": "prod",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "runbook": "'"${RUNBOOKS}"'/LinkRichAlert",
+    "wiki": "https://wiki.example.com/alerts/link-rich",
+    "docs": "https://docs.example.com/platform/alerts/link-rich",
+    "source_code": "https://github.com/example/platform/blob/main/alerts/link-rich.yml",
+    "playbook": "https://playbooks.example.com/oncall/link-rich",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Alert with many link-type labels and annotations"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=up%7Bjob%3D%22platform%22%7D"
+}]'
+
+printf " [14/17] InlineUrlsAlert..."
+resolve '[{
+  "labels": {
+    "alertname": "InlineUrlsAlert",
+    "severity": "info",
+    "namespace": "monitoring",
+    "cluster": "eu-west-1-prod",
+    "team": "observability",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Alert with inline URLs scattered across description text"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=up%7Bjob%3D%22prometheus%22%7D"
+}]'
+
+printf " [15/17] LabelOnlyLinksAlert..."
+resolve '[{
+  "labels": {
+    "alertname": "LabelOnlyLinksAlert",
+    "severity": "info",
+    "namespace": "staging",
+    "cluster": "eu-west-1-staging",
+    "team": "frontend",
+    "runbook": "'"${RUNBOOKS}"'/LabelOnlyLinksAlert",
+    "wiki": "https://wiki.example.com/alerts/label-only",
+    "grafana": "'"${GRAFANA}"'/d/frontend-overview?orgId=1",
+    "github_issue": "https://github.com/example/frontend/issues/42",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Alert with links exclusively in labels"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=http_requests_total%7Benv%3D%22staging%22%7D"
+}]'
+
+printf " [16/17] AnnotationOnlyLinksAlert..."
+resolve '[{
+  "labels": {
+    "alertname": "AnnotationOnlyLinksAlert",
+    "severity": "warning",
+    "namespace": "prod",
+    "cluster": "eu-west-1-prod",
+    "team": "data",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Alert with links exclusively in annotations"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=job_duration_seconds%7Bjob%3D%22s3-export%22%7D"
+}]'
+
+printf " [17/17] SpecialCharLabelAlert..."
+resolve '[{
+  "labels": {
+    "alertname": "SpecialCharLabelAlert",
+    "severity": "warning",
+    "namespace": "prod",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "kubernetes_version": "v1.28.4",
+    "image_tag": "payment-api-v2-3-1-rc",
+    "secret_path": "v1/b2b/cert/web-tuadev",
+    "runbook": "'"${RUNBOOKS}"'/SpecialCharLabelAlert",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Alert with special characters in label values"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=up%7Bjob%3D%22platform%22%7D"
+}]'
+
 echo ""
-echo "==> All 12 Kubernetes test alerts resolved."
+echo "==> All 17 Kubernetes test alerts resolved."


### PR DESCRIPTION
Point one Jarvis cluster at multiple Alertmanager HA members via a comma-separated `ALERTMANAGER_URL`. Jarvis polls every member, deduplicates alerts by fingerprint (freshest `updatedAt` wins), and stays healthy as long as at least one member responds.

## Changes
- **config**: parse members from comma-separated `ALERTMANAGER_URL`; `HOST_ALIAS` accepts one shared value or one alias per member (index-matched); duplicate member URLs and mismatched alias counts are startup errors
- **cluster**: new poll/merge/enrich pipeline dedups by fingerprint and tracks per-member health; silence writes target the first healthy member with retry (gossip replicates the rest)
- **api**: expose per-member health in `ClusterInfo` and `seenOn` on alerts
- **frontend**: `MemberInfo` type, `seenOn` on `EnrichedAlert`, header/detail UI
- **metrics**: per-member labels
- **docs**: README HA section, `.env.example` examples, architecture notes