### PR TITLE
feat(release): support pre-release (RC) tags in release workflow

### DIFF
--- a/.agents/release.md
+++ b/.agents/release.md
@@ -211,6 +211,45 @@ release history consistent.
 
 ---
 
+## Release Candidates (Pre-releases)
+
+For validating a batch of changes (e.g. dependency bumps, a CI fix) before
+committing to a real release. Tag format: `vX.Y.Z-rc.N` (semver pre-release
+identifier — the hyphen is what `release.yml` uses to detect a pre-release).
+
+Unlike a real release, an RC needs **no release branch and no repo changes**
+— no CHANGELOG, no README version bump, no chart bump. It's just a tag on
+the current `main` HEAD, so it can be pushed directly (tags aren't covered
+by the `protect-main` branch ruleset):
+
+```bash
+git fetch origin && git status -sb   # must not be ahead/behind, same as Phase 1
+git tag -a v1.7.0-rc.1 -m "Release candidate v1.7.0-rc.1"
+git push origin v1.7.0-rc.1
+```
+
+`release.yml` triggers on any `v*.*.*` tag (the glob matches pre-release
+suffixes too) and detects the hyphen to branch its behavior:
+
+- **Image tags**: `docker/metadata-action`'s `latest=auto` default already
+  excludes semver pre-releases from the `latest` tag — no workflow change
+  needed there. The RC image is pushed as `ghcr.io/kj187/jarvis:1.7.0-rc.1`
+  only.
+- **Release notes**: no curated notes file, no CHANGELOG section exists for
+  an RC tag (those are only generated in Phase 2 of a real release) — the
+  body is auto-generated instead: a short blurb + `git log` of commits since
+  the last **stable** tag (pre-release tags excluded from that lookup).
+- **GitHub Release**: created with `--prerelease` instead of `--latest`, so
+  it never overrides the "latest" pointer for the real release that follows.
+
+Cutting further RCs (`-rc.2`, …) or the real release afterwards needs no
+cleanup — the RC tag/release are independent of the real `vX.Y.Z` tag and
+leave no trace in its CHANGELOG or release notes. The RC's GitHub Release
+entry stays visible in the release list (marked "Pre-release") unless
+deleted manually — `gh release delete v1.7.0-rc.1 --cleanup-tag`.
+
+---
+
 ## What GitHub Actions does automatically (after tag push)
 
 From `.github/workflows/release.yml`:
@@ -231,12 +270,15 @@ From `.github/workflows/release.yml`:
 6. Build the release body: uses `.github/release-notes/vX.Y.Z.md` if present
    (fallback: awk-extract this version's CHANGELOG section), then appends
    image pull + digest, cosign verify, `gh attestation verify`, Helm install
-   + chart cosign verify, and SBOM pointers.
+   + chart cosign verify, and SBOM pointers. Pre-release tags (hyphen in the
+   tag name) skip both and get an auto-generated commit-log body instead —
+   see [Release Candidates](#release-candidates-pre-releases) above.
 7. Create the GitHub Release via `gh release create --notes-file
-   release-body.md --verify-tag --latest` with the SBOM as asset. Releases
-   are immutable: if a release for the tag already exists, the job fails —
-   never overwrite a published release; delete it manually first if a
-   re-release is really intended.
+   release-body.md --verify-tag` with the SBOM as asset — `--latest` for a
+   real release, `--prerelease` for a pre-release tag. Releases are
+   immutable: if a release for the tag already exists, the job fails — never
+   overwrite a published release; delete it manually first if a re-release
+   is really intended.
 
 **Helm chart** (separate workflow `.github/workflows/chart-release.yml`, *not*
 part of `release.yml`):

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,11 @@ jobs:
       attestations: write # required for build provenance and SBOM attestations
 
     steps:
+      # fetch-depth: 0 (full history + tags) so the pre-release notes step
+      # below can diff against the last stable tag.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Docker metadata
         id: meta
@@ -99,14 +103,31 @@ jobs:
           DIGEST="${{ steps.build.outputs.digest }}"
           CHART_VERSION=$(awk '/^version:/{print $2}' charts/jarvis/Chart.yaml)
 
-          # Prefer curated release notes committed by the release process;
-          # fall back to extracting this version's CHANGELOG section.
-          NOTES_FILE=".github/release-notes/${GITHUB_REF_NAME}.md"
-          if [ -f "${NOTES_FILE}" ]; then
-            cp "${NOTES_FILE}" release-body.md
+          # Pre-releases (tag contains a hyphen, e.g. v1.7.0-rc.1) never get
+          # curated notes or a CHANGELOG section — those are only generated
+          # for real releases, so an RC leaves no trace in either once the
+          # real release follows. Summarize commits since the last stable
+          # tag instead.
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            PREV_STABLE=$(git tag --list 'v*' | grep -Ev -- '-' | sort -V | tail -1)
+            {
+              printf '## Pre-release build\n\n'
+              printf 'Release candidate for the upcoming stable release. Not published as `latest`.\n\n'
+              if [ -n "${PREV_STABLE}" ]; then
+                printf '**Commits since %s:**\n\n' "${PREV_STABLE}"
+                git log "${PREV_STABLE}..${GITHUB_REF_NAME}" --pretty='- %s (%h)'
+              fi
+            } > release-body.md
           else
-            printf '## Changelog\n\n' > release-body.md
-            awk "/^## \[${GITHUB_REF_NAME}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md >> release-body.md
+            # Prefer curated release notes committed by the release process;
+            # fall back to extracting this version's CHANGELOG section.
+            NOTES_FILE=".github/release-notes/${GITHUB_REF_NAME}.md"
+            if [ -f "${NOTES_FILE}" ]; then
+              cp "${NOTES_FILE}" release-body.md
+            else
+              printf '## Changelog\n\n' > release-body.md
+              awk "/^## \[${GITHUB_REF_NAME}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md >> release-body.md
+            fi
           fi
 
           cat >> release-body.md <<'EOF'
@@ -164,9 +185,17 @@ jobs:
         run: |
           # Releases are immutable: if one already exists for this tag, fail
           # instead of silently overwriting it (delete manually if intended).
+          # Pre-release tags (contain a hyphen, e.g. v1.7.0-rc.1) are marked
+          # --prerelease instead of --latest, so they never override the
+          # "latest" pointer for the real release that follows.
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            STABILITY_FLAG="--prerelease"
+          else
+            STABILITY_FLAG="--latest"
+          fi
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --notes-file release-body.md \
             --verify-tag \
-            --latest \
+            "${STABILITY_FLAG}" \
             sbom.spdx.json


### PR DESCRIPTION
## Summary
- `release.yml` now branches on whether the pushed tag contains a hyphen (semver pre-release, e.g. `v1.7.0-rc.1`):
  - Release body: auto-generated commit-log summary since the last stable tag instead of curated notes / CHANGELOG lookup (neither exists for an RC).
  - GitHub Release created with `--prerelease` instead of `--latest`.
  - Image `latest` tag: already excluded for pre-releases by `docker/metadata-action`'s `latest=auto` default — no change needed there.
- `actions/checkout` now uses `fetch-depth: 0` so the RC notes step can diff against the last stable tag.
- Documented the full RC flow in `.agents/release.md` (tag-and-push directly from main, no release branch/CHANGELOG/README/chart bump needed).

Real releases are unaffected — an RC leaves no trace in the following real release's CHANGELOG or notes.

## Test plan
- [x] YAML syntax validated
- [ ] CI green on this PR
- [ ] Cut `v1.7.0-rc.1` after merge to verify the new branch end-to-end