### PR TITLE
fix(silences): match Alertmanager's anchored-regex semantics exactly

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -462,10 +462,17 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
 │   ├── useFormatTime.ts       → relative/absolute timestamp formatter (from settings)
 │   └── useVersion.ts          → app version (staleTime Infinity)
 ├── lib/
-│   ├── alertUtils.ts          → getFilterableLabels, matchesLabelMatchers, safeRegex,
-│   │                            getEffectiveAlertState, getSilenceState, silenceMatchesAlert,
-│   │                            getExpiredSilence, filterSilences, pickIdentifierLabel,
-│   │                            formatSilenceDuration, formatTime, severityOrder,│   │                            formatAckDuration, buildAckSilenceBody, FAST_SILENCE_DURATIONS,│   │                            HIDDEN_LABEL_KEYS, labelColorStyle
+│   ├── alertUtils.ts          → getFilterableLabels, matchesLabelMatchers (filter-bar only,
+│   │                            substring regex + pseudo-labels — never for silence matching),
+│   │                            safeRegex, anchoredRegex, silenceWouldMatchAlert (Alertmanager-exact:
+│   │                            anchored regex, real labels only — SilenceForm preview/overlap),
+│   │                            hasUnevaluableRegexMatcher, silenceMatchesAlert,
+│   │                            getEffectiveAlertState, getSilenceState (both consider ALL active
+│   │                            silences in silencedBy, not just the first), getExpiredSilence,
+│   │                            filterSilences, pickIdentifierLabel, formatSilenceDuration,
+│   │                            formatTime, severityOrder, formatAckDuration, buildAckSilenceBody,
+│   │                            computeGroupLabelValues, buildGroupAckSilenceBody, escapeRegexValue,
+│   │                            FAST_SILENCE_DURATIONS, HIDDEN_LABEL_KEYS, labelColorStyle
 │   │                            ← single source, never duplicate in components
 │   ├── alertSelection.ts      → makeAlertSelectionKey / parseAlertSelectionKey — selection key
 │   │                            format `<cluster>::<fingerprint>` (URL `alert=` param, cluster-safe)

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -35,6 +35,8 @@ cd frontend
 pnpm test                          # Playwright functional E2E (alias for test:e2e)
 pnpm test:e2e                      # Playwright functional E2E (browser must be installed)
 pnpm exec playwright install       # Install Playwright browsers (once)
+pnpm test:unit                     # Vitest — lib/alertUtils.ts matching/formatting logic only (see below)
+pnpm test:unit:coverage            # Same, with v8 coverage report
 pnpm duplication                   # jscpd code duplication check
 pnpm lint                          # eslint src e2e (flat config: eslint.config.js — typescript-eslint,
                                    # react-hooks, react-refresh; react-hooks/purity + set-state-in-effect
@@ -56,6 +58,7 @@ make test-all                      # backend + frontend + helm lint + helm unitt
 make test-backend                  # go test -race ./...
 make fuzz-backend                  # Go native fuzz targets (FUZZTIME=30s per target)
 make test-frontend                 # functional E2E (none + internal + oidc)
+make test-frontend-unit            # Vitest (lib/alertUtils.ts only, needs jarvis_frontend_1 running)
 make helm-lint                     # helm lint only
 make helm-test                     # helm unittest only
 
@@ -189,13 +192,37 @@ suppressed → resolved: directly resolved, no expired event
 
 ## Frontend Test Strategy
 
-There are **no frontend unit tests** (no Vitest). The unit-test stack was
-removed in favor of functional E2E (commit `test(frontend): remove unit-test
-stack in favor of functional e2e`). All frontend behaviour — including
-`alertUtils` logic (`getEffectiveAlertState`, `matchesLabelMatchers`,
-`safeRegex`, `getFilterableLabels`, regex matchers, `@cluster`/`@receiver`
-pseudo-labels) and Zustand store actions/filter state — is verified through
-Playwright functional E2E against a real running app.
+Frontend behaviour is verified through Playwright functional E2E against a
+real running app — Zustand store actions, filter state, and every component
+are covered this way, with **no general component/unit-test stack** (the
+Vitest setup that covered those was removed in favor of functional E2E,
+commit `test(frontend): remove unit-test stack in favor of functional e2e`).
+
+**Narrow, deliberate exception: `src/lib/alertUtils.ts`.** This file holds
+the silence-matching and effective-state logic (`matchesLabelMatchers`,
+`silenceMatchesAlert`, `getEffectiveAlertState`, `getSilenceState`,
+`getExpiredSilence`, `computeGroupLabelValues`, plus formatting/escaping
+helpers) — pure functions where a wrong Alertmanager-matching semantic can
+silence (or fail to silence) the wrong alerts. Playwright can assert what the
+*UI* shows, but property-based/fuzz testing across thousands of generated
+label/matcher combinations against a *reference implementation* of
+Alertmanager's matching semantics isn't practical to express as browser
+flows. This file therefore gets a minimal Vitest + fast-check setup, scoped
+to `src/lib/**` only:
+
+- `frontend/vitest.config.ts` — `include: ['src/lib/**/*.test.ts']`, coverage
+  restricted to `src/lib/alertUtils.ts`. No jsdom/component-testing
+  dependencies, no other directory is in scope.
+- `frontend/src/lib/alertUtils.test.ts` — example-based tests for
+  formatting/escaping helpers, plus `fast-check` property tests (e.g. "regex
+  built from `escapeRegexValue` matches only the original literal").
+- Matching-function tests (the ones directly tied to silence semantics) live
+  in the same file and are added alongside the anchored-regex rewrite (see
+  `tmp/fable/review_silence.md` S-01/S-03/S-05/S-06/S-14) — a 100%
+  branch-coverage gate on `alertUtils.ts` lands once that rewrite is done.
+
+This does **not** reopen the door to a general component-test stack —
+anything outside `src/lib/` stays E2E-only.
 
 Specs live under `frontend/e2e/`:
 
@@ -216,7 +243,7 @@ troubleshooting are documented in **`docs/testing-e2e.md`**.
 | Staged paths | Checks |
 |---|---|
 | `backend/**` | `go test ./... -count=1 -timeout 60s` + golangci-lint (incl. gosec; govulncheck runs in CI only) |
-| `frontend/**` | `pnpm audit --audit-level=high` + `pnpm lint` (eslint) + `pnpm duplication` (jscpd) — executed **inside the running dev container** (`jarvis_frontend_1`); hook fails if the container is not running |
+| `frontend/**` | `pnpm audit --audit-level=high` + `pnpm lint` (eslint) + `pnpm test:unit` (Vitest, `lib/alertUtils.ts`) + `pnpm duplication` (jscpd) — executed **inside the running dev container** (`jarvis_frontend_1`); hook fails if the container is not running |
 | `charts/**` | `helm lint` + `helm unittest` |
 | always | **gitleaks** secret scan of the staged diff (via podman, config `.gitleaks.toml`) |
 
@@ -251,6 +278,7 @@ backend:
 frontend:
   - pnpm audit --audit-level=high
   - pnpm lint         # eslint (flat config)
+  - pnpm test:unit    # Vitest (lib/alertUtils.ts only)
   - pnpm build
   - pnpm duplication  # jscpd code duplication check
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,6 +23,8 @@ if git diff --cached --name-only | grep -q "^frontend/"; then
     podman exec -e CI=true "$FRONTEND_CONTAINER" sh -c "cd /app && pnpm audit --audit-level=high"
     echo "  [Frontend] Running eslint..."
     podman exec -e CI=true "$FRONTEND_CONTAINER" sh -c "cd /app && pnpm lint"
+    echo "  [Frontend] Running unit tests (lib/alertUtils.ts)..."
+    podman exec -e CI=true "$FRONTEND_CONTAINER" sh -c "cd /app && pnpm test:unit"
     echo "  [Frontend] Running jscpd (code duplication)..."
     podman exec -e CI=true "$FRONTEND_CONTAINER" sh -c "cd /app && pnpm duplication"
   else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Unit tests (lib/alertUtils.ts)
+        run: pnpm test:unit
+
       - name: Build
         run: pnpm build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,12 @@ Tool-specific entry points map to the same files (no duplicated content):
    poll misses.
 2. **Increment `occurrence_count` only on second firing**: Not on the very
    first occurrence — only when `hadPreviousEvent = true`.
-3. **`getEffectiveAlertState`**: Alert `suppressed` + silence ≤15 min until
-   expiry → returns `active`. This logic **only** in `lib/alertUtils.ts` —
-   never duplicate.
+3. **`getEffectiveAlertState`**: Alert `suppressed` + **all** active silences
+   covering it (`status.silencedBy` can hold more than one) have ≤15 min
+   until expiry → returns `active`. Must consider every covering silence, not
+   just the first one found in `silencedBy` — a longer-running second silence
+   still keeps the alert suppressed. This logic **only** in
+   `lib/alertUtils.ts` — never duplicate.
 4. **Filter functions exclusively in `lib/alertUtils.ts`**:
    `getFilterableLabels`, `matchesLabelMatchers`, `safeRegex` — no copy-paste
    into components.
@@ -89,6 +92,19 @@ Tool-specific entry points map to the same files (no duplicated content):
     time. Never write `$1` literals directly in query strings.
 11. **CORS/WS Origin**: No wildcard `*`. `JARVIS_ALLOWED_ORIGINS` is used as
     allow-list for both HTTP CORS and the WebSocket upgrade.
+12. **Silence-matching semantics must mirror Alertmanager, not UI-filter
+    semantics**: whether a silence *would actually match/cover* an alert
+    (affected-alerts preview, overlap detection, expired-silence lookup) is
+    decided exclusively by `silenceWouldMatchAlert` / `silenceMatchesAlert` in
+    `lib/alertUtils.ts` — anchored regex (`anchoredRegex`, `^(?:pattern)$`,
+    matching Alertmanager's RE2 compilation), evaluated only against the
+    alert's real labels (no `@cluster`/`@receiver`/`receiver` pseudo-labels).
+    `matchesLabelMatchers` (substring regex, pseudo-labels, comma-list
+    receivers) is a **separate, deliberately lenient** function for the
+    filter bar UI only — never use it to decide what a silence covers. Mixing
+    the two was the root cause of a preview showing "0 affected alerts" while
+    Alertmanager silenced alerts anyway (unanchored `!~` substring match
+    disagreeing with AM's anchored one).
 
 ## Workflow Rules — always follow
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ FRONTEND_CONTAINER = jarvis_frontend_1
         up-alertmanager down-alertmanager \
         up-alertmanager-ha down-alertmanager-ha \
         up-postgres down-postgres \
-        test-all test-backend test-frontend fuzz-backend \
+        test-all test-backend test-frontend test-frontend-unit fuzz-backend \
         helm-lint helm-test \
         lint gosec govulncheck audit security-all \
         scan scan-history scan-staged scan-all \
@@ -66,7 +66,7 @@ down-postgres: ## Stop test PostgreSQL
 
 # ── Tests ──────────────────────────────────────────────────────────────────────
 
-test-all: test-backend test-frontend helm-lint helm-test ## Run all tests (backend + frontend + helm)
+test-all: test-backend test-frontend-unit test-frontend helm-lint helm-test ## Run all tests (backend + frontend + helm)
 
 test-backend: ## Backend: go test -race ./...
 	cd backend && go test -v -race ./...
@@ -82,6 +82,9 @@ test-frontend: ## Frontend: functional E2E tests across all auth modes
 	$(E2E_RUN) test none
 	$(E2E_RUN) test internal
 	$(E2E_RUN) test oidc
+
+test-frontend-unit: ## Frontend: Vitest unit tests (lib/alertUtils.ts matching/formatting logic only)
+	podman exec $(FRONTEND_CONTAINER) sh -c "cd /app && pnpm test:unit"
 
 helm-lint: ## Helm: lint chart
 	helm lint charts/jarvis/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "test": "playwright test --config playwright.e2e.config.ts",
     "test:e2e": "playwright test --config playwright.e2e.config.ts",
+    "test:unit": "vitest run",
+    "test:unit:coverage": "vitest run --coverage",
     "lint": "eslint src e2e",
     "duplication": "jscpd"
   },
@@ -32,14 +34,17 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.6.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
+    "fast-check": "^4.8.0",
     "globals": "^17.7.0",
     "jscpd": "^5.0.11",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",
-    "vite": "^8.1.3"
+    "vite": "^8.1.3",
+    "vitest": "^4.1.9"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
@@ -69,6 +72,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.3
         version: 0.5.3(eslint@10.6.0(jiti@2.7.0))
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -87,6 +93,9 @@ importers:
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
 
 packages:
 
@@ -156,6 +165,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@date-fns/tz@1.5.0':
     resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
@@ -347,6 +360,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
 
@@ -476,6 +492,12 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -568,6 +590,44 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -580,6 +640,13 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -601,6 +668,10 @@ packages:
 
   caniuse-lite@1.0.30001800:
     resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -681,6 +752,9 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -738,9 +812,20 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -800,11 +885,18 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -833,9 +925,24 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -960,6 +1067,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -978,6 +1092,10 @@ packages:
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -998,6 +1116,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1027,6 +1148,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.1:
+    resolution: {integrity: sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==}
 
   react-day-picker@10.0.1:
     resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
@@ -1082,9 +1206,22 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -1096,9 +1233,20 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1185,9 +1333,55 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -1329,6 +1523,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@date-fns/tz@1.5.0': {}
 
@@ -1477,6 +1673,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1583,6 +1781,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -1698,6 +1903,61 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)
 
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -1710,6 +1970,14 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@4.0.4: {}
 
@@ -1728,6 +1996,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   caniuse-lite@1.0.30001800: {}
+
+  chai@6.2.2: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -1781,6 +2051,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  es-module-lexer@2.3.0: {}
 
   escalade@3.2.0: {}
 
@@ -1865,7 +2137,17 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
+
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.1
 
   fast-deep-equal@3.1.3: {}
 
@@ -1909,11 +2191,15 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  has-flag@4.0.0: {}
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-escaper@2.0.2: {}
 
   ignore@5.3.2: {}
 
@@ -1931,7 +2217,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2028,6 +2329,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
@@ -2039,6 +2350,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-releases@2.0.50: {}
+
+  obug@2.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2061,6 +2374,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
@@ -2082,6 +2397,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.1: {}
 
   react-day-picker@10.0.1(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -2137,7 +2454,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tailwind-merge@3.6.0: {}
 
@@ -2145,10 +2472,16 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -2202,9 +2535,42 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
+  vitest@4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.0
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+    transitivePeerDependencies:
+      - msw
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/frontend/src/components/alerts/AlertDetailPanel.tsx
+++ b/frontend/src/components/alerts/AlertDetailPanel.tsx
@@ -27,7 +27,7 @@ import { Input } from '@/components/ui/input'
 import { makeAlertSelectionKeyForAlert } from '@/lib/alertSelection'
 import type { EnrichedAlert, LabelMatcher, Silence, SilenceMatcher } from '@/types'
 import { renderTextWithLinks, extractLinkButtons } from '@/lib/linkUtils'
-import { pickIdentifierLabel, tzAbbr } from '@/lib/alertUtils'
+import { pickIdentifierLabel, tzAbbr, silenceMatchesAlert } from '@/lib/alertUtils'
 
 const ALERT_EVENT_LABEL: Record<string, string> = {
   firing: 'Alert fired',
@@ -101,22 +101,6 @@ function formatDuration(ms: number): string {
   }
   if (minutes >= 1) return `${minutes}m`
   return 'a few seconds'
-}
-
-function silenceMatchesAlert(silence: Silence, alert: EnrichedAlert): boolean {
-  const labels: Record<string, string> = { ...alert.labels, '@cluster': alert.clusterName }
-  return silence.matchers.every((m) => {
-    const value = labels[m.name] ?? ''
-    if (m.isRegex) {
-      try {
-        const re = new RegExp(m.value)
-        return m.isEqual ? re.test(value) : !re.test(value)
-      } catch {
-        return false
-      }
-    }
-    return m.isEqual ? value === m.value : value !== m.value
-  })
 }
 
 function MatcherChip({ matcher }: { matcher: SilenceMatcher }) {

--- a/frontend/src/components/silences/SilenceForm.tsx
+++ b/frontend/src/components/silences/SilenceForm.tsx
@@ -13,7 +13,7 @@ import { DateTimePicker } from '@/components/ui/date-time-picker'
 import { useAlerts } from '@/hooks/useAlerts'
 import { useSilences } from '@/hooks/useSilences'
 import { useSilenceTemplates } from '@/hooks/useSilenceTemplates'
-import { matchesLabelMatchers, pickIdentifierLabel, tzAbbr, computeGroupLabelValues, escapeRegexValue } from '@/lib/alertUtils'
+import { silenceWouldMatchAlert, hasUnevaluableRegexMatcher, pickIdentifierLabel, tzAbbr, computeGroupLabelValues, escapeRegexValue } from '@/lib/alertUtils'
 import { upsertSilence, triggerPoll } from '@/api/client'
 import { useSettingsStore } from '@/store/useSettingsStore'
 import { useAuthStore } from '@/store/authStore'
@@ -584,14 +584,10 @@ export function SilenceForm({
   const [results, setResults] = useState<Map<string, ClusterResult>>(new Map())
   const [affectedOpen, setAffectedOpen] = useState(false)
 
-  const formLabelMatchers = useMemo<LabelMatcher[]>(
-    () => matchers.filter((m) => m.name).map((m) => ({ id: String(m.id), name: m.name, operator: m.operator, value: m.value })),
-    [matchers],
-  )
-
   const silenceGroups = useMemo(() => {
     if (isEdit || !prefillAlerts?.length) return []
-    const matchedAlerts = prefillAlerts.filter((a) => matchesLabelMatchers(a, formLabelMatchers))
+    const lm = buildLabelMatchers()
+    const matchedAlerts = prefillAlerts.filter((a) => silenceWouldMatchAlert(lm, a))
     const map = new Map<string, { silence: Silence; alerts: EnrichedAlert[] }>()
     for (const alert of matchedAlerts) {
       for (const silenceId of alert.status.silencedBy) {
@@ -605,7 +601,8 @@ export function SilenceForm({
       }
     }
     return [...map.values()]
-  }, [isEdit, prefillAlerts, allSilences, formLabelMatchers])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEdit, prefillAlerts, allSilences, matchers])
 
   // ── Matchers ────────────────────────────────────────────────────────────────
 
@@ -736,7 +733,7 @@ export function SilenceForm({
   const previewMatched = useCallback((): EnrichedAlert[] => {
     const lm = buildLabelMatchers()
     return allAlerts.filter(
-      (a) => selectedClusters.includes(a.clusterName) && matchesLabelMatchers(a, lm),
+      (a) => selectedClusters.includes(a.clusterName) && silenceWouldMatchAlert(lm, a),
     )
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allAlerts, matchers, selectedClusters])
@@ -745,6 +742,11 @@ export function SilenceForm({
   const liveMatchCount = matchedAlerts.length
 
   const hasActiveMatchers = matchers.some((m) => m.name && m.value)
+  const hasUnevaluableRegex = useMemo(
+    () => hasUnevaluableRegexMatcher(buildLabelMatchers()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [matchers],
+  )
   const parsedStartsAt = startsAt ? parse(startsAt, FMT, new Date()) : null
   const startsInFuture = Boolean(
     parsedStartsAt && isValid(parsedStartsAt) && parsedStartsAt.getTime() > Date.now(),
@@ -1048,6 +1050,21 @@ export function SilenceForm({
               <Plus className="mr-1 h-3 w-3" />
               Add matcher
             </Button>
+
+            {/* Unevaluable regex warning — pattern doesn't compile in the browser (e.g. RE2-only
+                syntax like `(?i)`), so the affected-alerts count below can't be trusted: matchers
+                using it are treated as matching everything rather than silently showing 0. */}
+            {hasUnevaluableRegex && (
+              <div className="flex gap-2.5 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-amber-700 dark:text-amber-400">
+                <CircleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                <div className="text-xs space-y-0.5">
+                  <p>
+                    One or more regex patterns can&apos;t be evaluated in the browser — the affected-alerts
+                    preview may be incomplete. Alertmanager decides the actual match when the silence is created.
+                  </p>
+                </div>
+              </div>
+            )}
 
             {/* Zero-match warning */}
             {hasActiveMatchers && liveMatchCount === 0 && (

--- a/frontend/src/lib/alertUtils.test.ts
+++ b/frontend/src/lib/alertUtils.test.ts
@@ -8,21 +8,45 @@ import {
   getFilterableLabels,
   pickIdentifierLabel,
   safeRegex,
+  anchoredRegex,
   severityOrder,
   buildAckSilenceBody,
   FAST_SILENCE_DURATIONS,
+  matchesLabelMatchers,
+  silenceWouldMatchAlert,
+  hasUnevaluableRegexMatcher,
+  silenceMatchesAlert,
+  getEffectiveAlertState,
+  getSilenceState,
 } from './alertUtils'
-import type { EnrichedAlert } from '@/types'
+import type { EnrichedAlert, LabelMatcher, Silence } from '@/types'
 
 /**
- * Scope note: this file covers only the functions in `alertUtils.ts` that
- * the planned silence-matching rewrite (anchored regex, S-01/S-03/S-05/S-06/
- * S-14 — see tmp/fable/review_silence.md) does not touch. Matching functions
- * (`matchesLabelMatchers`, `silenceMatchesAlert`, `getEffectiveAlertState`,
- * `getSilenceState`, `getExpiredSilence`, `filterSilences`,
- * `computeGroupLabelValues`, `buildGroupAckSilenceBody`) get their tests
- * alongside that rewrite instead of locking in pre-fix behavior here.
+ * Scope note: `computeGroupLabelValues`, `buildGroupAckSilenceBody`,
+ * `getExpiredSilence`, and `filterSilences` get their tests alongside the
+ * group-silence fix (S-06 — see tmp/fable/review_silence.md), which touches
+ * their behavior directly.
  */
+
+function makeSilence(overrides: Partial<Silence> = {}): Silence {
+  return {
+    id: 'silence-1',
+    matchers: [],
+    startsAt: '2026-01-01T00:00:00Z',
+    endsAt: '2026-01-01T01:00:00Z',
+    createdBy: 'alice',
+    comment: 'test',
+    status: { state: 'active' },
+    updatedAt: '2026-01-01T00:00:00Z',
+    clusterName: 'cluster-a',
+    alertmanagerUrl: 'https://am.example.com',
+    ...overrides,
+  }
+}
+
+function lm(name: string, operator: LabelMatcher['operator'], value: string): LabelMatcher {
+  return { id: name, name, operator, value }
+}
 
 function makeAlert(overrides: Partial<EnrichedAlert> = {}): EnrichedAlert {
   return {
@@ -264,5 +288,250 @@ describe('buildAckSilenceBody', () => {
     const alert = makeAlert({ labels: { alertname: 'X', empty: '' } })
     const body = buildAckSilenceBody(alert, 30, 'alice')
     expect(body.matchers.map((m) => m.name)).not.toContain('empty')
+  })
+})
+
+describe('anchoredRegex', () => {
+  it('anchors the pattern to the full string', () => {
+    const re = anchoredRegex('web1')
+    expect(re?.test('web1')).toBe(true)
+    expect(re?.test('web10')).toBe(false)
+    expect(re?.test('myweb1')).toBe(false)
+  })
+
+  it('supports alternation without over-matching', () => {
+    const re = anchoredRegex('a|b')
+    expect(re?.test('a')).toBe(true)
+    expect(re?.test('b')).toBe(true)
+    expect(re?.test('ab')).toBe(false)
+  })
+
+  it('matches the empty string against .*', () => {
+    expect(anchoredRegex('.*')?.test('')).toBe(true)
+  })
+
+  it('returns null for a pattern that fails to compile', () => {
+    expect(anchoredRegex('[')).toBeNull()
+    expect(anchoredRegex('(')).toBeNull()
+  })
+})
+
+describe('matchesLabelMatchers (filter-bar semantics — S-14)', () => {
+  it('receiver != matches only when NONE of the alert receivers is the excluded value', () => {
+    const alert = makeAlert({ receivers: [{ name: 'a' }, { name: 'b' }] })
+    // Alert has receiver "a" among its receivers — "receiver != a" must NOT match,
+    // even though "b" (a different receiver) is also present.
+    expect(matchesLabelMatchers(alert, [lm('receiver', '!=', 'a')])).toBe(false)
+    expect(matchesLabelMatchers(alert, [lm('receiver', '!=', 'c')])).toBe(true)
+  })
+
+  it('is consistent between != and !~ for receivers (both use every)', () => {
+    const alert = makeAlert({ receivers: [{ name: 'a' }, { name: 'b' }] })
+    expect(matchesLabelMatchers(alert, [lm('receiver', '!~', 'a')])).toBe(false)
+  })
+
+  it('stays substring/unanchored by design (filter UX, not silence semantics)', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', instance: 'web10' } })
+    expect(matchesLabelMatchers(alert, [lm('instance', '=~', 'web1')])).toBe(true)
+  })
+})
+
+describe('silenceWouldMatchAlert (Alertmanager-exact semantics — S-01/S-03)', () => {
+  it('anchors regex: "web1" does not match "web10"', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', instance: 'web10' } })
+    expect(silenceWouldMatchAlert([lm('instance', '=~', 'web1')], alert)).toBe(false)
+  })
+
+  it('anchors regex: "web1" matches "web1"', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', instance: 'web1' } })
+    expect(silenceWouldMatchAlert([lm('instance', '=~', 'web1')], alert)).toBe(true)
+  })
+
+  it('regression: instance!~"web" DOES match "web1" (the S-01 over-silencing case)', () => {
+    // This is the fatal case from the review: an unanchored implementation would
+    // report "no match" here (substring "web" found in "web1"), while Alertmanager's
+    // anchored ^(?:web)$ does not match "web1", so the negative matcher is true and
+    // Alertmanager silences it. The preview must agree with Alertmanager, not hide this.
+    const alert = makeAlert({ labels: { alertname: 'X', instance: 'web1' } })
+    expect(silenceWouldMatchAlert([lm('instance', '!~', 'web')], alert)).toBe(true)
+  })
+
+  it('missing label matches the empty string (AM matcher semantics)', () => {
+    const alert = makeAlert({ labels: { alertname: 'X' } })
+    expect(silenceWouldMatchAlert([lm('instance', '=', '')], alert)).toBe(true)
+    expect(silenceWouldMatchAlert([lm('instance', '!=', 'web1')], alert)).toBe(true)
+  })
+
+  it('ignores pseudo-labels: receiver/@receiver/@cluster never match real alert labels', () => {
+    const alert = makeAlert({ labels: { alertname: 'X' }, receivers: [{ name: 'team-x' }], clusterName: 'team-x' })
+    expect(silenceWouldMatchAlert([lm('receiver', '=', 'team-x')], alert)).toBe(false)
+    expect(silenceWouldMatchAlert([lm('@cluster', '=', 'team-x')], alert)).toBe(false)
+    // A matcher on a pseudo-label name with "!=" matches everything (label is always ""),
+    // which is exactly what Alertmanager would do too — not a bug, just a consequence of
+    // there being no real label with that name.
+    expect(silenceWouldMatchAlert([lm('receiver', '!=', 'team-x')], alert)).toBe(true)
+  })
+
+  it('respects real labels literally named "receiver" if present', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', receiver: 'real-value' } })
+    expect(silenceWouldMatchAlert([lm('receiver', '=', 'real-value')], alert)).toBe(true)
+  })
+
+  it('ANDs multiple matchers, including duplicate names', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', env: 'prod' } })
+    expect(silenceWouldMatchAlert([lm('env', '=', 'prod'), lm('env', '=', 'staging')], alert)).toBe(false)
+  })
+
+  it('conservatively treats an unparseable regex as a match (safe direction)', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', instance: 'anything' } })
+    expect(silenceWouldMatchAlert([lm('instance', '=~', '(')], alert)).toBe(true)
+    expect(silenceWouldMatchAlert([lm('instance', '!~', '(')], alert)).toBe(true)
+  })
+
+  it('property: for literal (non-regex) matchers, agrees with a naive reference implementation', () => {
+    const referenceMatch = (matchers: LabelMatcher[], labels: Record<string, string>): boolean =>
+      matchers.every((m) => {
+        const value = labels[m.name] ?? ''
+        return m.operator === '=' ? value === m.value : value !== m.value
+      })
+
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            name: fc.constantFrom('alertname', 'instance', 'env', 'pod', 'missing'),
+            operator: fc.constantFrom<'=' | '!='>('=', '!='),
+            value: fc.string(),
+          }),
+          { minLength: 1, maxLength: 4 },
+        ),
+        fc.dictionary(fc.constantFrom('alertname', 'instance', 'env', 'pod'), fc.string()),
+        (rawMatchers, labels) => {
+          const matchers: LabelMatcher[] = rawMatchers.map((m, i) => ({ id: String(i), ...m }))
+          const alert = makeAlert({ labels: { alertname: 'X', ...labels } })
+          expect(silenceWouldMatchAlert(matchers, alert)).toBe(referenceMatch(matchers, alert.labels))
+        },
+      ),
+    )
+  })
+})
+
+describe('hasUnevaluableRegexMatcher', () => {
+  it('is false when there are no regex matchers', () => {
+    expect(hasUnevaluableRegexMatcher([lm('instance', '=', 'web1')])).toBe(false)
+  })
+
+  it('is false for a compilable regex', () => {
+    expect(hasUnevaluableRegexMatcher([lm('instance', '=~', 'web.*')])).toBe(false)
+  })
+
+  it('is true for an uncompilable regex (e.g. RE2-only inline flag)', () => {
+    expect(hasUnevaluableRegexMatcher([lm('instance', '=~', '(?i)watchdog')])).toBe(true)
+  })
+
+  it('checks !~ matchers too', () => {
+    expect(hasUnevaluableRegexMatcher([lm('instance', '!~', '(')])).toBe(true)
+  })
+})
+
+describe('silenceMatchesAlert (Alertmanager-exact semantics on Silence.matchers)', () => {
+  it('anchors regex matching', () => {
+    const silence = makeSilence({ matchers: [{ name: 'instance', value: 'web1', isEqual: true, isRegex: true }] })
+    expect(silenceMatchesAlert(silence, makeAlert({ labels: { alertname: 'X', instance: 'web1' } }))).toBe(true)
+    expect(silenceMatchesAlert(silence, makeAlert({ labels: { alertname: 'X', instance: 'web10' } }))).toBe(false)
+  })
+
+  it('does not inject an @cluster pseudo-label', () => {
+    const silence = makeSilence({ matchers: [{ name: '@cluster', value: 'cluster-a', isEqual: true, isRegex: false }] })
+    const alert = makeAlert({ clusterName: 'cluster-a', labels: { alertname: 'X' } })
+    expect(silenceMatchesAlert(silence, alert)).toBe(false)
+  })
+
+  it('exact non-regex matching', () => {
+    const silence = makeSilence({ matchers: [{ name: 'env', value: 'prod', isEqual: true, isRegex: false }] })
+    expect(silenceMatchesAlert(silence, makeAlert({ labels: { alertname: 'X', env: 'prod' } }))).toBe(true)
+    expect(silenceMatchesAlert(silence, makeAlert({ labels: { alertname: 'X', env: 'staging' } }))).toBe(false)
+  })
+
+  it('negative regex matcher (isEqual: false) mirrors !~', () => {
+    const silence = makeSilence({ matchers: [{ name: 'instance', value: 'web', isEqual: false, isRegex: true }] })
+    expect(silenceMatchesAlert(silence, makeAlert({ labels: { alertname: 'X', instance: 'web1' } }))).toBe(true)
+  })
+})
+
+describe('getEffectiveAlertState (multi-silence — S-05)', () => {
+  it('returns the raw state when not suppressed', () => {
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: [], state: 'active' } })
+    expect(getEffectiveAlertState(alert, [])).toBe('active')
+  })
+
+  it('flips to active when the only covering silence expires within 15 minutes', () => {
+    const now = Date.now()
+    const silence = makeSilence({ id: 's1', endsAt: new Date(now + 5 * 60_000).toISOString() })
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s1'], state: 'suppressed' } })
+    expect(getEffectiveAlertState(alert, [silence])).toBe('active')
+  })
+
+  it('regression: stays suppressed when a SECOND silence still has 3 days left, even if the first expires in 5 minutes', () => {
+    const now = Date.now()
+    const soon = makeSilence({ id: 's1', endsAt: new Date(now + 5 * 60_000).toISOString() })
+    const long = makeSilence({ id: 's2', endsAt: new Date(now + 3 * 86_400_000).toISOString() })
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s1', 's2'], state: 'suppressed' } })
+    expect(getEffectiveAlertState(alert, [soon, long])).toBe('suppressed')
+    // Order must not matter — the max-remaining silence decides regardless of silencedBy order.
+    const alertReversed = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s2', 's1'], state: 'suppressed' } })
+    expect(getEffectiveAlertState(alertReversed, [soon, long])).toBe('suppressed')
+  })
+
+  it('ignores pending and expired silences when computing remaining time', () => {
+    const now = Date.now()
+    const pending = makeSilence({ id: 's1', status: { state: 'pending' }, endsAt: new Date(now + 60_000).toISOString() })
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s1'], state: 'suppressed' } })
+    expect(getEffectiveAlertState(alert, [pending])).toBe('suppressed')
+  })
+
+  it('stays suppressed when the covering silence id is unknown', () => {
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['missing'], state: 'suppressed' } })
+    expect(getEffectiveAlertState(alert, [])).toBe('suppressed')
+  })
+})
+
+describe('getSilenceState (multi-silence — S-05)', () => {
+  it('returns null type when there is no covering silence', () => {
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: [], state: 'active' } })
+    expect(getSilenceState(alert, []).type).toBeNull()
+  })
+
+  it('picks the active silence with the LATEST endsAt, not the first in silencedBy', () => {
+    const now = Date.now()
+    const soon = makeSilence({ id: 's1', endsAt: new Date(now + 5 * 60_000).toISOString() })
+    const long = makeSilence({ id: 's2', endsAt: new Date(now + 3 * 86_400_000).toISOString() })
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s1', 's2'], state: 'suppressed' } })
+    const result = getSilenceState(alert, [soon, long])
+    expect(result.silence?.id).toBe('s2')
+    expect(result.type).toBe('active')
+  })
+
+  it('reports "expiring" when the longest-remaining active silence is still within 15 minutes', () => {
+    const now = Date.now()
+    const silence = makeSilence({ id: 's1', endsAt: new Date(now + 5 * 60_000).toISOString() })
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s1'], state: 'suppressed' } })
+    expect(getSilenceState(alert, [silence]).type).toBe('expiring')
+  })
+
+  it('falls back to pending only when no active silence covers the alert', () => {
+    const pending = makeSilence({ id: 's1', status: { state: 'pending' } })
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s1'], state: 'active' } })
+    expect(getSilenceState(alert, [pending]).type).toBe('pending')
+  })
+
+  it('prefers an active silence over a pending one when both cover the alert', () => {
+    const now = Date.now()
+    const pending = makeSilence({ id: 's1', status: { state: 'pending' } })
+    const active = makeSilence({ id: 's2', status: { state: 'active' }, endsAt: new Date(now + 3 * 86_400_000).toISOString() })
+    const alert = makeAlert({ status: { inhibitedBy: [], silencedBy: ['s1', 's2'], state: 'suppressed' } })
+    const result = getSilenceState(alert, [pending, active])
+    expect(result.type).toBe('active')
+    expect(result.silence?.id).toBe('s2')
   })
 })

--- a/frontend/src/lib/alertUtils.test.ts
+++ b/frontend/src/lib/alertUtils.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest'
+import fc from 'fast-check'
+import {
+  escapeRegexValue,
+  formatAckDuration,
+  formatSilenceDuration,
+  formatTime,
+  getFilterableLabels,
+  pickIdentifierLabel,
+  safeRegex,
+  severityOrder,
+  buildAckSilenceBody,
+  FAST_SILENCE_DURATIONS,
+} from './alertUtils'
+import type { EnrichedAlert } from '@/types'
+
+/**
+ * Scope note: this file covers only the functions in `alertUtils.ts` that
+ * the planned silence-matching rewrite (anchored regex, S-01/S-03/S-05/S-06/
+ * S-14 — see tmp/fable/review_silence.md) does not touch. Matching functions
+ * (`matchesLabelMatchers`, `silenceMatchesAlert`, `getEffectiveAlertState`,
+ * `getSilenceState`, `getExpiredSilence`, `filterSilences`,
+ * `computeGroupLabelValues`, `buildGroupAckSilenceBody`) get their tests
+ * alongside that rewrite instead of locking in pre-fix behavior here.
+ */
+
+function makeAlert(overrides: Partial<EnrichedAlert> = {}): EnrichedAlert {
+  return {
+    fingerprint: 'abc123',
+    status: { inhibitedBy: [], silencedBy: [], state: 'active' },
+    labels: { alertname: 'TestAlert', severity: 'warning' },
+    annotations: {},
+    startsAt: '2026-01-01T00:00:00Z',
+    endsAt: '0001-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    generatorURL: '',
+    receivers: [{ name: 'default' }],
+    clusterName: 'cluster-a',
+    alertmanagerUrl: 'https://am.example.com',
+    ...overrides,
+  }
+}
+
+describe('escapeRegexValue', () => {
+  it('escapes every regex metacharacter', () => {
+    expect(escapeRegexValue('a.b*c+d?e^f$g{h}i(j)k|l[m]n\\o')).toBe(
+      'a\\.b\\*c\\+d\\?e\\^f\\$g\\{h\\}i\\(j\\)k\\|l\\[m\\]n\\\\o',
+    )
+  })
+
+  it('leaves plain alphanumerics untouched', () => {
+    expect(escapeRegexValue('web1-prod')).toBe('web1-prod')
+  })
+
+  it('handles the empty string', () => {
+    expect(escapeRegexValue('')).toBe('')
+  })
+
+  it('property: escaped value used as a regex matches only the original literal', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (s, other) => {
+        fc.pre(s !== other)
+        const re = new RegExp(`^(?:${escapeRegexValue(s)})$`)
+        expect(re.test(s)).toBe(true)
+        expect(re.test(other)).toBe(false)
+      }),
+    )
+  })
+
+  it('property: never throws when compiled as a regex', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        expect(() => new RegExp(escapeRegexValue(s))).not.toThrow()
+      }),
+    )
+  })
+})
+
+describe('safeRegex', () => {
+  it('returns a working RegExp for a valid pattern', () => {
+    const re = safeRegex('foo.*')
+    expect(re?.test('foobar')).toBe(true)
+  })
+
+  it('returns null for an invalid pattern instead of throwing', () => {
+    expect(safeRegex('[')).toBeNull()
+    expect(safeRegex('(')).toBeNull()
+  })
+})
+
+describe('formatSilenceDuration', () => {
+  it('formats sub-minute durations as <1m', () => {
+    expect(formatSilenceDuration(30_000)).toBe('<1m')
+  })
+
+  it('formats minutes', () => {
+    expect(formatSilenceDuration(5 * 60_000)).toBe('5m')
+  })
+
+  it('formats hours with remainder minutes', () => {
+    expect(formatSilenceDuration(90 * 60_000)).toBe('1h 30m')
+  })
+
+  it('formats exact hours without remainder', () => {
+    expect(formatSilenceDuration(2 * 3_600_000)).toBe('2h')
+  })
+
+  it('formats days with remainder hours', () => {
+    expect(formatSilenceDuration(26 * 3_600_000)).toBe('1d 2h')
+  })
+
+  it('formats months', () => {
+    expect(formatSilenceDuration(35 * 86_400_000)).toBe('1mo 5d')
+  })
+
+  it('formats years', () => {
+    expect(formatSilenceDuration(400 * 86_400_000)).toBe('1y 1mo')
+  })
+
+  it('property: never throws for any non-negative duration', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 100 * 365 * 86_400_000 }), (ms) => {
+        expect(() => formatSilenceDuration(ms)).not.toThrow()
+      }),
+    )
+  })
+})
+
+describe('formatAckDuration', () => {
+  it('collapses exact weeks', () => {
+    expect(formatAckDuration(10080)).toBe('1w')
+    expect(formatAckDuration(20160)).toBe('2w')
+  })
+
+  it('collapses exact days (non-week)', () => {
+    expect(formatAckDuration(1440)).toBe('1d')
+  })
+
+  it('collapses exact hours', () => {
+    expect(formatAckDuration(60)).toBe('1h')
+    expect(formatAckDuration(240)).toBe('4h')
+  })
+
+  it('shows plain minutes under an hour', () => {
+    expect(formatAckDuration(5)).toBe('5m')
+    expect(formatAckDuration(30)).toBe('30m')
+  })
+
+  it('falls back to combined hours+minutes for non-exact values', () => {
+    expect(formatAckDuration(90)).toBe('1h 30m')
+  })
+
+  it('matches every FAST_SILENCE_DURATIONS label', () => {
+    for (const d of FAST_SILENCE_DURATIONS) {
+      expect(formatAckDuration(d.minutes)).toBe(d.label)
+    }
+  })
+})
+
+describe('formatTime', () => {
+  it('formats absolute time with a timezone suffix', () => {
+    const out = formatTime('2026-01-01T12:00:00Z', 'absolute')
+    expect(out).toContain('2026')
+  })
+
+  it('formats relative time with a suffix', () => {
+    const past = new Date(Date.now() - 60_000).toISOString()
+    expect(formatTime(past, 'relative')).toMatch(/ago/)
+  })
+})
+
+describe('severityOrder', () => {
+  it('orders known severities critical < error < warning < info < none', () => {
+    expect(severityOrder('critical')).toBeLessThan(severityOrder('error'))
+    expect(severityOrder('error')).toBeLessThan(severityOrder('warning'))
+    expect(severityOrder('warning')).toBeLessThan(severityOrder('info'))
+    expect(severityOrder('info')).toBeLessThan(severityOrder('none'))
+  })
+
+  it('sorts unknown severities last', () => {
+    expect(severityOrder('bogus')).toBeGreaterThan(severityOrder('none'))
+  })
+})
+
+describe('getFilterableLabels', () => {
+  it('adds @receiver, receiver, and @cluster pseudo-labels', () => {
+    const alert = makeAlert({ receivers: [{ name: 'team-a' }, { name: 'team-b' }] })
+    const labels = getFilterableLabels(alert)
+    expect(labels['@receiver']).toBe('team-a,team-b')
+    expect(labels['receiver']).toBe('team-a,team-b')
+    expect(labels['@cluster']).toBe('cluster-a')
+  })
+
+  it('falls back to an existing @receiver label when receivers is empty', () => {
+    const alert = makeAlert({ receivers: [], labels: { '@receiver': 'fallback-team' } })
+    const labels = getFilterableLabels(alert)
+    expect(labels['@receiver']).toBe('fallback-team')
+    expect(labels['receiver']).toBe('fallback-team')
+  })
+
+  it('preserves original alert labels alongside pseudo-labels', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', instance: 'web1' } })
+    const labels = getFilterableLabels(alert)
+    expect(labels.alertname).toBe('X')
+    expect(labels.instance).toBe('web1')
+  })
+})
+
+describe('pickIdentifierLabel', () => {
+  it('returns null for an empty alert list', () => {
+    expect(pickIdentifierLabel([])).toBeNull()
+  })
+
+  it('returns null when nothing differs besides skipped labels', () => {
+    const alerts = [
+      makeAlert({ labels: { alertname: 'X', severity: 'warning' } }),
+      makeAlert({ labels: { alertname: 'X', severity: 'critical' } }),
+    ]
+    expect(pickIdentifierLabel(alerts)).toBeNull()
+  })
+
+  it('picks the label with the highest distinct-value count', () => {
+    const alerts = [
+      makeAlert({ labels: { alertname: 'X', instance: 'a', pod: 'p1' } }),
+      makeAlert({ labels: { alertname: 'X', instance: 'b', pod: 'p1' } }),
+      makeAlert({ labels: { alertname: 'X', instance: 'c', pod: 'p1' } }),
+    ]
+    expect(pickIdentifierLabel(alerts)).toBe('instance')
+  })
+})
+
+describe('buildAckSilenceBody', () => {
+  it('excludes pseudo-labels and the receiver label', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', '@cluster': 'c', receiver: 'r', instance: 'web1' } })
+    const body = buildAckSilenceBody(alert, 30, 'alice')
+    const names = body.matchers.map((m) => m.name)
+    expect(names).not.toContain('@cluster')
+    expect(names).not.toContain('receiver')
+    expect(names).toEqual(['alertname', 'instance'])
+  })
+
+  it('produces exact-match, non-regex matchers sorted by name', () => {
+    const alert = makeAlert({ labels: { zeta: 'z', alertname: 'X' } })
+    const body = buildAckSilenceBody(alert, 30, 'alice')
+    expect(body.matchers.every((m) => m.isEqual && !m.isRegex)).toBe(true)
+    expect(body.matchers.map((m) => m.name)).toEqual(['alertname', 'zeta'])
+  })
+
+  it('sets endsAt to startsAt + durationMinutes', () => {
+    const alert = makeAlert()
+    const body = buildAckSilenceBody(alert, 60, 'alice')
+    const diffMinutes = (new Date(body.endsAt).getTime() - new Date(body.startsAt).getTime()) / 60_000
+    expect(diffMinutes).toBeCloseTo(60, 5)
+  })
+
+  it('carries the fingerprint and a duration-labeled comment', () => {
+    const alert = makeAlert({ fingerprint: 'deadbeef' })
+    const body = buildAckSilenceBody(alert, 60, 'alice')
+    expect(body.fingerprint).toBe('deadbeef')
+    expect(body.comment).toBe('Fast-Silence for 1h')
+  })
+
+  it('drops labels with empty values', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', empty: '' } })
+    const body = buildAckSilenceBody(alert, 30, 'alice')
+    expect(body.matchers.map((m) => m.name)).not.toContain('empty')
+  })
+})

--- a/frontend/src/lib/alertUtils.ts
+++ b/frontend/src/lib/alertUtils.ts
@@ -77,7 +77,7 @@ export function pickIdentifierLabel(
   return best
 }
 
-// ── Regex helper ──────────────────────────────────────────────────────────
+// ── Regex helpers ────────────────────────────────────────────────────────
 
 export function safeRegex(pattern: string): RegExp | null {
   try {
@@ -87,11 +87,35 @@ export function safeRegex(pattern: string): RegExp | null {
   }
 }
 
+/**
+ * Alertmanager-anchored regex: full-string match (`^(?:pattern)$`), matching
+ * how Alertmanager compiles a matcher's regex (RE2, fully anchored).
+ * `new RegExp(pattern).test(value)` is substring matching and diverges from
+ * AM in both directions — `instance=~"web1"` would appear to also match
+ * `web10`, and `instance!~"web"` would appear to NOT match `web1` even
+ * though AM's anchored negative match silences it (`^(?:web)$` doesn't match
+ * `web1`, so `!~` is true). Returns null for patterns that don't compile as
+ * a JS RegExp — such a pattern may still be valid RE2 (e.g. inline flags
+ * like `(?i)`); see `hasUnevaluableRegexMatcher` for surfacing that case.
+ */
+export function anchoredRegex(pattern: string): RegExp | null {
+  try {
+    return new RegExp(`^(?:${pattern})$`)
+  } catch {
+    return null
+  }
+}
+
 // ── Matcher logic ─────────────────────────────────────────────────────────
 
 /**
- * Returns true if the alert matches ALL of the given label matchers.
- * Special handling: receiver/@receiver labels are comma-separated and support partial matching.
+ * Returns true if the alert matches ALL of the given label matchers, for
+ * the alerts-page/silences-page **filter bar** — deliberately lenient UI
+ * filtering, not Alertmanager matching semantics: substring regex (not
+ * anchored) and receiver/@receiver pseudo-labels with comma-list partial
+ * matching. Do NOT use this to decide what a silence would actually cover —
+ * that is `silenceWouldMatchAlert`, which mirrors AM's anchored, pseudo-label-free
+ * semantics exactly.
  */
 export function matchesLabelMatchers(
   alert: EnrichedAlert,
@@ -109,7 +133,11 @@ export function matchesLabelMatchers(
         case '=':
           return receivers.includes(m.value)
         case '!=':
-          return receivers.some((r) => r !== m.value)
+          // Matches only if NONE of the alert's receivers is the excluded one —
+          // consistent with `!~` below (also `every`); `some` here would make
+          // `receiver!=a` match an alert whose receivers are [a, b] just
+          // because b !== a.
+          return receivers.every((r) => r !== m.value)
         case '=~': {
           const re = safeRegex(m.value)
           return re ? receivers.some((r) => re.test(r)) : false
@@ -132,6 +160,55 @@ export function matchesLabelMatchers(
       }
       case '!~': {
         const re = safeRegex(m.value)
+        return re ? !re.test(value) : true
+      }
+    }
+  })
+}
+
+/**
+ * True if any regex matcher's pattern doesn't compile as a JS RegExp (e.g.
+ * RE2-only syntax like `(?i)`), meaning `silenceWouldMatchAlert` couldn't
+ * evaluate it client-side and had to assume a match conservatively. Callers
+ * (the silence-preview UI) should surface this instead of trusting an
+ * "0 affected alerts" count at face value.
+ */
+export function hasUnevaluableRegexMatcher(matchers: LabelMatcher[]): boolean {
+  return matchers.some(
+    (m) => (m.operator === '=~' || m.operator === '!~') && anchoredRegex(m.value) === null,
+  )
+}
+
+/**
+ * True if the given matchers would match the alert in Alertmanager: anchored
+ * regex (not substring), evaluated only against the alert's real labels —
+ * no `@cluster`/`@receiver`/`receiver` pseudo-labels, since those don't
+ * exist as real Alertmanager labels (a matcher naming them targets the empty
+ * string there, not the UI's synthesized value). A missing label is treated
+ * as the empty string, matching AM's own matcher semantics. Used by
+ * `SilenceForm`'s affected-alerts preview and overlap detection — NOT the
+ * filter bar, which intentionally stays lenient (see `matchesLabelMatchers`).
+ *
+ * A regex matcher whose pattern doesn't compile in JS is conservatively
+ * treated as matching (see `hasUnevaluableRegexMatcher`): under-counting
+ * affected alerts is the dangerous direction (a silence created from a
+ * preview showing "0 affected" that actually silences alerts in
+ * Alertmanager); over-counting is not.
+ */
+export function silenceWouldMatchAlert(matchers: LabelMatcher[], alert: EnrichedAlert): boolean {
+  return matchers.every((m) => {
+    const value = alert.labels[m.name] ?? ''
+    switch (m.operator) {
+      case '=':
+        return value === m.value
+      case '!=':
+        return value !== m.value
+      case '=~': {
+        const re = anchoredRegex(m.value)
+        return re ? re.test(value) : true
+      }
+      case '!~': {
+        const re = anchoredRegex(m.value)
         return re ? !re.test(value) : true
       }
     }
@@ -189,9 +266,13 @@ export function filterSilences(
 // ── Effective alert state ─────────────────────────────────────────────────
 
 /**
- * Returns 'active' if the alert is suppressed but its silence expires within
- * 15 minutes (i.e. it will soon become active again).
- * Otherwise returns the raw alert state.
+ * Returns 'active' if the alert is suppressed but ALL active silences
+ * currently covering it (`status.silencedBy`) expire within 15 minutes —
+ * i.e. it will soon become active again regardless of which one runs out
+ * last. Otherwise returns the raw alert state. An alert can be covered by
+ * more than one silence at once; looking only at the first one found in
+ * `silencedBy` (as opposed to the one with the latest `endsAt`) could flip
+ * the effective state early while a longer-running silence still applies.
  */
 export function getEffectiveAlertState(
   alert: EnrichedAlert,
@@ -202,16 +283,14 @@ export function getEffectiveAlertState(
   const FIFTEEN_MIN = 15 * 60 * 1000
   const now = Date.now()
 
+  let maxRemaining: number | null = null
   for (const silenceId of alert.status.silencedBy) {
     const silence = silences.find((s) => s.id === silenceId)
-    if (silence && silence.status.state === 'active') {
-      const endsAt = new Date(silence.endsAt).getTime()
-      const remaining = endsAt - now
-      if (remaining <= FIFTEEN_MIN) {
-        return 'active'
-      }
-    }
+    if (!silence || silence.status.state !== 'active') continue
+    const remaining = new Date(silence.endsAt).getTime() - now
+    if (maxRemaining === null || remaining > maxRemaining) maxRemaining = remaining
   }
+  if (maxRemaining !== null && maxRemaining <= FIFTEEN_MIN) return 'active'
   return 'suppressed'
 }
 
@@ -223,37 +302,52 @@ export interface SilenceStateResult {
   remaining?: number
 }
 
+/**
+ * Picks the silence that best represents the alert's current suppression:
+ * among all ACTIVE silences in `silencedBy`, the one with the latest
+ * `endsAt` (the one that actually determines when the alert goes loud
+ * again) — checked before any pending silence, since a pending silence
+ * doesn't suppress anything yet.
+ */
 export function getSilenceState(alert: EnrichedAlert, silences: Silence[]): SilenceStateResult {
   const FIFTEEN_MIN = 15 * 60 * 1000
   const now = Date.now()
+
+  let best: { silence: Silence; remaining: number } | null = null
+  let pending: Silence | null = null
   for (const silenceId of alert.status.silencedBy) {
     const silence = silences.find((s) => s.id === silenceId)
     if (!silence) continue
-    const remaining = new Date(silence.endsAt).getTime() - now
-    if (silence.status.state === 'pending') return { type: 'pending', silence }
+    if (silence.status.state === 'pending' && !pending) pending = silence
     if (silence.status.state === 'active') {
-      if (remaining <= FIFTEEN_MIN) return { type: 'expiring', silence, remaining }
-      return { type: 'active', silence, remaining }
+      const remaining = new Date(silence.endsAt).getTime() - now
+      if (!best || remaining > best.remaining) best = { silence, remaining }
     }
   }
+  if (best) {
+    return best.remaining <= FIFTEEN_MIN
+      ? { type: 'expiring', silence: best.silence, remaining: best.remaining }
+      : { type: 'active', silence: best.silence, remaining: best.remaining }
+  }
+  if (pending) return { type: 'pending', silence: pending }
   return { type: null, silence: null }
 }
 
 /**
- * Returns true if the silence's matchers all match the given alert's labels
- * (including the @cluster pseudo-label).
+ * Returns true if the silence's matchers would match the alert in
+ * Alertmanager: anchored regex, evaluated only against the alert's real
+ * labels (no `@cluster` pseudo-label — no real Alertmanager label has that
+ * name, and cluster scoping is handled separately via `clusterName`
+ * comparisons at call sites). See `silenceWouldMatchAlert` for the
+ * equivalent used on the (differently-shaped) `LabelMatcher[]` the silence
+ * form works with, including the unparseable-regex rationale.
  */
 export function silenceMatchesAlert(silence: Silence, alert: EnrichedAlert): boolean {
-  const labels: Record<string, string> = { ...alert.labels, '@cluster': alert.clusterName }
   return silence.matchers.every((m) => {
-    const value = labels[m.name] ?? ''
+    const value = alert.labels[m.name] ?? ''
     if (m.isRegex) {
-      try {
-        const re = new RegExp(m.value)
-        return m.isEqual ? re.test(value) : !re.test(value)
-      } catch {
-        return false
-      }
+      const re = anchoredRegex(m.value)
+      return re ? (m.isEqual ? re.test(value) : !re.test(value)) : true
     }
     return m.isEqual ? value === m.value : value !== m.value
   })

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+/**
+ * Narrow, deliberate exception to the functional-E2E-only strategy (see
+ * `.agents/testing.md`): pure matching/formatting logic in `lib/alertUtils.ts`
+ * needs property-based/fuzz testing (fast-check) that isn't practical to
+ * express as Playwright UI flows. Scope is limited to `src/lib/**` — no
+ * broader component/unit-test stack is being reintroduced.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    include: ['src/lib/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/alertUtils.ts'],
+      // 100% branch-coverage gate lands once the silence-matching rewrite
+      // (anchored regex, S-01/S-03/S-05/S-06/S-14) has full test coverage —
+      // enabling it now would fail on functions not yet under test.
+    },
+  },
+})


### PR DESCRIPTION
## Summary
(Recreated after #62 was auto-closed when its stacked base branch feat/oneclick-ack was deleted on merge — GitHub doesn't retarget stacked PRs across a squash-merge. Same content, now against main directly.)

Part 1/6 of a silence-subsystem review (see `tmp/fable/review_silence.md`, local planning doc, not committed).

- The silence-matching helpers used unanchored JS regex (`new RegExp(pattern).test(value)`) and injected `@cluster`/`@receiver` pseudo-labels — both diverge from Alertmanager, which compiles matcher regex as `^(?:pattern)$` against only the alert's real labels.
- **The dangerous case**: a negative regex matcher like `instance!~"web"` showed "0 affected alerts" in the preview (substring match) while Alertmanager's anchored match silences it anyway. A silence could be created believing it had no effect and suppress unrelated alerts.
- Adds `anchoredRegex()` and `silenceWouldMatchAlert()` mirroring AM's exact semantics; `SilenceForm`'s preview/overlap detection now use it. The filter bar's `matchesLabelMatchers` stays intentionally lenient for its own UX purpose.
- `getEffectiveAlertState`/`getSilenceState` now consider every silence covering an alert (not just the first), picking the one with the latest `endsAt`.
- Removes a duplicate `silenceMatchesAlert` in `AlertDetailPanel` (critical invariant #4).
- Fixes `matchesLabelMatchers`' receiver `!=` to use `every` instead of `some`.

Also includes a preceding commit (`test(frontend): add scoped Vitest setup for lib/alertUtils.ts`) reintroducing a narrow, deliberate Vitest exception for this one file — see `.agents/testing.md` for the rationale (project had gone E2E-only).

## Test plan
- [x] `go test -race ./...`
- [x] `pnpm test:unit` (70 tests, new)
- [x] `pnpm build`, `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)