### PR TITLE
fix(silences): use shared fallback refetch interval for cluster health

### DIFF
--- a/docs/testing-e2e.md
+++ b/docs/testing-e2e.md
@@ -229,7 +229,10 @@ Quick reference: which spec file covers what. Use this to find the right place f
 
 Functional cases from the original test catalog that are **not** covered yet:
 
-- **E8** — Silences page auto-refresh (~30s interval).
+- **E8** — Silences page live update: `silences_update` WS push (not covered
+  by `websocket.spec.ts`, which only asserts `alerts_update` /
+  `claim_set`/`claim_released`/`comment_added`) and the 60s
+  `FALLBACK_REFETCH_INTERVAL_MS` safety-net poll.
 - **F18** — Precise/Broader/Pattern silence-matcher presets (remove label / `=` → `=~`).
 - **I5** — `full_protect` LoginPage gating the whole app (only a screenshot spec exists, no functional assertion).
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -13,6 +13,7 @@ import { useAuthStore } from '@/store/authStore'
 import { useSettingsStore } from '@/store/useSettingsStore'
 import { useQuery } from '@tanstack/react-query'
 import { fetchClusters } from '@/api/client'
+import { FALLBACK_REFETCH_INTERVAL_MS } from '@/lib/refetch'
 
 // ── Header ────────────────────────────────────────────────────────────────────
 
@@ -60,7 +61,7 @@ export function Header() {
   const { data: clusters = [] } = useQuery({
     queryKey: ['clusters'],
     queryFn: fetchClusters,
-    refetchInterval: 30_000,
+    refetchInterval: FALLBACK_REFETCH_INTERVAL_MS,
   })
 
   const [silenceFormOpen, setSilenceFormOpen] = useState(false)


### PR DESCRIPTION
## Summary
- `Header.tsx` polled `/api/v1/clusters` at a hardcoded `30_000` while every other snapshot-backed query already uses `FALLBACK_REFETCH_INTERVAL_MS` (60s, introduced in #80). Cluster health is now zero-AM-cost (`MemberUpStates`) and gets the same WS-reconnect invalidation coverage, so the same fallback cadence applies.
- Corrects the stale "E8" entry in `docs/testing-e2e.md`, which still described pre-#80 30s silence polling instead of the current `silences_update` WS push + 60s fallback.

## Test plan
- [x] `pnpm build` (in dev container) — green
- [x] Pre-commit hooks (eslint, vitest 100% coverage gate, jscpd, gitleaks) — green