### PR TITLE
fix(backend): silence staticcheck SA5011 false positive in registry_test

### DIFF
--- a/backend/internal/cluster/registry_test.go
+++ b/backend/internal/cluster/registry_test.go
@@ -33,6 +33,7 @@ func TestNewRegistry_SingleCluster(t *testing.T) {
 	cl := r.Get("homelab")
 	if cl == nil {
 		t.Fatal("expected cluster homelab, got nil")
+		return
 	}
 	if cl.Name != "homelab" {
 		t.Errorf("Name = %q, want homelab", cl.Name)


### PR DESCRIPTION
## Summary
- `golangci-lint-action` floats to latest; a new staticcheck release started flagging `cl.Name` access after a `t.Fatal` nil-check as a possible nil dereference in `registry_test.go`, even though `t.Fatal` calls `runtime.Goexit` and halts the test.
- Blocked required `Backend` CI check on every open PR, including unrelated Dependabot bumps.

## Fix
Add an explicit `return` after `t.Fatal` to make the control flow unambiguous to the analyzer.

## Test plan
- [x] `go test ./internal/cluster/...` passes
- [x] `golangci-lint run` clean locally (v2.12.2)
- [x] CI green on this PR