### PR TITLE
test(silences): add differential E2E specs against real Alertmanager

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -356,6 +356,8 @@ GET    /api/v1/alerts/:fingerprint/claims/history full_protect? → []Claim  ?cl
 
 # ── Silences (proxy → Alertmanager) ──────────────────────────────────────────
 GET    /api/v1/silences                          full_protect?  → []Silence  ?cluster=
+#        a cluster whose silence fetch fails is skipped (best-effort, logged via slog.Warn)
+#        rather than failing the whole request — its silences are simply absent from the response
 POST   /api/v1/silences                          Auth  (write)  → { id }
 #        validated server-side before the AM call (silence_validation.go validateSilenceMatchers):
 #        ≥1 matcher, no empty matcher names, every regex must compile (Go regexp = RE2, same
@@ -700,9 +702,14 @@ with its own `*alertmanager.Client`); `Cluster.AlertmanagerURL` /
   e.g. "2/2 members up", amber when degraded).
 - `Cluster.CreateSilence` / `DeleteSilence` send to the first healthy member
   (config order, from the cached up-state set by the last `FetchAlerts`),
-  retrying once against the next member on transport failure — never to all
-  members, since gossip already replicates and posting to every member would
-  create duplicates.
+  retrying once against the next member on transport failure or a 5xx
+  response — never to all members, since gossip already replicates and
+  posting to every member would create duplicates. Does NOT retry a 4xx
+  (`isRetryableWriteError` in `poll.go`): Alertmanager already evaluated and
+  rejected the request on its merits, so a second member would reject it
+  identically — retrying only adds latency and, for the non-idempotent
+  create, risks a duplicate if the first response was lost after
+  Alertmanager had already applied the write.
 - Enrichment (`cluster/enrich.go`, `enrichMerged`) — moved here from
   `history` — builds `EnrichedAlert` (incl. `@receiver` label) from merged
   alerts; lives in `cluster` because `history` imports `cluster` (not the

--- a/.agents/lessons.md
+++ b/.agents/lessons.md
@@ -9,6 +9,31 @@ instead of duplicating.
 
 ---
 
+## A plausible-sounding Alertmanager validation rule can still be wrong — verify against a real instance
+
+**Symptom**: A new backend check (`validateSilenceMatchers`, added to reject
+matchers Alertmanager itself would reject) silently rejected a legitimate
+`instance!~"web"` silence with 400 "must not match the empty string" — no
+error surfaced anywhere except a differential E2E test noticing the silence
+was simply never created.
+**Cause**: The check ("at least one matcher must not match the empty
+string") was implemented symmetrically for positive AND negative matchers.
+Reasoning from first principles about what AM's rule "should" do (and even
+writing consistent unit tests around that reasoning) produced a self-coherent
+but factually wrong model: real Alertmanager (verified via direct API calls,
+bypassing Jarvis) only applies this check to positive matchers (`=`, `=~`) —
+negative matchers (`!=`, `!~`) are always accepted, since being broad/exclusionary
+is their entire point (e.g. `env!=kube-system`).
+**Rule**: For any check meant to mirror a rule enforced by an external system
+(Alertmanager, but the same applies to any upstream API), verify the actual
+behavior with direct calls to that system — `curl` it — rather than trusting
+a mental model, even one that produces passing self-consistent unit tests.
+Unit tests against your own reference implementation can only catch
+regressions from that implementation; they cannot catch the implementation
+itself being wrong. See `frontend/e2e/functional/none/silence-matching-semantics.spec.ts`
+(differential tests against a real Alertmanager) and
+`tmp/fable/review_silence.md` T-06 for the broader pattern this guards against.
+
 ## Silence matchers must exclude pseudo-labels (`@receiver`, `@cluster`, `receiver`)
 
 **Symptom**: One-click Fast-Silence created a silence, but the alert never

--- a/backend/internal/api/silences.go
+++ b/backend/internal/api/silences.go
@@ -27,7 +27,11 @@ func (s *Server) getSilences(c echo.Context) error {
 		}
 		raw, err := cl.FetchSilences(ctx, nil)
 		if err != nil {
-			continue // best-effort
+			// Best-effort: a cluster's silences are simply missing from the response rather
+			// than failing the whole request, but log it — otherwise this shows up to users
+			// only as an unexplained gap (e.g. a silence badge that should be there isn't).
+			slog.Warn("fetch silences failed", "cluster", cl.Name, "err", err)
+			continue
 		}
 		for _, rs := range raw {
 			allSilences = append(allSilences, convertSilence(rs, cl.Name, cl.AlertmanagerLinkURL))
@@ -239,9 +243,9 @@ func (s *Server) getSilenceTemplates(c echo.Context) error {
 // POST /api/v1/silence-templates
 func (s *Server) createSilenceTemplate(c echo.Context) error {
 	var body struct {
-		Name    string                  `json:"name"`
+		Name     string                  `json:"name"`
 		Matchers []models.SilenceMatcher `json:"matchers"`
-		Reason  string                  `json:"reason"`
+		Reason   string                  `json:"reason"`
 	}
 	if err := c.Bind(&body); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
@@ -295,9 +299,9 @@ func (s *Server) updateSilenceTemplate(c echo.Context) error {
 	}
 
 	var body struct {
-		Name    string                  `json:"name"`
+		Name     string                  `json:"name"`
 		Matchers []models.SilenceMatcher `json:"matchers"`
-		Reason  string                  `json:"reason"`
+		Reason   string                  `json:"reason"`
 	}
 	if err := c.Bind(&body); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")

--- a/backend/internal/cluster/poll.go
+++ b/backend/internal/cluster/poll.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -146,9 +147,15 @@ func (c *Cluster) PingAll(ctx context.Context) []MemberStatus {
 }
 
 // CreateSilence sends the silence to the first healthy member (config
-// order); on transport failure, retries once against the next healthy
-// member. Never sent to all members — gossip replicates silences between
-// real HA members, so posting to every member would create duplicates.
+// order); on transport failure or a 5xx response, retries once against the
+// next healthy member. Never sent to all members — gossip replicates
+// silences between real HA members, so posting to every member would create
+// duplicates. Does NOT retry a 4xx response (see isRetryableWriteError) — the
+// request reached Alertmanager and was rejected on its merits (invalid
+// matcher, bad ID, …); a second member will reject it identically, so
+// retrying only adds latency and (for a non-idempotent create) risks a
+// duplicate if the first response was lost after Alertmanager had already
+// applied the write.
 func (c *Cluster) CreateSilence(ctx context.Context, s alertmanager.PostableSilence) (string, error) {
 	members := c.writeOrder()
 	if len(members) == 0 {
@@ -161,6 +168,9 @@ func (c *Cluster) CreateSilence(ctx context.Context, s alertmanager.PostableSile
 			return id, nil
 		}
 		lastErr = err
+		if !isRetryableWriteError(err) {
+			return "", err
+		}
 	}
 	return "", lastErr
 }
@@ -178,8 +188,24 @@ func (c *Cluster) DeleteSilence(ctx context.Context, id string) error {
 			return nil
 		}
 		lastErr = err
+		if !isRetryableWriteError(err) {
+			return err
+		}
 	}
 	return lastErr
+}
+
+// isRetryableWriteError reports whether a failed write is worth retrying
+// against another member: true for transport/network errors and 5xx
+// responses, false for a 4xx *alertmanager.AMError — Alertmanager received
+// and rejected the request on its merits, and every member enforces the
+// same validation.
+func isRetryableWriteError(err error) bool {
+	var amErr *alertmanager.AMError
+	if errors.As(err, &amErr) {
+		return amErr.StatusCode >= 500
+	}
+	return true
 }
 
 // attemptCount caps write retries at 2: the first healthy member, plus one retry.

--- a/backend/internal/cluster/poll_test.go
+++ b/backend/internal/cluster/poll_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -296,5 +297,58 @@ func TestDeleteSilence_AllMembersDown_ReturnsError(t *testing.T) {
 
 	if err := cl.DeleteSilence(context.Background(), "id1"); err == nil {
 		t.Fatal("expected error when all members are down")
+	}
+}
+
+// badRequestServer returns a 4xx like Alertmanager's own validation rejection.
+func badRequestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid matcher", http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCreateSilence_FirstMember4xx_DoesNotRetrySecondMember(t *testing.T) {
+	rejecting := badRequestServer(t)
+	secondCalled := false
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondCalled = true
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(alertmanager.PostSilenceResponse{SilenceID: "new-id"})
+	}))
+	defer second.Close()
+
+	cl := twoMemberCluster("prod", rejecting.URL, second.URL)
+	_, err := cl.CreateSilence(context.Background(), alertmanager.PostableSilence{Comment: "x"})
+	if err == nil {
+		t.Fatal("expected the 4xx to be returned, not retried away")
+	}
+	var amErr *alertmanager.AMError
+	if !errors.As(err, &amErr) || amErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected an AMError with status 400, got: %v", err)
+	}
+	if secondCalled {
+		t.Error("second member must not be called after a 4xx from the first — Alertmanager already rejected the request on its merits")
+	}
+}
+
+func TestDeleteSilence_FirstMember4xx_DoesNotRetrySecondMember(t *testing.T) {
+	rejecting := badRequestServer(t)
+	secondCalled := false
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	cl := twoMemberCluster("prod", rejecting.URL, second.URL)
+	err := cl.DeleteSilence(context.Background(), "id1")
+	if err == nil {
+		t.Fatal("expected the 4xx to be returned, not retried away")
+	}
+	if secondCalled {
+		t.Error("second member must not be called after a 4xx from the first")
 	}
 }

--- a/docs/testing-e2e.md
+++ b/docs/testing-e2e.md
@@ -215,6 +215,7 @@ Quick reference: which spec file covers what. Use this to find the right place f
 | `silences-page.spec.ts` | E1–E7, G1, G3 | List view persist, grouping, show/hide expired, sort, matcher filter, expiry status, re-create, expire single/group |
 | `silences-form-extended.spec.ts` | F3–F16 | Operator switch, regex tags+escaping, live match count, overlap warning, zero-match warning, duration presets, spinner normalisation, inline calendar, Now/Reset, end-after-start validation, author editability, reason required, preview summary, results step |
 | `silences-form-templates.spec.ts` | F1–F2, F14–F15, F17, G4–G8 | Form open/close (Cancel/ESC/backdrop), cluster guard, templates CRUD (create/apply/edit/delete) |
+| `silence-matching-semantics.spec.ts` | — | Differential tests against the real Alertmanager instance: form preview's affected-alerts count and actual post-submit suppression must agree — anchored `=~`/`!~` regex (not substring), regex-OR matcher escaping with metacharacter label values |
 | `settings.spec.ts` | H1–H11 | All settings: timeFormat, defaultViewMode, resolvedPageSize, defaultFilters, silenceDuration, defaultCreatorName, pollInterval, claimAnimation, reset defaults, persistence |
 | `no-auth-notice.spec.ts` | I1 | NoAuth notice appears and dismiss persists |
 | `websocket.spec.ts` | J1–J4 | Reconnect indicator (force-close via patched WebSocket), `alerts_update` / `claim_set` / `claim_released` / `comment_added` live events |

--- a/frontend/e2e/functional/none/silence-matching-semantics.spec.ts
+++ b/frontend/e2e/functional/none/silence-matching-semantics.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, waitForActiveAlerts, JARVIS_BASE_URL } from '../../support/fixtures'
+import { dismissNoAuthNotice } from '../../support/auth'
+import type { Page, Locator } from '@playwright/test'
+
+const AM_URL = process.env.E2E_ALERTMANAGER_URL ?? 'http://localhost:9094'
+
+/**
+ * Differential tests against a REAL Alertmanager: what the silence-form
+ * preview claims will be affected must match what Alertmanager actually
+ * suppresses after the silence is created. This is the class of bug from
+ * tmp/fable/review_silence.md (S-01) that unit tests against a fake
+ * reference implementation can't catch on their own — only Alertmanager
+ * itself is authoritative on its own matching semantics.
+ */
+
+async function clearAllAMSilences(): Promise<void> {
+  const res = await fetch(`${AM_URL}/api/v2/silences`)
+  if (!res.ok) return
+  const silences = (await res.json()) as Array<{ id: string; status?: { state?: string } }>
+  for (const silence of silences) {
+    if (silence.status?.state !== 'expired') {
+      await fetch(`${AM_URL}/api/v2/silence/${silence.id}`, { method: 'DELETE' })
+    }
+  }
+}
+
+async function openSilenceForm(page: Page) {
+  await page.getByRole('button', { name: 'Create silence' }).first().click()
+  const dialog = page.getByRole('dialog', { name: 'Create silence' })
+  await expect(dialog).toBeVisible({ timeout: 5_000 })
+  return dialog
+}
+
+/** Fills the label name of the first (only) matcher row. */
+async function fillSilenceLabel(dialog: Locator, labelName: string) {
+  const labelBtn = dialog.getByRole('button', { name: 'label' }).first()
+  await labelBtn.click()
+  const searchInput = dialog.getByPlaceholder('Search…').first()
+  await searchInput.fill(labelName)
+  await searchInput.press('Enter')
+}
+
+/** The value input of the first matcher row (TagValueInput's internal input). */
+function getValueInput(dialog: Locator): Locator {
+  return dialog.locator('.flex.min-h-8 input').first()
+}
+
+async function selectOperator(dialog: Locator, operator: '=' | '!=' | '=~' | '!~') {
+  await dialog.locator('select').first().selectOption(operator)
+}
+
+function matchBadge(dialog: Locator): Locator {
+  return dialog.locator('button').filter({ hasText: /affected alerts/ }).first()
+}
+
+async function matchCount(dialog: Locator): Promise<number> {
+  const text = await matchBadge(dialog).textContent()
+  return parseInt(text?.match(/\d+/)?.[0] ?? '0', 10)
+}
+
+async function fillAuthorReasonAndSubmit(dialog: Locator, reason: string) {
+  // Pin an explicit duration rather than relying on the ambient default —
+  // these tests assert real Alertmanager suppression a few seconds/polls
+  // later and must not race a short-lived silence.
+  await dialog.getByRole('button', { name: '1h', exact: true }).click()
+  await dialog.getByPlaceholder('Your name').fill('e2e-semantics')
+  await dialog.getByPlaceholder('Reason for the silence…').fill(reason)
+  await dialog.getByRole('button', { name: 'Preview' }).click()
+  await dialog.getByRole('button', { name: 'Create', exact: true }).click()
+  await expect(dialog.getByText('Silence submitted')).toBeVisible({ timeout: 10_000 })
+}
+
+/** Fetches an alert's status.state from Jarvis's own API by a label match (assumes uniqueness). */
+async function alertState(instance: string): Promise<string | undefined> {
+  const res = await fetch(`${JARVIS_BASE_URL}/api/v1/alerts`)
+  const alerts = (await res.json()) as Array<{ labels: Record<string, string>; status: { state: string } }>
+  return alerts.find((a) => a.labels.instance === instance)?.status.state
+}
+
+test.describe('Silence matching semantics (Alertmanager parity — S-01)', () => {
+  test.afterEach(async () => {
+    await clearAllAMSilences()
+  })
+
+  test('anchored =~ "web1" matches only web1, not web10 (preview agrees with Alertmanager)', async ({ page, am, jarvis }) => {
+    await dismissNoAuthNotice(page)
+    await am.fire([
+      { labels: { alertname: 'AnchorRegexTest', instance: 'web1' } },
+      { labels: { alertname: 'AnchorRegexTest', instance: 'web10' } },
+    ])
+    await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, 2)
+
+    await page.goto('/')
+    const dialog = await openSilenceForm(page)
+
+    await fillSilenceLabel(dialog, 'instance')
+    await selectOperator(dialog, '=~')
+    const valueInput = getValueInput(dialog)
+    await valueInput.fill('web1')
+    await valueInput.press('Enter')
+
+    await expect(matchBadge(dialog)).toBeVisible({ timeout: 8_000 })
+    // The core regression check: an unanchored (substring) implementation would report
+    // 2 here, since "web1" is a substring of "web10" — Alertmanager's anchored match
+    // silences only the exact "web1" instance.
+    await expect.poll(() => matchCount(dialog)).toBe(1)
+
+    await fillAuthorReasonAndSubmit(dialog, 'S-01 anchored =~ regression test')
+    await jarvis.poll()
+
+    await expect.poll(() => alertState('web1'), { timeout: 10_000 }).toBe('suppressed')
+    await expect.poll(() => alertState('web10'), { timeout: 10_000 }).toBe('active')
+  })
+
+  test('anchored !~ "web" DOES match "web1" — the fatal over-silencing case from the review', async ({ page, am, jarvis }) => {
+    await dismissNoAuthNotice(page)
+    await am.fire([{ labels: { alertname: 'AnchorNegRegexTest', instance: 'web1' } }])
+    await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, 1)
+
+    await page.goto('/')
+    const dialog = await openSilenceForm(page)
+
+    await fillSilenceLabel(dialog, 'instance')
+    await selectOperator(dialog, '!~')
+    const valueInput = getValueInput(dialog)
+    await valueInput.fill('web')
+    await valueInput.press('Enter')
+
+    await expect(matchBadge(dialog)).toBeVisible({ timeout: 8_000 })
+    // Before the S-01 fix, an unanchored implementation reported 0 here (substring "web"
+    // found inside "web1", so "!~ web" looked like "no match") while Alertmanager's
+    // anchored ^(?:web)$ does not match "web1", making the negative matcher true — it
+    // silenced the alert anyway. A silence created from a preview showing "0 affected"
+    // that actually suppresses alerts is exactly the dangerous case this guards against.
+    await expect.poll(() => matchCount(dialog)).toBe(1)
+
+    await fillAuthorReasonAndSubmit(dialog, 'S-01 anchored !~ regression test')
+    await jarvis.poll()
+
+    await expect.poll(() => alertState('web1'), { timeout: 10_000 }).toBe('suppressed')
+  })
+
+  test('regex-OR matcher with metacharacter label values matches only the listed literals, not lookalikes', async ({ page, am, jarvis }) => {
+    await dismissNoAuthNotice(page)
+    await am.fire([
+      { labels: { alertname: 'EscapeRegexTest', instance: '10.0.0.1' } },
+      { labels: { alertname: 'EscapeRegexTest', instance: '10.0.0.2' } },
+      // Decoy: if "." in the tag values were left unescaped (matching ANY character
+      // instead of a literal dot), the "10.0.0.1" pattern would also match this.
+      { labels: { alertname: 'EscapeRegexTest', instance: '10a0b0c1' } },
+    ])
+    await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, 3)
+
+    await page.goto('/')
+    const dialog = await openSilenceForm(page)
+
+    await fillSilenceLabel(dialog, 'instance')
+    await selectOperator(dialog, '=~')
+    const valueInput = getValueInput(dialog)
+    await valueInput.fill('10.0.0.1')
+    await valueInput.press('Enter')
+    await valueInput.fill('10.0.0.2')
+    await valueInput.press('Enter')
+
+    await expect(matchBadge(dialog)).toBeVisible({ timeout: 8_000 })
+    await expect.poll(() => matchCount(dialog)).toBe(2)
+
+    await fillAuthorReasonAndSubmit(dialog, 'S-01 regex-OR escaping regression test')
+    await jarvis.poll()
+
+    await expect.poll(() => alertState('10.0.0.1'), { timeout: 10_000 }).toBe('suppressed')
+    await expect.poll(() => alertState('10.0.0.2'), { timeout: 10_000 }).toBe('suppressed')
+    await expect.poll(() => alertState('10a0b0c1'), { timeout: 10_000 }).toBe('active')
+  })
+})

--- a/frontend/e2e/functional/none/silences-form-extended.spec.ts
+++ b/frontend/e2e/functional/none/silences-form-extended.spec.ts
@@ -249,7 +249,7 @@ test('F13 author field is editable in none auth mode', async ({ page }) => {
   await expect(authorInput).toHaveValue('test-author')
 })
 
-test('F15 preview step shows Start, Ende, Author, Reason, Cluster, Matcher', async ({ page, am, jarvis }) => {
+test('F15 preview step shows Start, End, Author, Reason, Cluster, Matcher', async ({ page, am, jarvis }) => {
   await dismissNoAuthNotice(page)
   await clearAllAMSilences()
   await am.fire(kubernetesAlerts)
@@ -280,7 +280,7 @@ test('F15 preview step shows Start, Ende, Author, Reason, Cluster, Matcher', asy
   // Use .text-muted-foreground spans for labels that are ONLY in the preview step
   // (to avoid false positives from the same text appearing in form-step field labels).
   await expect(dialog.getByText('Start').first()).toBeVisible({ timeout: 5_000 })
-  await expect(dialog.getByText('Ende').first()).toBeVisible()
+  await expect(dialog.getByText('End').first()).toBeVisible()
   await expect(dialog.getByText('Author').first()).toBeVisible()
   // "Reason" label — use exact span to avoid matching the value "Preview test reason"
   await expect(dialog.locator('.text-muted-foreground').filter({ hasText: /^Reason$/ }).first()).toBeVisible()

--- a/frontend/src/components/silences/SilenceForm.tsx
+++ b/frontend/src/components/silences/SilenceForm.tsx
@@ -1161,11 +1161,11 @@ export function SilenceForm({
             <DateTimePicker value={startsAt} onChange={handleStartsAtChange} />
           </div>
 
-          {/* Ende — duration spinners and calendar side by side, always in sync */}
+          {/* End — duration spinners and calendar side by side, always in sync */}
           <div>
             <div className="mb-2 flex items-center justify-between">
               <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Ende
+                End
               </label>
               <Button
                 type="button"
@@ -1362,7 +1362,7 @@ export function SilenceForm({
           <div className="grid grid-cols-[80px_1fr] gap-y-1.5">
             <span className="text-muted-foreground">Start</span>
             <span className="font-mono">{startsAt ? `${format(new Date(startsAt), 'yyyy-MM-dd HH:mm')} ${tzAbbr}` : '—'}</span>
-            <span className="text-muted-foreground">Ende</span>
+            <span className="text-muted-foreground">End</span>
             <span className="font-mono">{previewEnd} {tzAbbr} <span className="text-muted-foreground ml-1">({previewDuration})</span></span>
             <span className="text-muted-foreground">Author</span>
             <span>{effectiveCreatedBy}</span>

--- a/frontend/src/hooks/useSilences.ts
+++ b/frontend/src/hooks/useSilences.ts
@@ -65,26 +65,35 @@ export function useAckAlert() {
  * `alerts` (normally just one) using `buildGroupAckSilenceBody`'s
  * common-vs-varying label matchers — the same scope `SilenceForm`'s group
  * prefill would default to — instead of fanning out one exact-match silence
- * per alert. Thin wrapper over `useUpsertSilence` — reuses its cache
- * invalidation + poll trigger.
+ * per alert. Reuses `useUpsertSilence`'s per-write cache invalidation + poll
+ * trigger, but wraps the whole fan-out in its OWN mutation for `isPending`:
+ * calling `mutateAsync` more than once concurrently on a single `useMutation`
+ * (as the previous version did, once per cluster) makes that mutation's own
+ * `isPending` reflect whichever call most recently changed state rather than
+ * "is any of them still in flight" — harmless for a single-cluster group
+ * (the overwhelmingly common case) but incorrect for a multi-cluster one.
  */
 export function useGroupAckAlert() {
   const upsert = useUpsertSilence()
-  const ackGroup = (alerts: EnrichedAlert[], durationMinutes: number) => {
-    const byCluster = new Map<string, EnrichedAlert[]>()
-    for (const a of alerts) {
-      const list = byCluster.get(a.clusterName) ?? []
-      list.push(a)
-      byCluster.set(a.clusterName, list)
-    }
-    const createdBy = resolveCreatorName()
-    return Promise.all(
-      [...byCluster.values()].map((clusterAlerts) =>
-        upsert.mutateAsync(buildGroupAckSilenceBody(clusterAlerts, durationMinutes, createdBy)),
-      ),
-    )
-  }
-  return { ackGroup, isPending: upsert.isPending }
+  const fanOut = useMutation({
+    mutationFn: ({ alerts, durationMinutes }: { alerts: EnrichedAlert[]; durationMinutes: number }) => {
+      const byCluster = new Map<string, EnrichedAlert[]>()
+      for (const a of alerts) {
+        const list = byCluster.get(a.clusterName) ?? []
+        list.push(a)
+        byCluster.set(a.clusterName, list)
+      }
+      const createdBy = resolveCreatorName()
+      return Promise.all(
+        [...byCluster.values()].map((clusterAlerts) =>
+          upsert.mutateAsync(buildGroupAckSilenceBody(clusterAlerts, durationMinutes, createdBy)),
+        ),
+      )
+    },
+  })
+  const ackGroup = (alerts: EnrichedAlert[], durationMinutes: number) =>
+    fanOut.mutateAsync({ alerts, durationMinutes })
+  return { ackGroup, isPending: fanOut.isPending }
 }
 
 export function useDeleteSilence() {


### PR DESCRIPTION
## Summary
(Recreated against main — see #67's history for why.)

Final part 6/6 of the silence-subsystem review.

- Adds `silence-matching-semantics.spec.ts`: drives the actual silence form against a real Alertmanager instance and asserts the preview's affected-alerts count matches what Alertmanager actually suppresses after the silence is created.
- **This test class already caught a real bug in this stack**: an earlier commit's `validateSilenceMatchers` wrongly rejected valid negative matchers (e.g. `instance!~"web"`) as "not meaningful" — a mistake a self-consistent unit test suite couldn't have found, only caught by testing against real Alertmanager.
- Full existing `none`-mode functional suite (127 specs) re-verified green.
- Smaller robustness fixes: `getSilences` logs a cluster's silence-fetch failure instead of it being silently invisible; `Cluster.CreateSilence`/`DeleteSilence` no longer retry a 4xx against the second HA member; `useGroupAckAlert`'s `isPending` now reflects the whole multi-cluster fan-out; "Ende" → "End"; gofmt fixes.
- New lesson recorded in `.agents/lessons.md`.

## Test plan
- [x] `go test -race ./...`
- [x] `pnpm test:unit:coverage`, `pnpm build`, `pnpm lint`
- [x] Full isolated e2e stack, `none` mode: 125 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)