### PR TITLE
security(api): require auth on /ws websocket upgrade in full_protect mode

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -332,7 +332,9 @@ GET    /auth/oidc/callback                       None        → exchanges code,
 POST   /setup                                    None  (RL)  Body: { username, password } (internal mode only; 403 if users exist)
 
 # ── WebSocket ────────────────────────────────────────────────────────────────
-WS     /ws                                       None        (origin checked against JARVIS_ALLOWED_ORIGINS)
+WS     /ws                                       full_protect?  (origin checked against JARVIS_ALLOWED_ORIGINS;
+#        in full_protect mode the upgrade request additionally requires a valid
+#        session cookie via RequireAuth — /ws streams the full alert snapshot)
 
 # ── Status / Version ─────────────────────────────────────────────────────────
 GET    /api/v1/status                            full_protect?  → { status, clusters, alerts, ws_clients }

--- a/.agents/security.md
+++ b/.agents/security.md
@@ -122,6 +122,13 @@ The backend validates the `Origin` header for both HTTP CORS and the WebSocket
 upgrade against `cfg.AllowedOrigins` (Critical Invariant #11 in `AGENTS.md`).
 Never use an unconditional `return true` in `upgrader.CheckOrigin`.
 
+In `full_protect` mode the `/ws` route is additionally wrapped with
+`auth.RequireAuth` (`internal/api/router.go`): the origin check alone does not
+gate non-browser clients (no `Origin` header ⇒ allowed), and `/ws` streams the
+full alert snapshot plus claim/comment events — exactly the data
+`full_protect` protects. The JWT session cookie rides on the upgrade request,
+so no WS-specific auth plumbing exists.
+
 Actual behavior in `internal/ws/hub.go`:
 
 ```go

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -129,10 +129,18 @@ func NewRouter(
 	e.Use(srv.firstRunRedirect)
 
 	// ── WebSocket ─────────────────────────────────────────────────────────────
-	e.GET("/ws", func(c echo.Context) error {
+	// full_protect: /ws streams the full alert snapshot plus claim/comment
+	// events, so it must be gated like the API routes below. The JWT session
+	// cookie is sent on the upgrade request, so RequireAuth works unchanged.
+	wsHandler := func(c echo.Context) error {
 		hub.ServeWS(c.Response().Writer, c.Request())
 		return nil
-	})
+	}
+	if cfg.AuthMode == "full_protect" {
+		e.GET("/ws", wsHandler, auth.RequireAuth(authProvider))
+	} else {
+		e.GET("/ws", wsHandler)
+	}
 
 	// ── Auth & Setup ──────────────────────────────────────────────────────────
 	// GET /setup is served by the SPA catch-all (index.html); no explicit route needed.

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -276,3 +276,59 @@ func TestAuthMode_ReadRoutes(t *testing.T) {
 		})
 	}
 }
+
+func TestWebSocket_FullProtectRequiresAuth(t *testing.T) {
+	srv := newTestRouterWithAuthMode(t, "full_protect")
+	defer srv.Close()
+	client := &http.Client{}
+
+	// Without a session cookie the request must be rejected by RequireAuth
+	// before reaching the WS handler — /ws streams the full alert snapshot,
+	// which is exactly the data full_protect gates.
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/ws", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /ws: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("GET /ws without session = %d, want 401", resp.StatusCode)
+	}
+
+	// With a valid session cookie the request must pass the middleware and
+	// reach the WS handler: a plain GET without upgrade headers then fails
+	// the websocket handshake with 400 — anything but 401 proves passthrough.
+	token, err := auth.CreateToken([]byte("aaaabbbbccccddddeeeeffffgggghhhh"), &auth.User{
+		ID: "u1", Username: "alice", Role: "user", Provider: "internal",
+	})
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	req2, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/ws", nil)
+	req2.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	resp2, err := client.Do(req2)
+	if err != nil {
+		t.Fatalf("GET /ws with session: %v", err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode == http.StatusUnauthorized {
+		t.Errorf("GET /ws with valid session = 401, want handler reached (e.g. 400 bad handshake)")
+	}
+}
+
+func TestWebSocket_WriteProtectStaysPublic(t *testing.T) {
+	srv := newTestRouterWithAuthMode(t, "write_protect")
+	defer srv.Close()
+
+	// In write_protect mode /ws stays public (read-only data): the request
+	// must reach the WS handler, which rejects a non-upgrade GET with 400.
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/ws", nil)
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("GET /ws: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Errorf("GET /ws in write_protect = 401, want handler reached (e.g. 400 bad handshake)")
+	}
+}

--- a/backend/internal/ws/hub.go
+++ b/backend/internal/ws/hub.go
@@ -31,8 +31,12 @@ type Hub struct {
 	metrics    *metrics.Metrics
 }
 
-// NewHub creates a new Hub.
+// NewHub creates a new Hub. A nil logger is replaced with a no-op logger so
+// callers (tests) that don't care about hub logs can pass nil safely.
 func NewHub(allowedOrigins []string, logger *slog.Logger, m *metrics.Metrics) *Hub {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
 	originSet := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
 		originSet[o] = struct{}{}


### PR DESCRIPTION
## Summary

Fixes finding B1 from the internal code review: the `/ws` endpoint was registered outside the authenticated route group and only checked the `Origin` header. Non-browser clients send no Origin header (`CheckOrigin` allows those deliberately — CSRF does not apply to them), so anyone with network access could open `ws://host/ws` and receive the complete alert stream — labels, annotations, claim and comment events — in `full_protect` deployments that gate exactly this data behind a login.

## Changes

- `full_protect` mode: `/ws` is now wrapped with `auth.RequireAuth`. The JWT session cookie rides on the upgrade request, so no WS-specific auth plumbing is needed.
- `write_protect` / `none` modes unchanged: `/ws` stays public there (read-only data), matching the API routes.
- `ws.NewHub` falls back to a no-op slog logger when passed nil — `ServeWS` logs failed upgrades, which panicked with the nil logger the api test helpers pass.
- Doc sync: `.agents/architecture.md` (endpoint table) + `.agents/security.md` (WS origin section).

## Tests

- `TestWebSocket_FullProtectRequiresAuth`: 401 without session cookie (red before the fix: handler was reached, 400 bad handshake); with a valid JWT cookie the request passes the middleware.
- `TestWebSocket_WriteProtectStaysPublic`: regression guard — `/ws` keeps working without auth in write_protect mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)