### PR TITLE
fix(alerts): redesign Fast-Silence menu, aligned submenu icon

### DIFF
--- a/.agents/lessons.md
+++ b/.agents/lessons.md
@@ -168,3 +168,22 @@ snapshots (`AlertStore` / `SilenceStore` / `MemberUpStates`), never from a
 synchronous AM call. Mutations write through to the snapshot + trigger a
 poll so the UI stays instant. When adding a read endpoint, ask: "does its
 cost scale with the number of open tabs?" — if yes, snapshot it.
+
+## e2e `/test/reset` didn't clear the 20-minute resolved-alert buffer
+
+**Symptom**: `silence-matching-semantics.spec.ts` flaked in CI with a wrong
+affected-alerts count (`silence-matching-semantics.spec.ts:135`), unrelated
+to the diff under test — pointed at cross-test state leakage.
+**Cause**: `POST /api/v1/test/reset` called `alertStore.Set(nil)` to clear
+alerts between tests. `Set` intentionally preserves `AlertStore`'s resolved
+buffer (alerts stay visible 20 minutes after resolving) — by design, `Set`
+only prunes buffer entries that reappear in the new active list, so `Set(nil)`
+touches the buffer not at all. A previous test's alert, resolved via
+`am.clearAll()` in the next test's fixture and picked up by the recorder's
+poll, landed in the buffer and leaked into `GET /api/v1/alerts` — which
+`SilenceForm`'s live affected-alerts preview reads unfiltered by state.
+**Rule**: `AlertStore.Reset()` (`internal/history/alert_store.go`) clears
+both the active list and the resolved buffer; `testReset` uses it instead of
+`Set(nil)`. `Set(nil)` keeps its production semantics for the real poll loop.
+Any store with a deliberately-persisted buffer/cache needs an explicit
+test-only full-wipe method — `Set(nil)`-shaped "clear" calls are not it.

--- a/backend/internal/api/testing_routes_e2e.go
+++ b/backend/internal/api/testing_routes_e2e.go
@@ -81,7 +81,7 @@ func (s *Server) testReset(c echo.Context) error {
 	if err := s.store.ResetForTesting(); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	s.alertStore.Set(nil)
+	s.alertStore.Reset()
 	s.silenceStore.Reset()
 	return c.NoContent(http.StatusNoContent)
 }

--- a/backend/internal/history/alert_store.go
+++ b/backend/internal/history/alert_store.go
@@ -30,6 +30,18 @@ func (s *AlertStore) Set(alerts []models.EnrichedAlert) {
 	}
 }
 
+// Reset clears both the active list and the resolved buffer. Unlike Set(nil),
+// which intentionally preserves the resolved buffer for its 20-minute
+// visibility window, Reset wipes the store entirely — used only by the e2e
+// test-reset route so a resolved alert from one test can't leak into the
+// next test's alert list for up to 20 minutes.
+func (s *AlertStore) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.alerts = nil
+	s.resolvedBuffer = nil
+}
+
 // Get returns a copy of all alerts: currently active + resolved buffer.
 func (s *AlertStore) Get() []models.EnrichedAlert {
 	s.mu.RLock()

--- a/backend/internal/history/alert_store_test.go
+++ b/backend/internal/history/alert_store_test.go
@@ -25,6 +25,22 @@ func TestAlertStore_SetGet(t *testing.T) {
 	}
 }
 
+func TestAlertStore_Reset(t *testing.T) {
+	s := &AlertStore{}
+	s.Set([]models.EnrichedAlert{makeAlert("fp1", "active")})
+	s.MarkResolvedForCluster("fp1", "")
+
+	if len(s.Get()) != 1 {
+		t.Fatalf("precondition: expected 1 alert in resolved buffer before Reset")
+	}
+
+	s.Reset()
+
+	if got := s.Get(); len(got) != 0 {
+		t.Errorf("Get() after Reset = %d alerts, want 0 (resolved buffer must be cleared too)", len(got))
+	}
+}
+
 func TestAlertStore_GetReturnsCopy(t *testing.T) {
 	s := &AlertStore{}
 	s.Set([]models.EnrichedAlert{makeAlert("fp1", "active")})

--- a/frontend/src/components/alerts/AckButton.tsx
+++ b/frontend/src/components/alerts/AckButton.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react'
 import { createPortal } from 'react-dom'
-import { Bell, BellOff, Check, ChevronDown, ChevronUp, Loader2, TriangleAlert } from 'lucide-react'
+import { Bell, BellOff, Check, ChevronDown, ChevronRight, ChevronUp, Loader2, TriangleAlert } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { LoginModal } from '@/components/auth/LoginModal'
 import { useAckAlert, useGroupAckAlert } from '@/hooks/useSilences'
@@ -69,8 +69,10 @@ const FEEDBACK_MS = 2500
 const MENU_CLOSE_MS = 140
 /** Vertical gap between the trigger and the menu. */
 const GAP = 6
-/** Conservative menu width used to decide whether it still fits right-aligned to the trigger's left edge. */
-const MENU_WIDTH_ESTIMATE = 220
+/** Fixed menu width (`w-60` below) — also used to decide whether it still fits right-aligned to the trigger's left edge. */
+const MENU_WIDTH_ESTIMATE = 240
+/** Placeholder coords for the aligned-menu first paint — off-screen so nothing flashes before `alignMenuToTrigger` (in a `useLayoutEffect`, so before the browser paints) moves it over the real trigger icon. */
+const OFFSCREEN = -9999
 
 /**
  * One-click Fast-Silence button with a duration menu. Hovering (or clicking /
@@ -106,6 +108,9 @@ export function AckButton({
   const feedbackTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
   const closeTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
   const triggerRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const menuIconRef = useRef<SVGSVGElement>(null)
+  const alignedRef = useRef(false)
   const durationRef = useRef<number>(FAST_SILENCE_DURATIONS[0].minutes)
   const activeAlerts = alerts.filter((a) => getEffectiveAlertState(a, silences) === 'active')
 
@@ -146,13 +151,28 @@ export function AckButton({
     const el = triggerRef.current
     if (!el) return
     const r = el.getBoundingClientRect()
+
+    if (onCreateSilence) {
+      // Real position depends on the menu's rendered width (its first button
+      // centers its content), which isn't known until it's in the DOM — park
+      // it off-screen and let the layout effect below move it over the
+      // trigger icon before paint. Always mirror the "Silence…" button's icon
+      // to the right of its label so the menu opens leftward from the
+      // trigger — there's always room in that direction (it opens inside the
+      // alert card/row itself), unlike rightward where a right-column trigger
+      // can run out of viewport.
+      alignedRef.current = false
+      setCoords({ top: OFFSCREEN, left: OFFSCREEN })
+      return
+    }
+
     const overflowsRight = r.left + MENU_WIDTH_ESTIMATE > window.innerWidth
     setCoords(
       overflowsRight
         ? { top: r.bottom + GAP, right: window.innerWidth - r.right }
         : { top: r.bottom + GAP, left: r.left },
     )
-  }, [])
+  }, [onCreateSilence])
 
   const openMenu = useCallback(() => {
     clearTimeout(closeTimer.current)
@@ -175,6 +195,31 @@ export function AckButton({
       window.removeEventListener('resize', close)
     }
   }, [menuOpen])
+
+  // Runs before paint once the (off-screen) menu is in the DOM: measures
+  // where its own Bell icon actually landed and shifts the whole menu so that
+  // icon lands exactly on top of the trigger's Bell icon.
+  useLayoutEffect(() => {
+    if (!menuOpen || !onCreateSilence || alignedRef.current) return
+    const trigger = triggerRef.current
+    const icon = menuIconRef.current
+    if (!trigger || !icon) return
+
+    const tr = trigger.getBoundingClientRect()
+    const ir = icon.getBoundingClientRect()
+    // Actual rendered width, not the static MENU_WIDTH_ESTIMATE guess used by
+    // the non-aligned path below (that one clamps before the menu exists at
+    // all) — clamping against an overestimate here would needlessly push a
+    // narrower menu further left/right than the icon alignment calls for.
+    const menuWidth = menuRef.current?.getBoundingClientRect().width ?? MENU_WIDTH_ESTIMATE
+    const dx = (tr.left + tr.width / 2) - (ir.left + ir.width / 2)
+    const dy = (tr.top + tr.height / 2) - (ir.top + ir.height / 2)
+    alignedRef.current = true
+    setCoords((c) => ({
+      top: Math.max(8, c.top + dy),
+      left: Math.max(8, Math.min((c.left ?? 0) + dx, window.innerWidth - menuWidth - 8)),
+    }))
+  }, [menuOpen, onCreateSilence])
 
   if (requireActive && activeAlerts.length === 0) return null
 
@@ -297,56 +342,57 @@ export function AckButton({
       {menuOpen &&
         createPortal(
           <div
+            ref={menuRef}
             role="menu"
             data-testid="alert-ack-menu"
             onMouseEnter={() => clearTimeout(closeTimer.current)}
             onMouseLeave={scheduleClose}
-            className="fixed z-[100] min-w-[8rem] rounded-md border border-border bg-popover p-1 shadow-lg"
+            className="fixed z-[100] w-60 rounded-xl border border-border bg-popover p-2 shadow-xl"
             style={{ top: coords.top, left: coords.left, right: coords.right }}
           >
             {onCreateSilence && (
-              <>
-                <button
-                  type="button"
-                  role="menuitem"
-                  data-testid="alert-ack-open-form"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    clearTimeout(closeTimer.current)
-                    setMenuOpen(false)
-                    onCreateSilence(alerts)
-                  }}
-                  className="flex w-full items-center justify-center gap-1.5 rounded border border-border bg-accent/40 px-2 py-1.5 text-center text-xs font-semibold text-popover-foreground hover:bg-accent hover:text-foreground cursor-pointer"
-                >
-                  <Bell className="h-3 w-3" />
+              <button
+                type="button"
+                role="menuitem"
+                data-testid="alert-ack-open-form"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  clearTimeout(closeTimer.current)
+                  setMenuOpen(false)
+                  onCreateSilence(alerts)
+                }}
+                className="flex w-full flex-row-reverse items-center gap-2 rounded-lg bg-link/10 px-2.5 py-2 text-left text-[13px] font-semibold text-link transition-colors hover:bg-link/15 cursor-pointer"
+              >
+                <Bell ref={menuIconRef} className="h-4 w-4 shrink-0" />
+                <ChevronRight className="h-3.5 w-3.5 shrink-0 opacity-60" />
+                <span className="min-w-0 flex-1">
                   Silence…
-                </button>
-                {activeAlerts.length > 0 && (
-                  <div className="my-1.5 flex items-center gap-2">
-                    <div className="h-px flex-1 bg-border" />
-                    <span className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">or</span>
-                    <div className="h-px flex-1 bg-border" />
-                  </div>
-                )}
-              </>
+                  <span className="block text-[11px] font-medium opacity-70">Open full form</span>
+                </span>
+              </button>
             )}
             {activeAlerts.length > 0 && (
               <>
-                <p className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                  {alerts.length > 1 ? `Fast-Silence ${activeAlerts.length} alerts for…` : 'Fast-Silence for…'}
-                </p>
-                {FAST_SILENCE_DURATIONS.map((d) => (
-                  <button
-                    key={d.minutes}
-                    type="button"
-                    role="menuitem"
-                    data-testid="alert-ack-option"
-                    onClick={pick(d.minutes)}
-                    className="flex w-full items-center rounded px-2 py-1 text-left text-xs text-popover-foreground hover:bg-accent hover:text-foreground cursor-pointer"
-                  >
-                    {d.label}
-                  </button>
-                ))}
+                <div className={cn('flex items-center gap-2 px-0.5', onCreateSilence && 'mb-1.5 mt-2')}>
+                  <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {alerts.length > 1 ? `Fast-Silence ${activeAlerts.length} alerts` : 'Fast-Silence'}
+                  </span>
+                  <div className="h-px flex-1 bg-border" />
+                </div>
+                <div className="grid grid-cols-4 gap-1">
+                  {FAST_SILENCE_DURATIONS.map((d) => (
+                    <button
+                      key={d.minutes}
+                      type="button"
+                      role="menuitem"
+                      data-testid="alert-ack-option"
+                      onClick={pick(d.minutes)}
+                      className="flex items-center justify-center rounded-lg border border-border bg-card px-1 py-1.5 text-xs font-semibold tabular-nums text-foreground transition-colors hover:border-link/40 hover:bg-link/10 hover:text-link cursor-pointer"
+                    >
+                      {d.label}
+                    </button>
+                  ))}
+                </div>
               </>
             )}
           </div>,

--- a/frontend/src/components/alerts/AlertCard.tsx
+++ b/frontend/src/components/alerts/AlertCard.tsx
@@ -267,7 +267,7 @@ export function AlertCard({
         title="Double-click to collapse"
       >
         <span className="break-all font-semibold leading-tight text-foreground">{alertname}</span>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2" title="">
           {showSeverityBadge && severityRaw && <AlertBadge severity={severity} />}
           {count > 1 && (
             <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-accent px-1.5 text-xs font-bold">

--- a/frontend/src/components/alerts/AlertDetailPanel.tsx
+++ b/frontend/src/components/alerts/AlertDetailPanel.tsx
@@ -610,7 +610,7 @@ export function AlertDetailPanel({
                   : (theme === 'light' ? 'bg-muted' : 'bg-slate-900'),
               )}
             >
-              <div className="mb-3 flex items-center justify-between gap-2">
+              <div className="mb-3 flex items-center justify-between gap-2 pr-8">
                 <div className={cn(
                   'flex items-center gap-1.5 text-xs font-semibold',
                   isPending
@@ -622,7 +622,7 @@ export function AlertDetailPanel({
                   <BellOff className="h-3 w-3 shrink-0" />
                   {isPending ? 'Silence pending' : 'Silence active'}
                 </div>
-                <div className="flex shrink-0 items-center gap-1">
+                <div className="flex shrink-0 items-center gap-2">
                   {isExpiring && (
                     <>
                       {([
@@ -737,12 +737,12 @@ export function AlertDetailPanel({
         {/* Expired silence banners */}
         {expiredSilences.map((s) => (
           <div key={s.id} className={cn('border-b border-border px-5 py-4', theme === 'light' ? 'bg-muted' : 'bg-slate-950')}>
-            <div className="mb-3 flex items-center justify-between gap-2">
+            <div className="mb-3 flex items-center justify-between gap-2 pr-8">
               <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
                 <BellOff className="h-3 w-3 shrink-0" />
                 Silence expired
               </div>
-              <div className="flex shrink-0 items-center gap-1">
+              <div className="flex shrink-0 items-center gap-2">
                 <button
                   className="flex items-center gap-1 rounded border border-border px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent cursor-pointer"
                   onClick={() => setSilenceFormTarget(s)}

--- a/scripts/fire-test-alerts.sh
+++ b/scripts/fire-test-alerts.sh
@@ -33,7 +33,7 @@ pause() {
 
 echo "==> Firing Kubernetes test alerts to ${AM} (randomized, ~2 min)"
 
-printf "  [1/10] KubePodCrashLooping (critical, payment-api, prod)..."
+printf "  [1/23] KubePodCrashLooping (critical, payment-api, prod)..."
 post '[{
   "labels": {
     "alertname": "KubePodCrashLooping",
@@ -56,7 +56,51 @@ post '[{
 }]'
 
 pause
-printf "  [2/10] KubeNodeNotReady (critical, worker-node-3, prod)..."
+printf "  [2/23] KubePodCrashLooping (critical, payment-api, prod) — 2nd pod (groups with #1)..."
+post '[{
+  "labels": {
+    "alertname": "KubePodCrashLooping",
+    "severity": "critical",
+    "namespace": "prod",
+    "pod": "payment-api-7d9f6b8c4-9m3qz",
+    "container": "payment-api",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "runbook": "'"${RUNBOOKS}"'/KubePodCrashLooping",
+    "test_suite": "jarvis"
+  },
+  "annotations": {
+    "summary": "Pod payment-api-7d9f6b8c4-9m3qz is crash looping",
+    "description": "Pod has restarted 9 times in the last 15 minutes. Exit code: 137 (OOMKilled).",
+    "dashboard": "'"${GRAFANA}"'/d/k8s-pods?var-namespace=prod&var-pod=payment-api-7d9f6b8c4-9m3qz&orgId=1"
+  },
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_restarts_total%7Bnamespace%3D%22prod%22%7D"
+}]'
+
+pause
+printf "  [3/23] KubePodCrashLooping (critical, payment-api, prod) — 3rd pod (groups with #1)..."
+post '[{
+  "labels": {
+    "alertname": "KubePodCrashLooping",
+    "severity": "critical",
+    "namespace": "prod",
+    "pod": "payment-api-7d9f6b8c4-p7wln",
+    "container": "payment-api",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "runbook": "'"${RUNBOOKS}"'/KubePodCrashLooping",
+    "test_suite": "jarvis"
+  },
+  "annotations": {
+    "summary": "Pod payment-api-7d9f6b8c4-p7wln is crash looping",
+    "description": "Pod has restarted 22 times in the last 15 minutes. Exit code: 137 (OOMKilled).",
+    "dashboard": "'"${GRAFANA}"'/d/k8s-pods?var-namespace=prod&var-pod=payment-api-7d9f6b8c4-p7wln&orgId=1"
+  },
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_restarts_total%7Bnamespace%3D%22prod%22%7D"
+}]'
+
+pause
+printf "  [4/23] KubeNodeNotReady (critical, worker-node-3, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeNodeNotReady",
@@ -76,7 +120,7 @@ post '[{
 }]'
 
 pause
-printf "  [3/10] KubeAPIServerErrorsHigh (critical, kube-system, prod)..."
+printf "  [5/23] KubeAPIServerErrorsHigh (critical, kube-system, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeAPIServerErrorsHigh",
@@ -96,7 +140,7 @@ post '[{
 }]'
 
 pause
-printf "  [4/10] KubeJobFailed (critical, data-pipeline, prod)..."
+printf "  [6/23] KubeJobFailed (critical, data-pipeline, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeJobFailed",
@@ -118,7 +162,7 @@ post '[{
 }]'
 
 pause
-printf "  [5/10] KubeDeploymentReplicasMismatch (warning, frontend, staging)..."
+printf "  [7/23] KubeDeploymentReplicasMismatch (warning, frontend, staging)..."
 post '[{
   "labels": {
     "alertname": "KubeDeploymentReplicasMismatch",
@@ -139,7 +183,7 @@ post '[{
 }]'
 
 pause
-printf "  [6/10] KubePersistentVolumeFillingUp (warning, prometheus, prod)..."
+printf "  [8/23] KubePersistentVolumeFillingUp (warning, prometheus, prod)..."
 post '[{
   "labels": {
     "alertname": "KubePersistentVolumeFillingUp",
@@ -160,7 +204,7 @@ post '[{
 }]'
 
 pause
-printf "  [7/10] KubeHpaMaxedOut (warning, auth-service, prod)..."
+printf "  [9/23] KubeHpaMaxedOut (warning, auth-service, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeHpaMaxedOut",
@@ -180,7 +224,7 @@ post '[{
 }]'
 
 pause
-printf "  [8/10] KubePodOOMKilled (warning, ml-inference, prod)..."
+printf " [10/23] KubePodOOMKilled (warning, ml-inference, prod)..."
 post '[{
   "labels": {
     "alertname": "KubePodOOMKilled",
@@ -203,7 +247,49 @@ post '[{
 }]'
 
 pause
-printf "  [9/10] KubeContainerWaiting (info, batch-worker, prod)..."
+printf " [11/23] KubePodOOMKilled (warning, ml-inference, prod) — 2nd pod (groups with #10)..."
+post '[{
+  "labels": {
+    "alertname": "KubePodOOMKilled",
+    "severity": "warning",
+    "namespace": "prod",
+    "pod": "ml-inference-6c8d9f7b5-h4dtx",
+    "container": "inference-server",
+    "cluster": "eu-west-1-prod",
+    "team": "ml",
+    "runbook": "'"${RUNBOOKS}"'/KubePodOOMKilled",
+    "test_suite": "jarvis"
+  },
+  "annotations": {
+    "summary": "Container inference-server OOMKilled 2 times in 1h",
+    "description": "Memory limit: 4Gi, actual peak RSS: 4.6Gi. Increase memory limit or reduce batch size."
+  },
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_last_terminated_reason%7Breason%3D%22OOMKilled%22%7D"
+}]'
+
+pause
+printf " [12/23] KubePodOOMKilled (warning, ml-inference, prod) — 3rd pod (groups with #10)..."
+post '[{
+  "labels": {
+    "alertname": "KubePodOOMKilled",
+    "severity": "warning",
+    "namespace": "prod",
+    "pod": "ml-inference-6c8d9f7b5-vw8kc",
+    "container": "inference-server",
+    "cluster": "eu-west-1-prod",
+    "team": "ml",
+    "runbook": "'"${RUNBOOKS}"'/KubePodOOMKilled",
+    "test_suite": "jarvis"
+  },
+  "annotations": {
+    "summary": "Container inference-server OOMKilled 5 times in 1h",
+    "description": "Memory limit: 4Gi, actual peak RSS: 5.1Gi. Increase memory limit or reduce batch size."
+  },
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_last_terminated_reason%7Breason%3D%22OOMKilled%22%7D"
+}]'
+
+pause
+printf " [13/23] KubeContainerWaiting (info, batch-worker, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeContainerWaiting",
@@ -224,7 +310,49 @@ post '[{
 }]'
 
 pause
-printf " [10/10] KubeStatefulSetReplicasMismatch (info, kafka, prod)..."
+printf " [14/23] KubeContainerWaiting (info, batch-worker, prod) — 2nd pod (groups with #13)..."
+post '[{
+  "labels": {
+    "alertname": "KubeContainerWaiting",
+    "severity": "info",
+    "namespace": "prod",
+    "pod": "batch-worker-5f7b9c2d8-x9zzt",
+    "container": "batch-worker",
+    "reason": "ImagePullBackOff",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "test_suite": "jarvis"
+  },
+  "annotations": {
+    "summary": "Container batch-worker stuck in ImagePullBackOff",
+    "description": "Image ghcr.io/acme/batch-worker:v2.4.1 cannot be pulled. Registry credentials may have expired or image tag does not exist."
+  },
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_waiting_reason%7Breason%3D%22ImagePullBackOff%22%7D"
+}]'
+
+pause
+printf " [15/23] KubeContainerWaiting (info, batch-worker, prod) — 3rd pod (groups with #13)..."
+post '[{
+  "labels": {
+    "alertname": "KubeContainerWaiting",
+    "severity": "info",
+    "namespace": "prod",
+    "pod": "batch-worker-5f7b9c2d8-p3kjm",
+    "container": "batch-worker",
+    "reason": "ImagePullBackOff",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "test_suite": "jarvis"
+  },
+  "annotations": {
+    "summary": "Container batch-worker stuck in ImagePullBackOff",
+    "description": "Image ghcr.io/acme/batch-worker:v2.4.1 cannot be pulled. Registry credentials may have expired or image tag does not exist."
+  },
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_waiting_reason%7Breason%3D%22ImagePullBackOff%22%7D"
+}]'
+
+pause
+printf " [16/23] KubeStatefulSetReplicasMismatch (info, kafka, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeStatefulSetReplicasMismatch",
@@ -245,7 +373,7 @@ post '[{
 }]'
 
 pause
-printf " [11/12] KubeServiceEndpointError (error, checkout-api, prod)..."
+printf " [17/23] KubeServiceEndpointError (error, checkout-api, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeServiceEndpointError",
@@ -266,7 +394,7 @@ post '[{
 }]'
 
 pause
-printf " [12/12] KubeDNSErrors (error, kube-dns, prod)..."
+printf " [18/23] KubeDNSErrors (error, kube-dns, prod)..."
 post '[{
   "labels": {
     "alertname": "KubeDNSErrors",
@@ -288,7 +416,7 @@ post '[{
 }]'
 
 pause
-printf " [13/16] LinkRichAlert — many link labels + annotations..."
+printf " [19/23] LinkRichAlert — many link labels + annotations..."
 post '[{
   "labels": {
     "alertname": "LinkRichAlert",
@@ -315,7 +443,7 @@ post '[{
 }]'
 
 pause
-printf " [14/16] InlineUrlsAlert — multiple URLs embedded in description prose..."
+printf " [20/23] InlineUrlsAlert — multiple URLs embedded in description prose..."
 post '[{
   "labels": {
     "alertname": "InlineUrlsAlert",
@@ -334,7 +462,7 @@ post '[{
 }]'
 
 pause
-printf " [15/16] LabelOnlyLinksAlert — all links in labels, no annotation links..."
+printf " [21/23] LabelOnlyLinksAlert — all links in labels, no annotation links..."
 post '[{
   "labels": {
     "alertname": "LabelOnlyLinksAlert",
@@ -356,7 +484,7 @@ post '[{
 }]'
 
 pause
-printf " [16/16] AnnotationOnlyLinksAlert — all links in annotations, no label links..."
+printf " [22/23] AnnotationOnlyLinksAlert — all links in annotations, no label links..."
 post '[{
   "labels": {
     "alertname": "AnnotationOnlyLinksAlert",
@@ -378,7 +506,7 @@ post '[{
 }]'
 
 pause
-printf " [17/17] SpecialCharLabelAlert — label value with dots + label value with hyphens..."
+printf " [23/23] SpecialCharLabelAlert — label value with dots + label value with hyphens..."
 post '[{
   "labels": {
     "alertname": "SpecialCharLabelAlert",
@@ -401,5 +529,8 @@ post '[{
 }]'
 
 echo ""
-echo "==> Done. 17 Kubernetes test alerts active (test_suite=jarvis)."
+echo "==> Done. 23 Kubernetes test alerts active (test_suite=jarvis)."
+echo "    KubePodCrashLooping, KubePodOOMKilled and KubeContainerWaiting each fired as"
+echo "    3 alerts (same alertname/cluster/namespace, different pod) — Alertmanager"
+echo "    groups them (group_by: alertname, cluster, namespace) into 3-alert groups."
 echo "    Alerts persist until you run 'make alerts-resolve' (endsAt: ${ENDS_AT})."

--- a/scripts/resolve-test-alerts.sh
+++ b/scripts/resolve-test-alerts.sh
@@ -26,7 +26,7 @@ echo "==> Resolving Kubernetes test alerts (test_suite=jarvis) via ${AM}"
 echo "    endsAt: ${ENDS_AT}"
 echo ""
 
-printf "  [1/10] KubePodCrashLooping..."
+printf "  [1/23] KubePodCrashLooping..."
 resolve '[{
   "labels": {
     "alertname": "KubePodCrashLooping",
@@ -43,7 +43,41 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_restarts_total"
 }]'
 
-printf "  [2/10] KubeNodeNotReady..."
+printf "  [2/23] KubePodCrashLooping (2nd pod)..."
+resolve '[{
+  "labels": {
+    "alertname": "KubePodCrashLooping",
+    "severity": "critical",
+    "namespace": "prod",
+    "pod": "payment-api-7d9f6b8c4-9m3qz",
+    "container": "payment-api",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "runbook": "'"${RUNBOOKS}"'/KubePodCrashLooping",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Pod payment-api-7d9f6b8c4-9m3qz is crash looping"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_restarts_total"
+}]'
+
+printf "  [3/23] KubePodCrashLooping (3rd pod)..."
+resolve '[{
+  "labels": {
+    "alertname": "KubePodCrashLooping",
+    "severity": "critical",
+    "namespace": "prod",
+    "pod": "payment-api-7d9f6b8c4-p7wln",
+    "container": "payment-api",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "runbook": "'"${RUNBOOKS}"'/KubePodCrashLooping",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Pod payment-api-7d9f6b8c4-p7wln is crash looping"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_restarts_total"
+}]'
+
+printf "  [4/23] KubeNodeNotReady..."
 resolve '[{
   "labels": {
     "alertname": "KubeNodeNotReady",
@@ -61,7 +95,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_node_status_condition"
 }]'
 
-printf "  [3/10] KubeAPIServerErrorsHigh..."
+printf "  [5/23] KubeAPIServerErrorsHigh..."
 resolve '[{
   "labels": {
     "alertname": "KubeAPIServerErrorsHigh",
@@ -79,7 +113,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=rate(apiserver_request_total%7Bcode%3D~%225..%22%7D%5B5m%5D)"
 }]'
 
-printf "  [4/10] KubeJobFailed..."
+printf "  [6/23] KubeJobFailed..."
 resolve '[{
   "labels": {
     "alertname": "KubeJobFailed",
@@ -95,7 +129,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_job_status_failed"
 }]'
 
-printf "  [5/10] KubeDeploymentReplicasMismatch..."
+printf "  [7/23] KubeDeploymentReplicasMismatch..."
 resolve '[{
   "labels": {
     "alertname": "KubeDeploymentReplicasMismatch",
@@ -114,7 +148,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_deployment_status_replicas_available"
 }]'
 
-printf "  [6/10] KubePersistentVolumeFillingUp..."
+printf "  [8/23] KubePersistentVolumeFillingUp..."
 resolve '[{
   "labels": {
     "alertname": "KubePersistentVolumeFillingUp",
@@ -133,7 +167,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kubelet_volume_stats_used_bytes"
 }]'
 
-printf "  [7/10] KubeHpaMaxedOut..."
+printf "  [9/23] KubeHpaMaxedOut..."
 resolve '[{
   "labels": {
     "alertname": "KubeHpaMaxedOut",
@@ -151,7 +185,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_horizontalpodautoscaler_status_current_replicas"
 }]'
 
-printf "  [8/10] KubePodOOMKilled..."
+printf " [10/23] KubePodOOMKilled..."
 resolve '[{
   "labels": {
     "alertname": "KubePodOOMKilled",
@@ -168,7 +202,41 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_last_terminated_reason"
 }]'
 
-printf "  [9/10] KubeContainerWaiting..."
+printf " [11/23] KubePodOOMKilled (2nd pod)..."
+resolve '[{
+  "labels": {
+    "alertname": "KubePodOOMKilled",
+    "severity": "warning",
+    "namespace": "prod",
+    "pod": "ml-inference-6c8d9f7b5-h4dtx",
+    "container": "inference-server",
+    "cluster": "eu-west-1-prod",
+    "team": "ml",
+    "runbook": "'"${RUNBOOKS}"'/KubePodOOMKilled",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Container inference-server OOMKilled 2 times in 1h"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_last_terminated_reason"
+}]'
+
+printf " [12/23] KubePodOOMKilled (3rd pod)..."
+resolve '[{
+  "labels": {
+    "alertname": "KubePodOOMKilled",
+    "severity": "warning",
+    "namespace": "prod",
+    "pod": "ml-inference-6c8d9f7b5-vw8kc",
+    "container": "inference-server",
+    "cluster": "eu-west-1-prod",
+    "team": "ml",
+    "runbook": "'"${RUNBOOKS}"'/KubePodOOMKilled",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Container inference-server OOMKilled 5 times in 1h"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_last_terminated_reason"
+}]'
+
+printf " [13/23] KubeContainerWaiting..."
 resolve '[{
   "labels": {
     "alertname": "KubeContainerWaiting",
@@ -185,7 +253,41 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_waiting_reason"
 }]'
 
-printf " [10/10] KubeStatefulSetReplicasMismatch..."
+printf " [14/23] KubeContainerWaiting (2nd pod)..."
+resolve '[{
+  "labels": {
+    "alertname": "KubeContainerWaiting",
+    "severity": "info",
+    "namespace": "prod",
+    "pod": "batch-worker-5f7b9c2d8-x9zzt",
+    "container": "batch-worker",
+    "reason": "ImagePullBackOff",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Container batch-worker stuck in ImagePullBackOff"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_waiting_reason"
+}]'
+
+printf " [15/23] KubeContainerWaiting (3rd pod)..."
+resolve '[{
+  "labels": {
+    "alertname": "KubeContainerWaiting",
+    "severity": "info",
+    "namespace": "prod",
+    "pod": "batch-worker-5f7b9c2d8-p3kjm",
+    "container": "batch-worker",
+    "reason": "ImagePullBackOff",
+    "cluster": "eu-west-1-prod",
+    "team": "platform",
+    "test_suite": "jarvis"
+  },
+  "annotations": {"summary": "Container batch-worker stuck in ImagePullBackOff"},
+  "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_pod_container_status_waiting_reason"
+}]'
+
+printf " [16/23] KubeStatefulSetReplicasMismatch..."
 resolve '[{
   "labels": {
     "alertname": "KubeStatefulSetReplicasMismatch",
@@ -204,7 +306,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_statefulset_status_replicas_ready"
 }]'
 
-printf " [11/12] KubeServiceEndpointError..."
+printf " [17/23] KubeServiceEndpointError..."
 resolve '[{
   "labels": {
     "alertname": "KubeServiceEndpointError",
@@ -220,7 +322,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=kube_endpoint_address_available"
 }]'
 
-printf " [12/12] KubeDNSErrors..."
+printf " [18/23] KubeDNSErrors..."
 resolve '[{
   "labels": {
     "alertname": "KubeDNSErrors",
@@ -236,7 +338,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=rate(coredns_dns_responses_total%7Brcode%3D%22SERVFAIL%22%7D%5B5m%5D)"
 }]'
 
-printf " [13/17] LinkRichAlert..."
+printf " [19/23] LinkRichAlert..."
 resolve '[{
   "labels": {
     "alertname": "LinkRichAlert",
@@ -255,7 +357,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=up%7Bjob%3D%22platform%22%7D"
 }]'
 
-printf " [14/17] InlineUrlsAlert..."
+printf " [20/23] InlineUrlsAlert..."
 resolve '[{
   "labels": {
     "alertname": "InlineUrlsAlert",
@@ -269,7 +371,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=up%7Bjob%3D%22prometheus%22%7D"
 }]'
 
-printf " [15/17] LabelOnlyLinksAlert..."
+printf " [21/23] LabelOnlyLinksAlert..."
 resolve '[{
   "labels": {
     "alertname": "LabelOnlyLinksAlert",
@@ -287,7 +389,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=http_requests_total%7Benv%3D%22staging%22%7D"
 }]'
 
-printf " [16/17] AnnotationOnlyLinksAlert..."
+printf " [22/23] AnnotationOnlyLinksAlert..."
 resolve '[{
   "labels": {
     "alertname": "AnnotationOnlyLinksAlert",
@@ -301,7 +403,7 @@ resolve '[{
   "generatorURL": "'"${PROM}"'/graph?g0.expr=job_duration_seconds%7Bjob%3D%22s3-export%22%7D"
 }]'
 
-printf " [17/17] SpecialCharLabelAlert..."
+printf " [23/23] SpecialCharLabelAlert..."
 resolve '[{
   "labels": {
     "alertname": "SpecialCharLabelAlert",
@@ -320,4 +422,4 @@ resolve '[{
 }]'
 
 echo ""
-echo "==> All 17 Kubernetes test alerts resolved."
+echo "==> All 23 Kubernetes test alerts resolved."


### PR DESCRIPTION
## Summary
- Restyle the AckButton Fast-Silence dropdown: single 4-column grid of duration buttons plus a "Silence…" row whose Bell icon dynamically aligns over the trigger icon on open (measured before paint via `useLayoutEffect`), so the submenu reads as an extension of the same control.
- Widen spacing in AlertDetailPanel's active/expired silence banner headers so action buttons don't crowd the silence badge.
- Extend `fire-test-alerts.sh` / `resolve-test-alerts.sh` fixtures with 2 extra pods each for `KubePodCrashLooping`, `KubePodOOMKilled`, `KubeContainerWaiting` so they form 3-alert groups — gives manual testers a group to exercise group Fast-Silence against.

## Test plan
- [x] `pnpm build` (tsc + vite) green
- [x] Frontend unit tests + 100% coverage gate on `alertUtils.ts` (unaffected by this PR, still green)
- [x] Pre-commit hooks (eslint, jscpd, gitleaks) passed on both commits
- [ ] Manual check: open Fast-Silence menu on a single alert and on a group, confirm submenu icon aligns with trigger and no visual jump