### PR TITLE
fix(silences): validate matchers server-side and relay AM rejections

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -357,15 +357,22 @@ GET    /api/v1/alerts/:fingerprint/claims/history full_protect? → []Claim  ?cl
 # ── Silences (proxy → Alertmanager) ──────────────────────────────────────────
 GET    /api/v1/silences                          full_protect?  → []Silence  ?cluster=
 POST   /api/v1/silences                          Auth  (write)  → { id }
+#        validated server-side before the AM call (silence_validation.go validateSilenceMatchers):
+#        ≥1 matcher, no empty matcher names, every regex must compile (Go regexp = RE2, same
+#        engine as AM — accepts syntax like `(?i)` that a browser's JS RegExp rejects), ≥1 matcher
+#        must not match the empty string, endsAt > startsAt, endsAt > now
+#        AM 4xx response (e.g. its own validation rejection) → relayed as 400 with a sanitized
+#        message (sanitizeAMMessage); AM 5xx/transport failure → generic 502
 #        id set → update (AM may return a NEW id; the old silence is then expired to avoid duplicates)
 #        fingerprint set → SilenceEvent recorded (action: created | updated | pending when startsAt is in the future)
 #        when auth mode ≠ none: createdBy/performedBy forced to the session username
 DELETE /api/v1/silences/:id                      Auth  (write)  ?cluster= (required) &fingerprint= &by=  → records "deleted" event
+#        AM 4xx response → relayed as 400 (sanitized); AM 5xx/transport failure → generic 502
 
 # ── Silence Templates (DB, shared) ───────────────────────────────────────────
 GET    /api/v1/silence-templates                 full_protect?  → []SilenceTemplate
-POST   /api/v1/silence-templates                 Auth  (write)  Body: { name, matchers[], reason? }
-PUT    /api/v1/silence-templates/:id             Auth  (write)  Body: { name, matchers[], reason? }
+POST   /api/v1/silence-templates                 Auth  (write)  Body: { name, matchers[], reason? }  — validateSilenceMatchers applies
+PUT    /api/v1/silence-templates/:id             Auth  (write)  Body: { name, matchers[], reason? }  — validateSilenceMatchers applies
 DELETE /api/v1/silence-templates/:id             Auth  (write)
 
 # ── Poll / Clusters ──────────────────────────────────────────────────────────

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -100,7 +100,9 @@ make fixtures-unsilence            # expire test silences
 | `internal/api` | `alerts_test.go` | Alert list/detail handler |
 | `internal/api` | `claims_test.go` | Claim set/release handler |
 | `internal/api` | `comments_test.go` | Comment create/delete handler (author-gated) |
-| `internal/api` | `silences_test.go` | Silence list/create handler + silence templates CRUD |
+| `internal/api` | `silences_test.go` | Silence list/create/delete handler + silence templates CRUD + backend validation (empty/invalid matchers, endsAt checks) + AM 4xx passthrough |
+| `internal/api` | `silence_validation_test.go` | `validateSilenceMatchers` (empty-string-match rule, RE2 compile), `sanitizeAMMessage`, `isUniqueViolation` |
+| `internal/api` | `silence_validation_fuzz_test.go` | Fuzz: `validateSilenceMatchers` accept/reject is consistent with its own regex compilation; `sanitizeAMMessage` never panics, always bounded and newline-free |
 | `internal/api` | `auth_handler_test.go` | login/logout/me/info, OIDC handlers |
 | `internal/api` | `setup_test.go` | first-run `/setup` handler (internal mode, 403 when users exist) |
 | `internal/api` | `admin_handler_test.go` | admin user CRUD + role/self guards |
@@ -273,7 +275,8 @@ backend:
   - upload-artifact: coverage.out + report.xml; coverage upload to Codecov
   - govulncheck ./...
   - golangci-lint run   # includes gosec (enabled in .golangci.yml)
-  - fuzz targets, 20s each (FuzzRedactDSN, FuzzParseNullableTimeString, FuzzParseSecretKey)
+  - fuzz targets, 20s each (FuzzRedactDSN, FuzzParseNullableTimeString, FuzzParseSecretKey,
+    FuzzValidateSilenceMatchers, FuzzSanitizeAMMessage)
 
 frontend:
   - pnpm audit --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
           go test ./internal/db -run '^$' -fuzz '^FuzzRedactDSN$' -fuzztime 20s
           go test ./internal/history -run '^$' -fuzz '^FuzzParseNullableTimeString$' -fuzztime 20s
           go test ./internal/config -run '^$' -fuzz '^FuzzParseSecretKey$' -fuzztime 20s
+          go test ./internal/api -run '^$' -fuzz '^FuzzValidateSilenceMatchers$' -fuzztime 20s
+          go test ./internal/api -run '^$' -fuzz '^FuzzSanitizeAMMessage$' -fuzztime 20s
 
   frontend:
     name: Frontend

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ fuzz-backend: ## Backend: run all Go native fuzz targets (FUZZTIME=30s per targe
 	cd backend && go test ./internal/db -run '^$$' -fuzz '^FuzzRedactDSN$$' -fuzztime $(FUZZTIME)
 	cd backend && go test ./internal/history -run '^$$' -fuzz '^FuzzParseNullableTimeString$$' -fuzztime $(FUZZTIME)
 	cd backend && go test ./internal/config -run '^$$' -fuzz '^FuzzParseSecretKey$$' -fuzztime $(FUZZTIME)
+	cd backend && go test ./internal/api -run '^$$' -fuzz '^FuzzValidateSilenceMatchers$$' -fuzztime $(FUZZTIME)
+	cd backend && go test ./internal/api -run '^$$' -fuzz '^FuzzSanitizeAMMessage$$' -fuzztime $(FUZZTIME)
 
 test-frontend: ## Frontend: functional E2E tests across all auth modes
 	$(E2E_RUN) test none

--- a/backend/internal/alertmanager/client.go
+++ b/backend/internal/alertmanager/client.go
@@ -16,6 +16,19 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// AMError wraps a non-2xx response from Alertmanager, preserving the status
+// code so callers can distinguish AM-side rejections (4xx — e.g. an invalid
+// matcher or a duplicate/expired silence ID; safe to relay to the user) from
+// transport/server failures (5xx, network errors — kept as a generic error).
+type AMError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *AMError) Error() string {
+	return fmt.Sprintf("alertmanager returned %d: %s", e.StatusCode, e.Body)
+}
+
 // NewClient creates a new Alertmanager API client without authentication.
 func NewClient(baseURL string) *Client {
 	return NewClientWithAuth(baseURL, Auth{})
@@ -83,7 +96,7 @@ func (c *Client) CreateSilence(ctx context.Context, s PostableSilence) (string, 
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("alertmanager returned %d: %s", resp.StatusCode, string(b))
+		return "", &AMError{StatusCode: resp.StatusCode, Body: string(b)}
 	}
 
 	var result PostSilenceResponse
@@ -108,7 +121,7 @@ func (c *Client) DeleteSilence(ctx context.Context, id string) error {
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("alertmanager returned %d: %s", resp.StatusCode, string(b))
+		return &AMError{StatusCode: resp.StatusCode, Body: string(b)}
 	}
 	return nil
 }

--- a/backend/internal/api/silence_validation.go
+++ b/backend/internal/api/silence_validation.go
@@ -43,27 +43,31 @@ func validateSilenceMatchers(matchers []models.SilenceMatcher) error {
 
 // matcherMatchesEmptyString reports whether the matcher would match a label
 // value of "" (i.e. a missing label), for the "at least one matcher must be
-// meaningful" check. Only evaluated for *positive* matchers (`=`, `=~`) —
-// negative matchers (`!=`, `!~`) are never flagged, regardless of whether
-// they'd also match an absent label: confirmed empirically against a running
-// Alertmanager that e.g. a lone `instance!~"web"` (which also matches a
-// missing `instance` label) is accepted, while a lone `instance=~".*"` is
-// rejected. Negative matchers are inherently broad/exclusionary by design
-// (e.g. `env!=kube-system`), which is exactly the pattern this check must
-// NOT reject — unlike the "positively matches literally everything" mistake
-// it exists to catch.
+// meaningful" check. The empty-string verdict only ever comes out true for
+// *positive* matchers (`=`, `=~`) — negative matchers (`!=`, `!~`) are never
+// flagged as trivial, regardless of whether they'd also match an absent
+// label: confirmed empirically against a running Alertmanager that e.g. a
+// lone `instance!~"web"` (which also matches a missing `instance` label) is
+// accepted, while a lone `instance=~".*"` is rejected. Negative matchers are
+// inherently broad/exclusionary by design (e.g. `env!=kube-system`), which
+// is exactly the pattern this check must NOT reject.
+//
+// Regex compilation, however, is checked for EVERY regex matcher regardless
+// of positive/negative — an uncompilable pattern is a genuine error
+// Alertmanager itself would reject, independent of this function's
+// "meaningful" verdict. A fuzz test caught an earlier version of this
+// function returning early for negative matchers before ever attempting to
+// compile the regex, silently letting invalid patterns like `!~"(00000000"`
+// through.
 func matcherMatchesEmptyString(m models.SilenceMatcher) (bool, error) {
-	if !m.IsEqual {
-		return false, nil
-	}
 	if m.IsRegex {
 		re, err := regexp.Compile("^(?:" + m.Value + ")$")
 		if err != nil {
 			return false, err
 		}
-		return re.MatchString(""), nil
+		return m.IsEqual && re.MatchString(""), nil
 	}
-	return m.Value == "", nil
+	return m.IsEqual && m.Value == "", nil
 }
 
 // isUniqueViolation reports whether err represents a unique-constraint

--- a/backend/internal/api/silence_validation.go
+++ b/backend/internal/api/silence_validation.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+// validateSilenceMatchers checks the matcher list against Alertmanager's own
+// silence-validation rules (silence/silence.go Validate in Alertmanager):
+// at least one matcher, no empty names, every regex must compile, and at
+// least one matcher must not match the empty string (a silence made only of
+// matchers that are trivially satisfied by an absent label silences nothing
+// meaningful, and Alertmanager rejects it). Go's regexp package is RE2 — the
+// same engine Alertmanager uses — so a pattern that compiles here is
+// guaranteed to compile in Alertmanager too, including syntax the frontend's
+// JS RegExp can't evaluate (e.g. inline flags like `(?i)`).
+func validateSilenceMatchers(matchers []models.SilenceMatcher) error {
+	if len(matchers) == 0 {
+		return fmt.Errorf("at least one matcher is required")
+	}
+	hasMeaningfulMatcher := false
+	for _, m := range matchers {
+		if m.Name == "" {
+			return fmt.Errorf("matcher name must not be empty")
+		}
+		matchesEmpty, err := matcherMatchesEmptyString(m)
+		if err != nil {
+			return fmt.Errorf("matcher %q: invalid regular expression", m.Name)
+		}
+		if !matchesEmpty {
+			hasMeaningfulMatcher = true
+		}
+	}
+	if !hasMeaningfulMatcher {
+		return fmt.Errorf("at least one matcher must not match the empty string")
+	}
+	return nil
+}
+
+// matcherMatchesEmptyString reports whether the matcher would match a label
+// value of "" (i.e. a missing label) — matching Alertmanager's own matcher
+// semantics (anchored regex; a missing label is treated as "").
+func matcherMatchesEmptyString(m models.SilenceMatcher) (bool, error) {
+	if m.IsRegex {
+		re, err := regexp.Compile("^(?:" + m.Value + ")$")
+		if err != nil {
+			return false, err
+		}
+		matches := re.MatchString("")
+		if m.IsEqual {
+			return matches, nil
+		}
+		return !matches, nil
+	}
+	if m.IsEqual {
+		return m.Value == "", nil
+	}
+	return m.Value != "", nil
+}
+
+// isUniqueViolation reports whether err represents a unique-constraint
+// violation from either backing store dialect (SQLite or PostgreSQL) —
+// substring-matched rather than dialect-switched, so a driver upgrade or
+// wording change on either side doesn't silently stop this from firing.
+func isUniqueViolation(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "duplicate key value violates unique constraint")
+}
+
+// sanitizeAMMessage extracts a safe-to-display message from an Alertmanager
+// error response body: unwraps the common `{"message": "..."}` error shape,
+// collapses whitespace/newlines, and truncates to a bounded length so a
+// pathological AM response can't blow up the response body or leak binary
+// noise to the client.
+func sanitizeAMMessage(body string) string {
+	msg := body
+	var parsed struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err == nil && parsed.Message != "" {
+		msg = parsed.Message
+	}
+	msg = strings.Join(strings.Fields(msg), " ")
+	const maxLen = 300
+	if r := []rune(msg); len(r) > maxLen {
+		msg = string(r[:maxLen]) + "…"
+	}
+	if msg == "" {
+		msg = "alertmanager rejected the request"
+	}
+	return msg
+}

--- a/backend/internal/api/silence_validation.go
+++ b/backend/internal/api/silence_validation.go
@@ -10,14 +10,14 @@ import (
 )
 
 // validateSilenceMatchers checks the matcher list against Alertmanager's own
-// silence-validation rules (silence/silence.go Validate in Alertmanager):
-// at least one matcher, no empty names, every regex must compile, and at
-// least one matcher must not match the empty string (a silence made only of
-// matchers that are trivially satisfied by an absent label silences nothing
-// meaningful, and Alertmanager rejects it). Go's regexp package is RE2 — the
-// same engine Alertmanager uses — so a pattern that compiles here is
-// guaranteed to compile in Alertmanager too, including syntax the frontend's
-// JS RegExp can't evaluate (e.g. inline flags like `(?i)`).
+// silence-validation rules (verified empirically against a running
+// Alertmanager 0.32.2 — see tmp/fable/review_silence.md T-06): at least one
+// matcher, no empty names, every regex must compile, and at least one
+// *positive* matcher (`=`/`=~`) must not match the empty string. Go's regexp
+// package is RE2 — the same engine Alertmanager uses — so a pattern that
+// compiles here is guaranteed to compile in Alertmanager too, including
+// syntax the frontend's JS RegExp can't evaluate (e.g. inline flags like
+// `(?i)`).
 func validateSilenceMatchers(matchers []models.SilenceMatcher) error {
 	if len(matchers) == 0 {
 		return fmt.Errorf("at least one matcher is required")
@@ -42,24 +42,28 @@ func validateSilenceMatchers(matchers []models.SilenceMatcher) error {
 }
 
 // matcherMatchesEmptyString reports whether the matcher would match a label
-// value of "" (i.e. a missing label) — matching Alertmanager's own matcher
-// semantics (anchored regex; a missing label is treated as "").
+// value of "" (i.e. a missing label), for the "at least one matcher must be
+// meaningful" check. Only evaluated for *positive* matchers (`=`, `=~`) —
+// negative matchers (`!=`, `!~`) are never flagged, regardless of whether
+// they'd also match an absent label: confirmed empirically against a running
+// Alertmanager that e.g. a lone `instance!~"web"` (which also matches a
+// missing `instance` label) is accepted, while a lone `instance=~".*"` is
+// rejected. Negative matchers are inherently broad/exclusionary by design
+// (e.g. `env!=kube-system`), which is exactly the pattern this check must
+// NOT reject — unlike the "positively matches literally everything" mistake
+// it exists to catch.
 func matcherMatchesEmptyString(m models.SilenceMatcher) (bool, error) {
+	if !m.IsEqual {
+		return false, nil
+	}
 	if m.IsRegex {
 		re, err := regexp.Compile("^(?:" + m.Value + ")$")
 		if err != nil {
 			return false, err
 		}
-		matches := re.MatchString("")
-		if m.IsEqual {
-			return matches, nil
-		}
-		return !matches, nil
+		return re.MatchString(""), nil
 	}
-	if m.IsEqual {
-		return m.Value == "", nil
-	}
-	return m.Value != "", nil
+	return m.Value == "", nil
 }
 
 // isUniqueViolation reports whether err represents a unique-constraint

--- a/backend/internal/api/silence_validation_fuzz_test.go
+++ b/backend/internal/api/silence_validation_fuzz_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+// FuzzValidateSilenceMatchers asserts validateSilenceMatchers never panics
+// on arbitrary matcher input, and that whenever it accepts a regex matcher,
+// the same pattern actually compiles as the anchored regex the function
+// itself uses to decide meaningfulness — i.e. its own accept/reject
+// decision is internally consistent.
+func FuzzValidateSilenceMatchers(f *testing.F) {
+	seeds := []struct {
+		name    string
+		value   string
+		isEqual bool
+		isRegex bool
+	}{
+		{"alertname", "Test", true, false},
+		{"instance", "web1|web2", true, true},
+		{"instance", "(?i)watchdog", true, true},
+		{"instance", "a(", true, true},
+		{"", "x", true, false},
+		{"instance", "", true, false},
+		{"instance", ".*", false, true},
+		{"instance", "\x00", true, false},
+	}
+	for _, s := range seeds {
+		f.Add(s.name, s.value, s.isEqual, s.isRegex)
+	}
+
+	f.Fuzz(func(t *testing.T, name, value string, isEqual, isRegex bool) {
+		matchers := []models.SilenceMatcher{{Name: name, Value: value, IsEqual: isEqual, IsRegex: isRegex}}
+
+		err := validateSilenceMatchers(matchers)
+
+		if isRegex {
+			_, compileErr := regexp.Compile("^(?:" + value + ")$")
+			if err == nil && compileErr != nil {
+				t.Fatalf("validateSilenceMatchers accepted a pattern that doesn't compile: %q", value)
+			}
+		}
+	})
+}
+
+// FuzzSanitizeAMMessage asserts sanitizeAMMessage never panics on arbitrary
+// (including malformed-JSON and binary) input, and always returns a bounded,
+// newline-free string.
+func FuzzSanitizeAMMessage(f *testing.F) {
+	seeds := []string{
+		"",
+		`{"message": "ok"}`,
+		`{"message":`,
+		"line1\nline2\r\n",
+		"\x00\x01\x02",
+		`{"message": ""}`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, body string) {
+		got := sanitizeAMMessage(body)
+		if got == "" {
+			t.Fatalf("sanitizeAMMessage(%q) returned empty string", body)
+		}
+		for _, r := range got {
+			if r == '\n' || r == '\r' {
+				t.Fatalf("sanitizeAMMessage(%q) = %q contains a newline", body, got)
+			}
+		}
+	})
+}

--- a/backend/internal/api/silence_validation_test.go
+++ b/backend/internal/api/silence_validation_test.go
@@ -20,7 +20,7 @@ func TestValidateSilenceMatchers(t *testing.T) {
 		errSubstr string
 	}{
 		{
-			name:    "valid single matcher",
+			name:     "valid single matcher",
 			matchers: []models.SilenceMatcher{validMatcher()},
 		},
 		{
@@ -67,13 +67,17 @@ func TestValidateSilenceMatchers(t *testing.T) {
 			errSubstr: "must not match the empty string",
 		},
 		{
-			name:      "only a negative matcher matching empty (foo != x matches empty since x != \"\")",
-			matchers:  []models.SilenceMatcher{{Name: "instance", Value: "x", IsEqual: false, IsRegex: false}},
-			wantErr:   true,
-			errSubstr: "must not match the empty string",
+			// Empirically verified against a running Alertmanager (0.32.2): a lone
+			// `!=` matcher is ALWAYS accepted, even though it also matches a missing
+			// label (x != "" is true) — AM's "meaningful matcher" check only applies
+			// to positive (`=`/`=~`) matchers. See tmp/fable/review_silence.md T-06:
+			// this exact case was originally (wrongly) rejected here, and the mistake
+			// was only caught by an E2E test against real Alertmanager.
+			name:     "lone negative equal matcher is always accepted, regardless of empty-match",
+			matchers: []models.SilenceMatcher{{Name: "instance", Value: "x", IsEqual: false, IsRegex: false}},
 		},
 		{
-			name:     "negative matcher with empty value does NOT match empty (meaningful)",
+			name:     "negative matcher with empty value is accepted",
 			matchers: []models.SilenceMatcher{{Name: "instance", Value: "", IsEqual: false, IsRegex: false}},
 		},
 		{
@@ -83,18 +87,17 @@ func TestValidateSilenceMatchers(t *testing.T) {
 			errSubstr: "must not match the empty string",
 		},
 		{
-			// !~ "web1" is satisfied by almost everything, including a missing/empty
-			// label ("" doesn't match "web1" either) — so alone it's not meaningful.
-			name:      "negative regex whose pattern does not match empty is itself not meaningful",
-			matchers:  []models.SilenceMatcher{{Name: "instance", Value: "web1", IsEqual: false, IsRegex: true}},
-			wantErr:   true,
-			errSubstr: "must not match the empty string",
+			// Verified against real Alertmanager: `!~"web"` is accepted even though it
+			// also matches a missing `instance` label — same "negative matchers are
+			// never flagged" rule as the plain `!=` case above.
+			name:     "lone negative regex matcher is always accepted, regardless of empty-match",
+			matchers: []models.SilenceMatcher{{Name: "instance", Value: "web1", IsEqual: false, IsRegex: true}},
 		},
 		{
-			// !~ ".*" never matches anything (everything matches ".*", so its negation
-			// is never true) — including the empty string, which is exactly what makes
-			// this matcher "meaningful" per the same empty-string check.
-			name:     "negative regex whose pattern DOES match empty is meaningful",
+			// !~ ".*" never matches anything real either — also accepted, confirming
+			// the rule is "negative matchers are exempt", not "negative matchers that
+			// happen to also reject empty are exempt".
+			name:     "lone negative regex matching nothing at all is still accepted",
 			matchers: []models.SilenceMatcher{{Name: "instance", Value: ".*", IsEqual: false, IsRegex: true}},
 		},
 	}

--- a/backend/internal/api/silence_validation_test.go
+++ b/backend/internal/api/silence_validation_test.go
@@ -48,6 +48,16 @@ func TestValidateSilenceMatchers(t *testing.T) {
 			errSubstr: "invalid regular expression",
 		},
 		{
+			// Regression: an earlier version of matcherMatchesEmptyString returned
+			// early for negative matchers before ever compiling the regex, so an
+			// invalid pattern on a negative matcher slipped through uncaught. Found
+			// by FuzzValidateSilenceMatchers in CI.
+			name:      "invalid regex on a NEGATIVE matcher is still rejected",
+			matchers:  []models.SilenceMatcher{{Name: "instance", Value: "(00000000", IsEqual: false, IsRegex: true}},
+			wantErr:   true,
+			errSubstr: "invalid regular expression",
+		},
+		{
 			name: "valid RE2 syntax that JS RegExp rejects (inline flag)",
 			// (?i) is valid RE2 syntax (Go's regexp = RE2, same engine as Alertmanager)
 			// even though it fails to compile as a JS RegExp in the frontend preview.

--- a/backend/internal/api/silence_validation_test.go
+++ b/backend/internal/api/silence_validation_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+func validMatcher() models.SilenceMatcher {
+	return models.SilenceMatcher{Name: "alertname", Value: "Test", IsEqual: true, IsRegex: false}
+}
+
+func TestValidateSilenceMatchers(t *testing.T) {
+	tests := []struct {
+		name      string
+		matchers  []models.SilenceMatcher
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid single matcher",
+			matchers: []models.SilenceMatcher{validMatcher()},
+		},
+		{
+			name:      "empty matcher list",
+			matchers:  []models.SilenceMatcher{},
+			wantErr:   true,
+			errSubstr: "at least one matcher",
+		},
+		{
+			name:      "nil matcher list",
+			matchers:  nil,
+			wantErr:   true,
+			errSubstr: "at least one matcher",
+		},
+		{
+			name:      "empty matcher name",
+			matchers:  []models.SilenceMatcher{{Name: "", Value: "x", IsEqual: true}},
+			wantErr:   true,
+			errSubstr: "name must not be empty",
+		},
+		{
+			name:      "invalid regex",
+			matchers:  []models.SilenceMatcher{{Name: "instance", Value: "a(", IsEqual: true, IsRegex: true}},
+			wantErr:   true,
+			errSubstr: "invalid regular expression",
+		},
+		{
+			name: "valid RE2 syntax that JS RegExp rejects (inline flag)",
+			// (?i) is valid RE2 syntax (Go's regexp = RE2, same engine as Alertmanager)
+			// even though it fails to compile as a JS RegExp in the frontend preview.
+			matchers: []models.SilenceMatcher{{Name: "instance", Value: "(?i)watchdog", IsEqual: true, IsRegex: true}},
+		},
+		{
+			name: "equal matcher on empty value matches empty string but a second matcher is meaningful",
+			matchers: []models.SilenceMatcher{
+				{Name: "instance", Value: "", IsEqual: true, IsRegex: false},
+				validMatcher(),
+			},
+		},
+		{
+			name:      "only a matcher matching the empty string",
+			matchers:  []models.SilenceMatcher{{Name: "instance", Value: "", IsEqual: true, IsRegex: false}},
+			wantErr:   true,
+			errSubstr: "must not match the empty string",
+		},
+		{
+			name:      "only a negative matcher matching empty (foo != x matches empty since x != \"\")",
+			matchers:  []models.SilenceMatcher{{Name: "instance", Value: "x", IsEqual: false, IsRegex: false}},
+			wantErr:   true,
+			errSubstr: "must not match the empty string",
+		},
+		{
+			name:     "negative matcher with empty value does NOT match empty (meaningful)",
+			matchers: []models.SilenceMatcher{{Name: "instance", Value: "", IsEqual: false, IsRegex: false}},
+		},
+		{
+			name:      "regex matching empty string (.*) alone is not meaningful",
+			matchers:  []models.SilenceMatcher{{Name: "instance", Value: ".*", IsEqual: true, IsRegex: true}},
+			wantErr:   true,
+			errSubstr: "must not match the empty string",
+		},
+		{
+			// !~ "web1" is satisfied by almost everything, including a missing/empty
+			// label ("" doesn't match "web1" either) — so alone it's not meaningful.
+			name:      "negative regex whose pattern does not match empty is itself not meaningful",
+			matchers:  []models.SilenceMatcher{{Name: "instance", Value: "web1", IsEqual: false, IsRegex: true}},
+			wantErr:   true,
+			errSubstr: "must not match the empty string",
+		},
+		{
+			// !~ ".*" never matches anything (everything matches ".*", so its negation
+			// is never true) — including the empty string, which is exactly what makes
+			// this matcher "meaningful" per the same empty-string check.
+			name:     "negative regex whose pattern DOES match empty is meaningful",
+			matchers: []models.SilenceMatcher{{Name: "instance", Value: ".*", IsEqual: false, IsRegex: true}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSilenceMatchers(tt.matchers)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.errSubstr)
+			}
+		})
+	}
+}
+
+func TestSanitizeAMMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "extracts message field from JSON error body",
+			in:   `{"message": "silence must contain at least one matcher"}`,
+			want: "silence must contain at least one matcher",
+		},
+		{
+			name: "collapses newlines and extra whitespace",
+			in:   "line one\nline   two\n",
+			want: "line one line two",
+		},
+		{
+			name: "falls back to a generic message for an empty body",
+			in:   "",
+			want: "alertmanager rejected the request",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeAMMessage(tt.in); got != tt.want {
+				t.Errorf("sanitizeAMMessage(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("truncates a very long message", func(t *testing.T) {
+		long := strings.Repeat("a", 1000)
+		got := sanitizeAMMessage(long)
+		if len([]rune(got)) > 301 {
+			t.Errorf("expected truncated message, got length %d", len([]rune(got)))
+		}
+		if !strings.HasSuffix(got, "…") {
+			t.Errorf("expected truncated message to end with ellipsis, got %q", got)
+		}
+	})
+}
+
+func TestIsUniqueViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"sqlite unique violation", errors.New("insert silence template: UNIQUE constraint failed: silence_templates.name"), true},
+		{"postgres unique violation", errors.New(`insert silence template: duplicate key value violates unique constraint "silence_templates_name_key"`), true},
+		{"unrelated error", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUniqueViolation(tt.err); got != tt.want {
+				t.Errorf("isUniqueViolation(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/api/silences.go
+++ b/backend/internal/api/silences.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -73,6 +73,20 @@ func (s *Server) createSilence(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "unknown cluster")
 	}
 
+	modelMatchers := make([]models.SilenceMatcher, len(body.Matchers))
+	for i, m := range body.Matchers {
+		modelMatchers[i] = models.SilenceMatcher{IsEqual: m.IsEqual, IsRegex: m.IsRegex, Name: m.Name, Value: m.Value}
+	}
+	if err := validateSilenceMatchers(modelMatchers); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if !body.EndsAt.After(body.StartsAt) {
+		return echo.NewHTTPError(http.StatusBadRequest, "endsAt must be after startsAt")
+	}
+	if !body.EndsAt.After(time.Now()) {
+		return echo.NewHTTPError(http.StatusBadRequest, "endsAt must be in the future")
+	}
+
 	ctx, cancel := context.WithTimeout(c.Request().Context(), 10*time.Second)
 	defer cancel()
 
@@ -86,6 +100,9 @@ func (s *Server) createSilence(c echo.Context) error {
 		createdBy = u.Username
 		performedBy = u.Username
 	}
+	if createdBy == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "createdBy is required")
+	}
 
 	postable := amclient.PostableSilence{
 		ID:        body.ID,
@@ -97,14 +114,23 @@ func (s *Server) createSilence(c echo.Context) error {
 	}
 	id, err := cl.CreateSilence(ctx, postable)
 	if err != nil {
+		var amErr *amclient.AMError
+		if errors.As(err, &amErr) && amErr.StatusCode >= 400 && amErr.StatusCode < 500 {
+			slog.Warn("alertmanager rejected silence", "cluster", body.Cluster, "status", amErr.StatusCode, "err", err)
+			return echo.NewHTTPError(http.StatusBadRequest, sanitizeAMMessage(amErr.Body))
+		}
 		slog.Error("create silence failed", "cluster", body.Cluster, "err", err)
 		return echo.NewHTTPError(http.StatusBadGateway, "alertmanager request failed")
 	}
 
-	// Alertmanager may return a new ID instead of updating in-place.
-	// Expire the old silence to prevent duplicates.
+	// Alertmanager may return a new ID instead of updating in-place (it does this
+	// itself whenever matchers or startsAt change on an update — see PostableSilence
+	// handling in Alertmanager's silence.Set). Expire the old silence defensively to
+	// prevent duplicates in case Alertmanager didn't already do so.
 	if body.ID != "" && id != body.ID {
-		_ = cl.DeleteSilence(ctx, body.ID)
+		if err := cl.DeleteSilence(ctx, body.ID); err != nil {
+			slog.Warn("expire old silence after id change failed", "cluster", body.Cluster, "old_id", body.ID, "err", err)
+		}
 	}
 
 	if body.Fingerprint != "" {
@@ -144,6 +170,11 @@ func (s *Server) deleteSilence(c echo.Context) error {
 	defer cancel()
 
 	if err := cl.DeleteSilence(ctx, silenceID); err != nil {
+		var amErr *amclient.AMError
+		if errors.As(err, &amErr) && amErr.StatusCode >= 400 && amErr.StatusCode < 500 {
+			slog.Warn("alertmanager rejected silence deletion", "cluster", clusterName, "id", silenceID, "status", amErr.StatusCode, "err", err)
+			return echo.NewHTTPError(http.StatusBadRequest, sanitizeAMMessage(amErr.Body))
+		}
 		slog.Error("delete silence failed", "cluster", clusterName, "id", silenceID, "err", err)
 		return echo.NewHTTPError(http.StatusBadGateway, "alertmanager request failed")
 	}
@@ -224,8 +255,8 @@ func (s *Server) createSilenceTemplate(c echo.Context) error {
 	if len([]rune(body.Reason)) > 2_000 {
 		return echo.NewHTTPError(http.StatusBadRequest, "reason too long (max 2000 characters)")
 	}
-	if len(body.Matchers) == 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "at least one matcher is required")
+	if err := validateSilenceMatchers(body.Matchers); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	// Generate a unique ID for the template.
@@ -233,9 +264,7 @@ func (s *Server) createSilenceTemplate(c echo.Context) error {
 
 	template, err := s.store.CreateSilenceTemplate(id, body.Name, body.Matchers, body.Reason)
 	if err != nil {
-		// Check for unique constraint violation (name already exists).
-		if err.Error() == "insert silence template: UNIQUE constraint failed: silence_templates.name" ||
-			err.Error() == "insert silence template: duplicate key value violates unique constraint \"silence_templates_name_key\"" {
+		if isUniqueViolation(err) {
 			return echo.NewHTTPError(http.StatusConflict, "template name already exists")
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create template")
@@ -282,14 +311,13 @@ func (s *Server) updateSilenceTemplate(c echo.Context) error {
 	if len([]rune(body.Reason)) > 2_000 {
 		return echo.NewHTTPError(http.StatusBadRequest, "reason too long (max 2000 characters)")
 	}
-	if len(body.Matchers) == 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "at least one matcher is required")
+	if err := validateSilenceMatchers(body.Matchers); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	template, err := s.store.UpdateSilenceTemplate(id, body.Name, body.Matchers, body.Reason)
 	if err != nil {
-		// Check for unique constraint violation (name already exists for different template).
-		if strings.Contains(err.Error(), "UNIQUE constraint failed") || strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+		if isUniqueViolation(err) {
 			return echo.NewHTTPError(http.StatusConflict, "template name already exists")
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update template")

--- a/backend/internal/api/silences_test.go
+++ b/backend/internal/api/silences_test.go
@@ -160,7 +160,7 @@ func TestCreateSilence_HappyPath(t *testing.T) {
 	now := time.Now().UTC()
 	body := map[string]interface{}{
 		"cluster":   "testcluster",
-		"matchers":  []interface{}{},
+		"matchers":  []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": false, "value": "Test"}},
 		"startsAt":  now.Format(time.RFC3339),
 		"endsAt":    now.Add(time.Hour).Format(time.RFC3339),
 		"createdBy": "alice",
@@ -297,7 +297,7 @@ func TestCreateSilence_AMError(t *testing.T) {
 	now := time.Now().UTC()
 	body := map[string]interface{}{
 		"cluster":   "testcluster",
-		"matchers":  []interface{}{},
+		"matchers":  []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": false, "value": "Test"}},
 		"startsAt":  now.Format(time.RFC3339),
 		"endsAt":    now.Add(time.Hour).Format(time.RFC3339),
 		"createdBy": "alice",
@@ -440,7 +440,7 @@ func TestCreateSilence_ExpireOldSilenceWhenAMReturnsNewID(t *testing.T) {
 	body := map[string]interface{}{
 		"cluster":   "testcluster",
 		"id":        "old-silence-id",
-		"matchers":  []interface{}{},
+		"matchers":  []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": false, "value": "Test"}},
 		"startsAt":  now.Format(time.RFC3339),
 		"endsAt":    now.Add(time.Hour).Format(time.RFC3339),
 		"createdBy": "alice",
@@ -484,7 +484,7 @@ func TestCreateSilence_NoDeleteWhenSameIDReturned(t *testing.T) {
 	body := map[string]interface{}{
 		"cluster":   "testcluster",
 		"id":        "same-silence-id",
-		"matchers":  []interface{}{},
+		"matchers":  []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": false, "value": "Test"}},
 		"startsAt":  now.Format(time.RFC3339),
 		"endsAt":    now.Add(time.Hour).Format(time.RFC3339),
 		"createdBy": "alice",
@@ -519,7 +519,7 @@ func TestCreateSilence_AuthMode_UsesContextUserForAudit(t *testing.T) {
 	now := time.Now().UTC()
 	body := map[string]interface{}{
 		"cluster":     "testcluster",
-		"matchers":    []interface{}{},
+		"matchers":    []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": false, "value": "Test"}},
 		"startsAt":    now.Format(time.RFC3339),
 		"endsAt":      now.Add(time.Hour).Format(time.RFC3339),
 		"createdBy":   "spoofed",
@@ -547,5 +547,192 @@ func TestCreateSilence_AuthMode_UsesContextUserForAudit(t *testing.T) {
 	}
 	if events[0].PerformedBy != "real-user" {
 		t.Fatalf("performedBy = %q, want real-user", events[0].PerformedBy)
+	}
+}
+
+func TestCreateSilence_Validation(t *testing.T) {
+	now := time.Now().UTC()
+	validMatchers := []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": false, "value": "Test"}}
+
+	tests := []struct {
+		name string
+		body map[string]interface{}
+	}{
+		{
+			name: "empty matcher list",
+			body: map[string]interface{}{
+				"cluster": "testcluster", "matchers": []interface{}{},
+				"startsAt": now.Format(time.RFC3339), "endsAt": now.Add(time.Hour).Format(time.RFC3339),
+				"createdBy": "alice", "comment": "test",
+			},
+		},
+		{
+			name: "matcher with empty name",
+			body: map[string]interface{}{
+				"cluster":  "testcluster",
+				"matchers": []interface{}{map[string]interface{}{"name": "", "isEqual": true, "isRegex": false, "value": "x"}},
+				"startsAt": now.Format(time.RFC3339), "endsAt": now.Add(time.Hour).Format(time.RFC3339),
+				"createdBy": "alice", "comment": "test",
+			},
+		},
+		{
+			name: "matcher with invalid regex",
+			body: map[string]interface{}{
+				"cluster":  "testcluster",
+				"matchers": []interface{}{map[string]interface{}{"name": "instance", "isEqual": true, "isRegex": true, "value": "a("}},
+				"startsAt": now.Format(time.RFC3339), "endsAt": now.Add(time.Hour).Format(time.RFC3339),
+				"createdBy": "alice", "comment": "test",
+			},
+		},
+		{
+			name: "only a matcher matching the empty string",
+			body: map[string]interface{}{
+				"cluster":  "testcluster",
+				"matchers": []interface{}{map[string]interface{}{"name": "instance", "isEqual": true, "isRegex": false, "value": ""}},
+				"startsAt": now.Format(time.RFC3339), "endsAt": now.Add(time.Hour).Format(time.RFC3339),
+				"createdBy": "alice", "comment": "test",
+			},
+		},
+		{
+			name: "endsAt before startsAt",
+			body: map[string]interface{}{
+				"cluster": "testcluster", "matchers": validMatchers,
+				"startsAt": now.Format(time.RFC3339), "endsAt": now.Add(-time.Hour).Format(time.RFC3339),
+				"createdBy": "alice", "comment": "test",
+			},
+		},
+		{
+			name: "endsAt in the past",
+			body: map[string]interface{}{
+				"cluster": "testcluster", "matchers": validMatchers,
+				"startsAt": now.Add(-2 * time.Hour).Format(time.RFC3339), "endsAt": now.Add(-time.Hour).Format(time.RFC3339),
+				"createdBy": "alice", "comment": "test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			am := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				t.Fatal("alertmanager should not be called when validation fails")
+			}))
+			defer am.Close()
+
+			srv := newTestServerWithAM(t, am.URL)
+			e := echo.New()
+			b, _ := json.Marshal(tt.body)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/silences", bytes.NewReader(b))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := srv.createSilence(c)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			he, ok := err.(*echo.HTTPError)
+			if !ok || he.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %v", err)
+			}
+		})
+	}
+}
+
+// A valid RE2 pattern using inline-flag syntax (e.g. `(?i)`) that a browser's
+// JS RegExp can't compile must still be accepted server-side — Go's regexp
+// package is RE2, the same engine Alertmanager uses.
+func TestCreateSilence_AcceptsRE2OnlySyntax(t *testing.T) {
+	am := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(amclient.PostSilenceResponse{SilenceID: "new-silence"}) //nolint:errcheck
+	}))
+	defer am.Close()
+
+	srv := newTestServerWithAM(t, am.URL)
+	e := echo.New()
+
+	now := time.Now().UTC()
+	body := map[string]interface{}{
+		"cluster":   "testcluster",
+		"matchers":  []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": true, "value": "(?i)watchdog"}},
+		"startsAt":  now.Format(time.RFC3339),
+		"endsAt":    now.Add(time.Hour).Format(time.RFC3339),
+		"createdBy": "alice",
+		"comment":   "test silence",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/silences", bytes.NewReader(b))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := srv.createSilence(c); err != nil {
+		t.Fatalf("createSilence: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201", rec.Code)
+	}
+}
+
+func TestCreateSilence_AMValidationErrorPassthrough(t *testing.T) {
+	am := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message": "silence must not match all alerts"}`))
+	}))
+	defer am.Close()
+
+	srv := newTestServerWithAM(t, am.URL)
+	e := echo.New()
+
+	now := time.Now().UTC()
+	body := map[string]interface{}{
+		"cluster":   "testcluster",
+		"matchers":  []interface{}{map[string]interface{}{"name": "alertname", "isEqual": true, "isRegex": false, "value": "Test"}},
+		"startsAt":  now.Format(time.RFC3339),
+		"endsAt":    now.Add(time.Hour).Format(time.RFC3339),
+		"createdBy": "alice",
+		"comment":   "test silence",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/silences", bytes.NewReader(b))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := srv.createSilence(c)
+	if err == nil {
+		t.Fatal("expected error for AM 400")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %v", err)
+	}
+	if !contains(he.Message.(string), "silence must not match all alerts") {
+		t.Errorf("expected AM message relayed, got: %v", he.Message)
+	}
+}
+
+func TestDeleteSilence_AMValidationErrorPassthrough(t *testing.T) {
+	am := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "silence already expired", http.StatusGone)
+	}))
+	defer am.Close()
+
+	srv := newTestServerWithAM(t, am.URL)
+	e := echo.New()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/?cluster=testcluster", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("silence-1")
+
+	err := srv.deleteSilence(c)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for AM 4xx passthrough, got %v", err)
 	}
 }

--- a/frontend/e2e/functional/none/silences-form-templates.spec.ts
+++ b/frontend/e2e/functional/none/silences-form-templates.spec.ts
@@ -10,6 +10,23 @@ async function clearAllTemplates(baseURL: string): Promise<void> {
   }
 }
 
+/**
+ * Fills the first (blank) matcher row with a complete name+value pair — a
+ * silence needs at least one such matcher before Preview can enable, so
+ * tests that assert Preview's enabled state for some OTHER reason (a
+ * missing reason, no cluster selected, ...) need this filled in first to
+ * isolate the thing they're actually testing.
+ */
+async function fillFirstMatcher(page: import('@playwright/test').Page, name: string, value: string) {
+  await page.getByRole('button', { name: 'label' }).first().click()
+  const searchInput = page.getByPlaceholder('Search…').first()
+  await searchInput.fill(name)
+  await searchInput.press('Enter')
+  const valueInput = page.getByPlaceholder('value').first()
+  await valueInput.fill(value)
+  await valueInput.press('Enter')
+}
+
 test('F1 silence form opens and closes via Cancel', async ({ page }) => {
   await dismissNoAuthNotice(page)
 
@@ -56,6 +73,7 @@ test('F14 reason is required before preview is enabled', async ({ page }) => {
   await expect(page.getByText('Create Silence').first()).toBeVisible()
 
   await page.getByPlaceholder('Your name').fill('e2e-user')
+  await fillFirstMatcher(page, 'alertname', 'Test')
 
   const previewButton = page.getByRole('button', { name: 'Preview' })
   await expect(previewButton).toBeDisabled()
@@ -73,6 +91,7 @@ test('F2 submit requires at least one selected cluster', async ({ page }) => {
 
   await page.getByPlaceholder('Your name').fill('e2e-user')
   await page.getByPlaceholder('Reason for the silence…').fill('Planned maintenance')
+  await fillFirstMatcher(page, 'alertname', 'Test')
 
   const previewButton = page.getByRole('button', { name: 'Preview' })
   await expect(previewButton).toBeEnabled()

--- a/frontend/src/components/silences/SilenceForm.tsx
+++ b/frontend/src/components/silences/SilenceForm.tsx
@@ -742,6 +742,10 @@ export function SilenceForm({
   const liveMatchCount = matchedAlerts.length
 
   const hasActiveMatchers = matchers.some((m) => m.name && m.value)
+  // A row with only the name or only the value filled in is neither a valid matcher nor an
+  // intentionally-blank placeholder row (which has both empty) — silently dropping it at submit
+  // (the old behavior) makes the silence broader than the user intended without any signal.
+  const incompleteMatchers = matchers.filter((m) => Boolean(m.name) !== Boolean(m.value))
   const hasUnevaluableRegex = useMemo(
     () => hasUnevaluableRegexMatcher(buildLabelMatchers()),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -823,7 +827,9 @@ export function SilenceForm({
     effectiveCreatedBy.trim() &&
     selectedClusters.length > 0 &&
     Boolean(startsAt) &&
-    Boolean(endsAt)
+    Boolean(endsAt) &&
+    hasActiveMatchers &&
+    incompleteMatchers.length === 0
 
   // ── Form step ────────────────────────────────────────────────────────────────
 
@@ -1050,6 +1056,19 @@ export function SilenceForm({
               <Plus className="mr-1 h-3 w-3" />
               Add matcher
             </Button>
+
+            {/* Incomplete-matcher warning — blocks submit (see canSubmit) rather than silently
+                dropping the row, which would make the silence broader than intended. */}
+            {incompleteMatchers.length > 0 && (
+              <div className="flex gap-2.5 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2.5 text-destructive">
+                <CircleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                <p className="text-xs">
+                  {incompleteMatchers.length === 1
+                    ? 'One matcher is missing a label name or a value — fill it in or remove the row.'
+                    : `${incompleteMatchers.length} matchers are missing a label name or a value — fill them in or remove the rows.`}
+                </p>
+              </div>
+            )}
 
             {/* Unevaluable regex warning — pattern doesn't compile in the browser (e.g. RE2-only
                 syntax like `(?i)`), so the affected-alerts count below can't be trusted: matchers


### PR DESCRIPTION
## Summary
(Recreated against main after the stacked-PR base-branch-deletion issue — see #67's history. Same content as the original #63.)

Part 2/6 of the silence-subsystem review.

- Backend accepted any matcher list — including an empty one, which Alertmanager itself rejects — and forwarded it unvalidated.
- Adds `validateSilenceMatchers` (checked before the AM call): at least one matcher, no empty names, every regex must compile, and at least one *positive* matcher must not match the empty string — verified **empirically against a running Alertmanager 0.32.2**. Includes a follow-up fix (second commit) for a mistake in this exact rule that wrongly rejected valid negative matchers, caught by the differential E2E test added in the final PR of this stack.
- Alertmanager's HTTP client returns a typed `*AMError`; create/delete handlers relay AM's own 4xx rejections as 400 with a sanitized message instead of a generic 502.
- `SilenceForm` blocks Preview until at least one matcher has both a name and a value.
- Unifies template create/update's unique-constraint detection.

## Test plan
- [x] `go test -race ./...` incl. `silence_validation_test.go`, `silence_validation_fuzz_test.go`
- [x] `pnpm build`, `pnpm lint`, updated e2e specs (F2, F14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)