### PR TITLE
fix(silences): edit real regex matchers as raw text instead of corrupting them

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -478,9 +478,17 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
 │   │                            silences in silencedBy, not just the first), getExpiredSilence,
 │   │                            filterSilences, pickIdentifierLabel, formatSilenceDuration,
 │   │                            formatTime, severityOrder, formatAckDuration, buildAckSilenceBody,
-│   │                            computeGroupLabelValues, buildGroupAckSilenceBody, escapeRegexValue,
+│   │                            computeGroupLabelValues (only labels present on EVERY alert in the
+│   │                            group — a partial label is dropped, never partially OR-matched),
+│   │                            buildGroupAckSilenceBody (throws on multi-cluster input),
+│   │                            escapeRegexValue, unescapeRegex, isRoundTrippableTagList (detects
+│   │                            whether an AM regex matcher is a Jarvis-style escaped-literal-OR-list
+│   │                            SilenceForm can safely edit as tags, vs. a real regex needing raw-text
+│   │                            editing — see SilenceForm's `raw` matcher mode),
 │   │                            FAST_SILENCE_DURATIONS, HIDDEN_LABEL_KEYS, labelColorStyle
 │   │                            ← single source, never duplicate in components
+│   │                            100% test coverage enforced (frontend/vitest.config.ts) — a narrow
+│   │                            exception to the functional-E2E-only strategy, see .agents/testing.md
 │   ├── alertSelection.ts      → makeAlertSelectionKey / parseAlertSelectionKey — selection key
 │   │                            format `<cluster>::<fingerprint>` (URL `alert=` param, cluster-safe)
 │   ├── linkUtils.tsx          → isUrl, extractLinkButtons (URL-valued labels/annotations + runbook
@@ -526,7 +534,11 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
     │   ├── SilenceExpiry.tsx  → "expired X ago" / "expires in X" / "starts in X"
     │   ├── SilenceExpireModal.tsx → expire/extend confirmation (silence-ID link → AM)
     │   ├── SilenceForm.tsx    → 3 steps: form (matchers, clusters, duration, live match count,
-    │   │                        overlap/zero-match warnings) → preview → per-cluster results
+    │   │                        overlap/zero-match/unevaluable-regex warnings) → preview → per-cluster results
+    │   │                        Regex matchers whose AM value isn't a literal-tag-OR-list
+    │   │                        (`isRoundTrippableTagList`) load in raw-text mode (`SilenceMatcher.raw`)
+    │   │                        instead of the tag editor, and submit verbatim — editing a real regex
+    │   │                        as tags would corrupt it on save
     │   ├── MatcherEditor.tsx  → matcher rows: operators + tag multi-value + suggestions
     │   └── SilenceTemplateTab.tsx → template CRUD + apply-to-form
     ├── settings/

--- a/frontend/src/components/silences/SilenceForm.tsx
+++ b/frontend/src/components/silences/SilenceForm.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { format, addSeconds, parse, isValid } from 'date-fns'
 import { enUS } from 'date-fns/locale'
 import { DayPicker } from 'react-day-picker'
-import { Plus, X, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ArrowLeft, Check, Loader2, CircleAlert, RotateCcw } from 'lucide-react'
+import { Plus, X, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ArrowLeft, Check, Loader2, CircleAlert, RotateCcw, Code } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -13,7 +13,7 @@ import { DateTimePicker } from '@/components/ui/date-time-picker'
 import { useAlerts } from '@/hooks/useAlerts'
 import { useSilences } from '@/hooks/useSilences'
 import { useSilenceTemplates } from '@/hooks/useSilenceTemplates'
-import { silenceWouldMatchAlert, hasUnevaluableRegexMatcher, pickIdentifierLabel, tzAbbr, computeGroupLabelValues, escapeRegexValue } from '@/lib/alertUtils'
+import { silenceWouldMatchAlert, hasUnevaluableRegexMatcher, pickIdentifierLabel, tzAbbr, computeGroupLabelValues, escapeRegexValue, unescapeRegex, isRoundTrippableTagList } from '@/lib/alertUtils'
 import { upsertSilence, triggerPoll } from '@/api/client'
 import { useSettingsStore } from '@/store/useSettingsStore'
 import { useAuthStore } from '@/store/authStore'
@@ -44,18 +44,32 @@ interface SilenceMatcher {
   name: string
   operator: LabelMatcherOperator
   value: string
+  /**
+   * True for a regex matcher whose AM-side pattern isn't a Jarvis-style
+   * escaped-literal-OR-list (see `isRoundTrippableTagList`) — e.g. a real
+   * regex like `web-(1|2)\.example\.com` created via amtool or another
+   * tool. Edited as a single raw text field instead of `TagValueInput`, and
+   * submitted verbatim (not run through `toRegexValue`). Meaningless for
+   * `=`/`!=` operators.
+   */
+  raw?: boolean
 }
 
 let _id = 1
 const nextId = () => _id++
 
-function unescapeRegex(s: string): string {
-  // A backslash escape always means "literal next character", so strip the
-  // backslash before ANY character — not just the regex metacharacter set.
-  // This also cleans up escapes like \/ or \- that some Alertmanager setups or
-  // external tools add, which would otherwise survive recreate, get re-escaped
-  // to \\/ on submit, and break the matcher (0 affected alerts).
-  return s.replace(/\\(.)/g, '$1')
+/** Converts an AM-shaped silence matcher into the form's local editable shape. */
+function matcherFromAM(m: { name: string; value: string; isEqual: boolean; isRegex: boolean }): SilenceMatcher {
+  const operator = (m.isRegex ? (m.isEqual ? '=~' : '!~') : m.isEqual ? '=' : '!=') as LabelMatcherOperator
+  if (m.isRegex && !isRoundTrippableTagList(m.value)) {
+    return { id: nextId(), name: m.name, operator, value: m.value, raw: true }
+  }
+  return {
+    id: nextId(),
+    name: m.name,
+    operator,
+    value: m.isRegex ? m.value.split('|').map(unescapeRegex).join('|') : m.value,
+  }
 }
 
 // ── TagValueInput ─────────────────────────────────────────────────────────────
@@ -515,14 +529,7 @@ export function SilenceForm({
 
   const [matchers, setMatchers] = useState<SilenceMatcher[]>(() => {
     if (prefillSource?.matchers && !rebuildFromAlerts) {
-      return prefillSource.matchers.map((m) => ({
-        id: nextId(),
-        name: m.name,
-        operator: (
-          m.isRegex ? (m.isEqual ? '=~' : '!~') : m.isEqual ? '=' : '!='
-        ) as LabelMatcherOperator,
-        value: m.isRegex ? m.value.split('|').map(unescapeRegex).join('|') : m.value,
-      }))
+      return prefillSource.matchers.map(matcherFromAM)
     }
     if (prefillAlerts?.length) return buildPrefillMatchers(prefillAlerts)
     return [{ id: nextId(), name: '', operator: '=', value: '' }]
@@ -619,12 +626,20 @@ export function SilenceForm({
       m.map((x) => {
         if (x.id !== id) return x
         const updated = { ...x, [field]: value }
-        if (field === 'operator' && (value === '=' || value === '!=') && x.value.includes('|')) {
-          updated.value = x.value.split('|')[0]
+        if (field === 'operator' && (value === '=' || value === '!=')) {
+          // Leaving regex mode: `raw` only has meaning for =~/!~, and a raw pattern isn't a
+          // valid literal tag list — fall back to its first `|`-segment like the non-raw case.
+          if (x.value.includes('|') || x.raw) updated.value = x.value.split('|')[0]
+          updated.raw = false
         }
         return updated
       }),
     )
+  }
+
+  /** Toggles a regex matcher between the tag-list editor and a raw pattern text field. */
+  function toggleMatcherRaw(id: number) {
+    setMatchers((m) => m.map((x) => (x.id === id ? { ...x, raw: !x.raw } : x)))
   }
 
   // ── Clusters ────────────────────────────────────────────────────────────────
@@ -695,15 +710,7 @@ export function SilenceForm({
     setSelectedTemplate(templateId)
 
     // Replace matchers with template matchers
-    const newMatchers = template.matchers.map((m) => ({
-      id: nextId(),
-      name: m.name,
-      operator: (
-        m.isRegex ? (m.isEqual ? '=~' : '!~') : m.isEqual ? '=' : '!='
-      ) as LabelMatcherOperator,
-      value: m.value,
-    }))
-    setMatchers(newMatchers)
+    setMatchers(template.matchers.map(matcherFromAM))
 
     // Pre-fill comment with template reason if reason is not empty
     if (template.reason) {
@@ -724,7 +731,10 @@ export function SilenceForm({
         id: String(m.id),
         name: m.name,
         operator: m.operator,
-        value: m.operator === '=~' || m.operator === '!~' ? toRegexValue(m.value) : m.value,
+        // Raw regex matchers (S-09) are the actual AM pattern already — running them through
+        // toRegexValue (which escapes each pipe-separated segment as a literal) would corrupt
+        // a real regex like `web-(1|2)\.example\.com` into a literal-OR of its two halves.
+        value: (m.operator === '=~' || m.operator === '!~') && !m.raw ? toRegexValue(m.value) : m.value,
       }))
   }
 
@@ -771,7 +781,7 @@ export function SilenceForm({
         isEqual: m.operator === '=' || m.operator === '=~',
         isRegex: m.operator === '=~' || m.operator === '!~',
         name: m.name,
-        value: m.operator === '=~' || m.operator === '!~' ? toRegexValue(m.value) : m.value,
+        value: (m.operator === '=~' || m.operator === '!~') && !m.raw ? toRegexValue(m.value) : m.value,
       }))
 
     const initial = new Map<string, ClusterResult>(
@@ -1030,15 +1040,36 @@ export function SilenceForm({
                   <option value="=~">=~</option>
                   <option value="!~">!~</option>
                 </Select>
-                <div className="min-w-0">
-                  <TagValueInput
-                    value={m.value}
-                    onChange={(v) => updateMatcher(m.id, 'value', v)}
-                    suggestions={labelSuggestions.get(m.name) ?? []}
-                    placeholder="value"
-                    className="min-w-0"
-                    maxTags={m.operator === '=' || m.operator === '!=' ? 1 : undefined}
-                  />
+                <div className="flex min-w-0 items-center gap-1">
+                  {m.raw ? (
+                    <Input
+                      value={m.value}
+                      onChange={(e) => updateMatcher(m.id, 'value', e.target.value)}
+                      placeholder="raw regex pattern"
+                      className="min-w-0 font-mono text-xs"
+                    />
+                  ) : (
+                    <TagValueInput
+                      value={m.value}
+                      onChange={(v) => updateMatcher(m.id, 'value', v)}
+                      suggestions={labelSuggestions.get(m.name) ?? []}
+                      placeholder="value"
+                      className="min-w-0"
+                      maxTags={m.operator === '=' || m.operator === '!=' ? 1 : undefined}
+                    />
+                  )}
+                  {(m.operator === '=~' || m.operator === '!~') && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={cn('h-8 w-8 shrink-0', m.raw && 'text-primary')}
+                      onClick={() => toggleMatcherRaw(m.id)}
+                      title={m.raw ? 'Switch to tag list (comma/pipe-separated literal values)' : 'Switch to raw regex pattern'}
+                    >
+                      <Code className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
                 </div>
                 <Button
                   type="button"

--- a/frontend/src/lib/alertUtils.test.ts
+++ b/frontend/src/lib/alertUtils.test.ts
@@ -23,6 +23,8 @@ import {
   filterSilences,
   getExpiredSilence,
   labelColorStyle,
+  unescapeRegex,
+  isRoundTrippableTagList,
 } from './alertUtils'
 import type { EnrichedAlert, LabelMatcher, Silence } from '@/types'
 
@@ -94,6 +96,62 @@ describe('escapeRegexValue', () => {
       fc.property(fc.string(), (s) => {
         expect(() => new RegExp(escapeRegexValue(s))).not.toThrow()
       }),
+    )
+  })
+})
+
+describe('unescapeRegex', () => {
+  it('strips a backslash before any character, not just regex metacharacters', () => {
+    expect(unescapeRegex('web\\-prod')).toBe('web-prod')
+    expect(unescapeRegex('a\\/b')).toBe('a/b')
+    expect(unescapeRegex('a\\zb')).toBe('azb')
+  })
+
+  it('leaves a string with no backslashes untouched', () => {
+    expect(unescapeRegex('web1-prod')).toBe('web1-prod')
+  })
+
+  it('is the left inverse of escapeRegexValue for any string', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        expect(unescapeRegex(escapeRegexValue(s))).toBe(s)
+      }),
+    )
+  })
+})
+
+describe('isRoundTrippableTagList (S-09)', () => {
+  it('is true for a value SilenceForm itself would produce from literal tags', () => {
+    expect(isRoundTrippableTagList('web1')).toBe(true)
+    expect(isRoundTrippableTagList('web1|web2')).toBe(true)
+    expect(isRoundTrippableTagList(escapeRegexValue('10.0.0.1'))).toBe(true)
+  })
+
+  it('is false for a real regex with alternation groups (S-09 core case)', () => {
+    // web-(1|2)\.example\.com split on "|" gives "web-(1" / "2)\.example\.com" — re-escaping
+    // and rejoining produces a different string, so this must be flagged as non-round-trippable
+    // rather than silently edited (and corrupted) as a two-item literal tag list.
+    expect(isRoundTrippableTagList('web-(1|2)\\.example\\.com')).toBe(false)
+  })
+
+  it('is false for a power-user-typed regex like a character class or quantifier', () => {
+    expect(isRoundTrippableTagList('web-\\d+')).toBe(false)
+    expect(isRoundTrippableTagList('[a-z]+')).toBe(false)
+  })
+
+  it('is true for the empty string', () => {
+    expect(isRoundTrippableTagList('')).toBe(true)
+  })
+
+  it('property: always true for escapeRegexValue applied to arbitrary literal tags', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ minLength: 1 }).filter((s) => !s.includes('|')), { minLength: 1, maxLength: 5 }),
+        (tags) => {
+          const amValue = tags.map(escapeRegexValue).join('|')
+          expect(isRoundTrippableTagList(amValue)).toBe(true)
+        },
+      ),
     )
   })
 })

--- a/frontend/src/lib/alertUtils.ts
+++ b/frontend/src/lib/alertUtils.ts
@@ -499,6 +499,42 @@ export function escapeRegexValue(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+/**
+ * Inverse of `escapeRegexValue` for a single already-unescaped-boundary
+ * segment: a backslash always means "literal next character" in the
+ * pipe-separated-literal-tags model `SilenceForm` edits regex matchers with,
+ * so stripping it before ANY character (not just the regex metacharacter
+ * set) also cleans up escapes like `\/` or `\-` that some Alertmanager
+ * setups or external tools add — which would otherwise survive a
+ * recreate/edit round-trip, get re-escaped to `\\/` on submit, and break the
+ * matcher (0 affected alerts).
+ */
+export function unescapeRegex(s: string): string {
+  return s.replace(/\\(.)/g, '$1')
+}
+
+/**
+ * True if `amValue` (an Alertmanager regex matcher's raw pattern) is exactly
+ * what `SilenceForm` itself would produce from a pipe-separated list of
+ * literal values — i.e. splitting on `|`, unescaping each part, then
+ * re-escaping and re-joining reproduces the original string byte for byte.
+ * A real regex (alternation groups, character classes, quantifiers beyond a
+ * lone escaped metacharacter, …) will not round-trip: editing it as a
+ * literal-tag list and re-submitting silently corrupts it (S-09 — e.g.
+ * `web-(1|2)\.example\.com` becomes a literal-OR of `web-(1` and
+ * `2)\.example\.com`, matching neither of the original hosts). Callers
+ * should edit a non-round-tripping pattern as raw text instead.
+ */
+export function isRoundTrippableTagList(amValue: string): boolean {
+  const roundTripped = amValue
+    .split('|')
+    .filter(Boolean)
+    .map(unescapeRegex)
+    .map(escapeRegexValue)
+    .join('|')
+  return roundTripped === amValue
+}
+
 const GROUP_MATCHER_SKIP = new Set(['receiver', '@receiver', '@cluster'])
 
 /**


### PR DESCRIPTION
## Summary
Stacked on #64 — part 4/6 of the silence-subsystem review.

- `SilenceForm` edits regex matchers as a pipe-separated list of literal tag values, splitting the AM value on `|`, unescaping each part, and re-escaping + rejoining on submit. That model only round-trips for values Jarvis itself produced.
- A matcher with a real regex (e.g. created via amtool, or an alternation group like `web-(1|2)\.example\.com`) gets split into two literal alternatives and written back as garbage — editing an externally-created silence without changing anything silently broke it.
- Adds `isRoundTrippableTagList` (checks whether an AM regex value is exactly what the tag-list model would itself produce). Non-round-tripping matchers load in a raw text field instead, submit verbatim. A manual per-row toggle lets a user opt into raw mode too.
- Moved `unescapeRegex` into `lib/alertUtils.ts` alongside the new function so both get fast-check property coverage (including the round-trip proof that motivated this fix).

## Test plan
- [x] `go test -race ./...` (unaffected, re-verified)
- [x] `pnpm test:unit:coverage` (100% coverage gate stays green)
- [x] `pnpm build`, `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)