### PR TITLE
feat(alerts): add @age and @claimed-by advanced filter expressions

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -508,8 +508,16 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
 ├── lib/
 │   ├── refetch.ts             → FALLBACK_REFETCH_INTERVAL_MS (60s) — safety-net refetch cadence;
 │   │                            WS push is the primary channel, reads hit in-memory snapshots only
-│   ├── alertUtils.ts          → getFilterableLabels, matchesLabelMatchers (filter-bar only,
-│   │                            substring regex + pseudo-labels — never for silence matching),
+│   ├── alertUtils.ts          → getFilterableLabels (pseudo-labels: `@receiver`/`receiver`,
+│   │                            `@cluster`, `@claimed-by` = `activeClaim.claimedBy ?? ''`;
+│   │                            `@age` deliberately excluded — it's `now - startsAt`, a moving
+│   │                            target, not a static label snapshot), parseDurationValue
+│   │                            (single-unit `\d+(s|m|h|d)` → ms, else null), matchesLabelMatchers
+│   │                            (filter-bar only, substring regex + pseudo-labels — never for
+│   │                            silence matching; `@age` handled as a special case ahead of the
+│   │                            label lookup — only `>`/`<` meaningful, via parseDurationValue
+│   │                            against `Date.now() - startsAt`; `>`/`<` on any other field is
+│   │                            always false — LabelMatcherOperator: `=`,`!=`,`=~`,`!~`,`>`,`<`),
 │   │                            safeRegex, anchoredRegex, silenceWouldMatchAlert (Alertmanager-exact:
 │   │                            anchored regex, real labels only — SilenceForm preview/overlap),
 │   │                            hasUnevaluableRegexMatcher, silenceMatchesAlert,
@@ -562,8 +570,14 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
     ├── layout/
     │   ├── Header.tsx         → nav tabs, cluster status, WS indicator, polling/refresh, theme,
     │   │                        settings, create-silence, login/user-menu, mobile hamburger
-    │   └── MatcherChipsBar.tsx → chip-based label filter (=, !=, =~, !~), tag multi-value,
-    │                            suggestions, locked default-filter chips
+    │   └── MatcherChipsBar.tsx → chip-based label filter (=, !=, =~, !~, and @age-only >, <),
+    │                            tag multi-value, suggestions (always includes `@age`/`@claimed-by`
+    │                            via PSEUDO_FIELD_SUGGESTIONS — @age never appears from the live
+    │                            label snapshot, @claimed-by only when some alert is claimed),
+    │                            locked default-filter chips; operator auto-snaps to `>`/`=` when
+    │                            the field switches into/out of `@age`; an @age draft with an
+    │                            unparseable duration (red border, parseDurationValue) is never
+    │                            promoted from draft to a committed filter chip
     ├── alerts/
     │   ├── AlertsPage.tsx     → useWebSocket, filter/search, card|list + detail panel, fullscreen, pagination
     │   ├── AlertCardGrid.tsx  → grouped by settings `groupByLabel` (default severity), responsive

--- a/docs/features.md
+++ b/docs/features.md
@@ -82,10 +82,20 @@ Jarvis exposes the full Alertmanager matcher syntax as an interactive chip UI. Y
 | `!=` | Negative exact match |
 | `=~` | Regex match |
 | `!~` | Negative regex match |
+| `>` / `<` | Older than / younger than — `@age` only |
+
+**Pseudo-fields** (not real Alertmanager labels, computed by Jarvis):
+| Field | Meaning |
+|---|---|
+| `@cluster` | Which configured Alertmanager cluster the alert came from |
+| `@receiver` (alias `receiver`) | Alertmanager receiver(s) the alert routes to |
+| `@claimed-by` | Who currently has the alert claimed — empty string means unclaimed, so `@claimed-by != ""` finds every claimed alert and `@claimed-by = <name>` finds one person's claims |
+| `@age` | Time since the alert started firing, compared with `>`/`<` and a single-unit duration: `@age > 15m`, `@age < 2h` (units: `s`, `m`, `h`, `d`) |
 
 **How filters compose:**
 - Multiple matchers are ANDed — an alert must match all chips to be shown
 - Regex matchers are validated client-side before being applied
+- An `@age` chip re-evaluates on every alert-list refresh, so it stays accurate without a dedicated ticker
 - Clicking a label chip on any alert card instantly adds an exact-match filter for that label
 
 **URL serialization:**

--- a/frontend/e2e/functional/none/filters.spec.ts
+++ b/frontend/e2e/functional/none/filters.spec.ts
@@ -141,6 +141,86 @@ test('C11 search via the toggle input filters by label value', async ({ page, am
   await expect.poll(() => visibleAlertCount(page)).toBeGreaterThan(0)
 })
 
+test('D1 @age filter matches by alert age', async ({ page, am, jarvis }) => {
+  await dismissNoAuthNotice(page)
+  await resetPersistedUIState(page)
+  const now = new Date()
+  const old = new Date(now.getTime() - 20 * 60_000).toISOString()
+  await am.fire([
+    { labels: { alertname: 'D1FreshAlert', severity: 'warning' }, startsAt: now.toISOString() },
+    { labels: { alertname: 'D1OldAlert', severity: 'warning' }, startsAt: old },
+  ])
+  await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, 2)
+
+  await page.goto('/?state=active')
+  await ensureAlertsPage(page)
+  await expect.poll(() => visibleAlertCount(page)).toBe(2)
+
+  await page.getByRole('button', { name: 'Add filter' }).click()
+  const label = page.getByLabel('Label name')
+  await label.fill('@age')
+  await label.press('Enter')
+  const value = page.getByLabel('Label value')
+  await value.fill('15m')
+  await value.press('Enter')
+
+  // Operator auto-snaps to `>` when the field becomes @age (decision 1/7).
+  await expect.poll(() => decodeURIComponent(page.url())).toContain('"name":"@age"')
+  await expect.poll(() => decodeURIComponent(page.url())).toContain('"operator":">"')
+  await expect.poll(() => visibleAlertCount(page)).toBe(1)
+  await expect(page.getByText('D1OldAlert').first()).toBeVisible()
+  await expect(page.getByText('D1FreshAlert')).toHaveCount(0)
+})
+
+test('D2 @claimed-by filter matches the active claim', async ({ page, am, jarvis }) => {
+  await dismissNoAuthNotice(page)
+  await resetPersistedUIState(page)
+  await am.fire(kubernetesAlerts)
+  await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, kubernetesAlerts.length)
+
+  const res = await fetch(`${JARVIS_BASE_URL}/api/v1/alerts`)
+  const alerts: any[] = await res.json()
+  await jarvis.setClaim(alerts[0].fingerprint, 'd2-claimer')
+
+  await page.goto('/?state=active')
+  await ensureAlertsPage(page)
+  await expect.poll(() => visibleAlertCount(page)).toBe(kubernetesAlerts.length)
+
+  await page.getByRole('button', { name: 'Add filter' }).click()
+  const label = page.getByLabel('Label name')
+  await label.fill('@claimed-by')
+  await label.press('Enter')
+  const value = page.getByLabel('Label value')
+  await value.fill('d2-claimer')
+  await value.press('Enter')
+
+  await expect.poll(() => decodeURIComponent(page.url())).toContain('"name":"@claimed-by"')
+  await expect.poll(() => visibleAlertCount(page)).toBe(1)
+})
+
+test('D3 invalid @age duration cannot be committed as a chip', async ({ page, am, jarvis }) => {
+  await dismissNoAuthNotice(page)
+  await resetPersistedUIState(page)
+  await am.fire(kubernetesAlerts)
+  await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, kubernetesAlerts.length)
+
+  await page.goto('/?state=active')
+  await ensureAlertsPage(page)
+  await page.getByRole('button', { name: 'Add filter' }).click()
+
+  const label = page.getByLabel('Label name')
+  await label.fill('@age')
+  await label.press('Enter')
+  const value = page.getByLabel('Label value')
+  await value.fill('bogus')
+  await value.press('Enter')
+
+  // Draft stays open (not promoted to a real filter) — no matchers param in the URL.
+  await page.waitForTimeout(300)
+  expect(page.url()).not.toContain('matchers=')
+  await expect.poll(() => visibleAlertCount(page)).toBe(kubernetesAlerts.length)
+})
+
 test('C12 search from ?q= is prefilled and ESC clears/closes search', async ({ page, am, jarvis }) => {
   await dismissNoAuthNotice(page)
   await resetPersistedUIState(page)

--- a/frontend/src/components/layout/MatcherChipsBar.tsx
+++ b/frontend/src/components/layout/MatcherChipsBar.tsx
@@ -3,18 +3,27 @@ import { X, Lock, Plus, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/store/uiStore'
 import { useAlerts } from '@/hooks/useAlerts'
-import { getFilterableLabels } from '@/lib/alertUtils'
+import { getFilterableLabels, parseDurationValue } from '@/lib/alertUtils'
 import type { LabelMatcherOperator } from '@/types'
 
 const OPERATORS: LabelMatcherOperator[] = ['=', '!=', '=~', '!~']
+/** `>`/`<` are only meaningful for `@age` — never offered for normal labels (decision 1). */
+const AGE_OPERATORS: LabelMatcherOperator[] = ['>', '<']
+/** Always-suggested pseudo-fields that don't reliably appear via the live label snapshot:
+ * `@age` never does (excluded from `getFilterableLabels` — it's a moving target, not a
+ * static label), `@claimed-by` only when some alert is currently claimed. */
+const PSEUDO_FIELD_SUGGESTIONS = ['@age', '@claimed-by']
+const AGE_VALUE_SUGGESTIONS = ['5m', '15m', '30m', '1h', '4h', '1d']
 
 // ── Operator dropdown (styled to match the autocomplete) ──────────────────────
 
 function OperatorSelect({
   value,
+  operators,
   onChange,
 }: {
   value: LabelMatcherOperator
+  operators: LabelMatcherOperator[]
   onChange: (op: LabelMatcherOperator) => void
 }) {
   const [open, setOpen] = useState(false)
@@ -41,7 +50,7 @@ function OperatorSelect({
       </button>
       {open && (
         <div className="combo-dropdown absolute left-0 top-full z-50 -mt-px min-w-full overflow-hidden rounded-b border-x border-b border-border bg-popover shadow-lg">
-          {OPERATORS.map((op) => (
+          {operators.map((op) => (
             <button
               key={op}
               type="button"
@@ -71,6 +80,7 @@ function TagField({
   ariaLabel,
   autoFocus,
   maxWidthClass,
+  invalid,
 }: {
   values: string[]
   onChange: (next: string[]) => void
@@ -80,6 +90,8 @@ function TagField({
   ariaLabel: string
   autoFocus?: boolean
   maxWidthClass: string
+  /** Renders committed tags with a destructive style — e.g. an `@age` value that isn't a valid duration. */
+  invalid?: boolean
 }) {
   const [inputVal, setInputVal] = useState('')
   const [open, setOpen] = useState(false)
@@ -138,8 +150,13 @@ function TagField({
         {values.map((tag, i) => (
           <span
             key={i}
-            title={tag}
-            className="flex min-w-0 shrink items-center gap-0.5 rounded bg-accent px-1.5 py-0.5 text-[11px] text-accent-foreground"
+            title={invalid ? 'Invalid duration — use e.g. 15m, 2h, 1d' : tag}
+            className={cn(
+              'flex min-w-0 shrink items-center gap-0.5 rounded px-1.5 py-0.5 text-[11px]',
+              invalid
+                ? 'bg-destructive/15 text-destructive border border-destructive/50'
+                : 'bg-accent text-accent-foreground',
+            )}
           >
             <span className="min-w-0 truncate">{tag}</span>
             <button
@@ -235,21 +252,40 @@ function EditableMatcherChip({
 }) {
   const { name, operator, value } = matcher
   const valueTags = value ? value.split('|').filter(Boolean) : []
+  const isAgeField = name === '@age'
+  const ageInvalid = isAgeField && value !== '' && parseDurationValue(value) === null
 
   const valueOptions = useMemo(() => {
+    if (isAgeField) return AGE_VALUE_SUGGESTIONS
     if (name && labelValueMap.has(name)) {
       return Array.from(labelValueMap.get(name)!).sort()
     }
     const all = new Set<string>()
     labelValueMap.forEach((vals) => vals.forEach((v) => all.add(v)))
     return Array.from(all).sort()
-  }, [labelValueMap, name])
+  }, [labelValueMap, name, isAgeField])
 
   return (
-    <div className="flex items-center rounded border border-border bg-input min-h-7 max-w-full">
+    <div
+      className={cn(
+        'flex items-center rounded border bg-input min-h-7 max-w-full',
+        ageInvalid ? 'border-destructive' : 'border-border',
+      )}
+    >
       <TagField
         values={name ? [name] : []}
-        onChange={(arr) => onChange({ ...matcher, name: arr[0] ?? '' })}
+        onChange={(arr) => {
+          const nextName = arr[0] ?? ''
+          const nextIsAge = nextName === '@age'
+          const wasAgeOperator = operator === '>' || operator === '<'
+          // >/< are @age-only (decision 1) — snap the operator when the field
+          // switches into or out of @age so the dropdown never shows a stale,
+          // now-invalid operator.
+          let nextOperator = operator
+          if (nextIsAge && !wasAgeOperator) nextOperator = '>'
+          else if (!nextIsAge && wasAgeOperator) nextOperator = '='
+          onChange({ ...matcher, name: nextName, operator: nextOperator })
+        }}
         suggestions={labelNames}
         placeholder="label"
         single
@@ -260,6 +296,7 @@ function EditableMatcherChip({
       <div className="h-3.5 w-px bg-border shrink-0" />
       <OperatorSelect
         value={operator}
+        operators={isAgeField ? AGE_OPERATORS : OPERATORS}
         onChange={(op) => {
           const isRegex = op === '=~' || op === '!~'
           // = / != allow only a single value — collapse extras when leaving regex.
@@ -272,10 +309,11 @@ function EditableMatcherChip({
         values={valueTags}
         onChange={(arr) => onChange({ ...matcher, value: arr.join('|') })}
         suggestions={valueOptions}
-        placeholder="value"
-        single={operator === '=' || operator === '!='}
+        placeholder={isAgeField ? '15m' : 'value'}
+        single={operator === '=' || operator === '!=' || operator === '>' || operator === '<'}
         ariaLabel="Label value"
         maxWidthClass="max-w-[20rem]"
+        invalid={ageInvalid}
       />
       <button
         onClick={onRemove}
@@ -309,11 +347,18 @@ export function MatcherChipsBar({ allowAdd = false }: { allowAdd?: boolean }) {
     return map
   }, [allAlerts])
 
-  const labelNames = useMemo(() => Array.from(labelValueMap.keys()).sort(), [labelValueMap])
+  const labelNames = useMemo(() => {
+    const names = new Set(labelValueMap.keys())
+    PSEUDO_FIELD_SUGGESTIONS.forEach((n) => names.add(n))
+    return Array.from(names).sort()
+  }, [labelValueMap])
 
   function updateDraft(id: string, next: Draft) {
-    // Promote to a real filter as soon as both label and value are present.
-    if (next.name && next.value) {
+    // Promote to a real filter as soon as both label and value are present —
+    // except an @age draft with an unparseable duration, which must not
+    // commit as a chip that can never match (decision 3 + done-criterion).
+    const ageInvalid = next.name === '@age' && parseDurationValue(next.value) === null
+    if (next.name && next.value && !ageInvalid) {
       addLabelMatcher(next)
       setDrafts((d) => d.filter((x) => x.id !== id))
       return

--- a/frontend/src/lib/alertUtils.test.ts
+++ b/frontend/src/lib/alertUtils.test.ts
@@ -14,6 +14,7 @@ import {
   buildAckSilenceBody,
   FAST_SILENCE_DURATIONS,
   matchesLabelMatchers,
+  parseDurationValue,
   silenceWouldMatchAlert,
   hasUnevaluableRegexMatcher,
   silenceMatchesAlert,
@@ -301,6 +302,47 @@ describe('getFilterableLabels', () => {
     expect(labels.alertname).toBe('X')
     expect(labels.instance).toBe('web1')
   })
+
+  it('sets @claimed-by to the active claim\'s claimedBy', () => {
+    const alert = makeAlert({
+      activeClaim: { id: 1, fingerprint: 'abc123', clusterName: 'cluster-a', claimedBy: 'julian', claimedAt: '2026-01-01T00:00:00Z' },
+    })
+    const labels = getFilterableLabels(alert)
+    expect(labels['@claimed-by']).toBe('julian')
+  })
+
+  it('sets @claimed-by to the empty string when unclaimed', () => {
+    const alert = makeAlert()
+    const labels = getFilterableLabels(alert)
+    expect(labels['@claimed-by']).toBe('')
+  })
+})
+
+describe('parseDurationValue', () => {
+  it('parses seconds, minutes, hours, days', () => {
+    expect(parseDurationValue('30s')).toBe(30_000)
+    expect(parseDurationValue('15m')).toBe(15 * 60_000)
+    expect(parseDurationValue('2h')).toBe(2 * 60 * 60_000)
+    expect(parseDurationValue('1d')).toBe(24 * 60 * 60_000)
+  })
+
+  it('trims whitespace', () => {
+    expect(parseDurationValue('  15m  ')).toBe(15 * 60_000)
+  })
+
+  it('accepts 0 as a valid value', () => {
+    expect(parseDurationValue('0m')).toBe(0)
+  })
+
+  it('returns null for invalid input', () => {
+    expect(parseDurationValue('')).toBeNull()
+    expect(parseDurationValue('15')).toBeNull()
+    expect(parseDurationValue('m')).toBeNull()
+    expect(parseDurationValue('15x')).toBeNull()
+    expect(parseDurationValue('1.5h')).toBeNull()
+    expect(parseDurationValue('15m ago')).toBeNull()
+    expect(parseDurationValue('-5m')).toBeNull()
+  })
 })
 
 describe('pickIdentifierLabel', () => {
@@ -462,6 +504,57 @@ describe('matchesLabelMatchers (filter-bar semantics — S-14)', () => {
     const alert = makeAlert({ labels: { alertname: 'X', env: 'prod' } })
     expect(matchesLabelMatchers(alert, [lm('env', '=~', '(')])).toBe(false)
     expect(matchesLabelMatchers(alert, [lm('env', '!~', '(')])).toBe(true)
+  })
+
+  it('@age >: matches when the alert is older than the duration', () => {
+    const alert = makeAlert({ startsAt: new Date(Date.now() - 20 * 60_000).toISOString() })
+    expect(matchesLabelMatchers(alert, [lm('@age', '>', '15m')])).toBe(true)
+    expect(matchesLabelMatchers(alert, [lm('@age', '>', '25m')])).toBe(false)
+  })
+
+  it('@age <: matches when the alert is younger than the duration', () => {
+    const alert = makeAlert({ startsAt: new Date(Date.now() - 10 * 60_000).toISOString() })
+    expect(matchesLabelMatchers(alert, [lm('@age', '<', '15m')])).toBe(true)
+    expect(matchesLabelMatchers(alert, [lm('@age', '<', '5m')])).toBe(false)
+  })
+
+  it('@age with an invalid duration value matches nothing', () => {
+    const alert = makeAlert({ startsAt: new Date(Date.now() - 20 * 60_000).toISOString() })
+    expect(matchesLabelMatchers(alert, [lm('@age', '>', 'bogus')])).toBe(false)
+    expect(matchesLabelMatchers(alert, [lm('@age', '<', 'bogus')])).toBe(false)
+  })
+
+  it('@age with an unsupported operator matches nothing', () => {
+    const alert = makeAlert({ startsAt: new Date(Date.now() - 20 * 60_000).toISOString() })
+    expect(matchesLabelMatchers(alert, [lm('@age', '=', '15m')])).toBe(false)
+    expect(matchesLabelMatchers(alert, [lm('@age', '!=', '15m')])).toBe(false)
+    expect(matchesLabelMatchers(alert, [lm('@age', '=~', '15m')])).toBe(false)
+    expect(matchesLabelMatchers(alert, [lm('@age', '!~', '15m')])).toBe(false)
+  })
+
+  it('> and < on a normal (non-@age) label never match', () => {
+    const alert = makeAlert({ labels: { alertname: 'X', env: 'prod' } })
+    expect(matchesLabelMatchers(alert, [lm('env', '>', 'prod')])).toBe(false)
+    expect(matchesLabelMatchers(alert, [lm('env', '<', 'prod')])).toBe(false)
+  })
+
+  it('@claimed-by = / != match against the active claim', () => {
+    const claimed = makeAlert({
+      activeClaim: { id: 1, fingerprint: 'abc123', clusterName: 'cluster-a', claimedBy: 'julian', claimedAt: '2026-01-01T00:00:00Z' },
+    })
+    const unclaimed = makeAlert()
+    expect(matchesLabelMatchers(claimed, [lm('@claimed-by', '=', 'julian')])).toBe(true)
+    expect(matchesLabelMatchers(unclaimed, [lm('@claimed-by', '=', 'julian')])).toBe(false)
+    expect(matchesLabelMatchers(unclaimed, [lm('@claimed-by', '!=', '')])).toBe(false)
+    expect(matchesLabelMatchers(claimed, [lm('@claimed-by', '!=', '')])).toBe(true)
+  })
+
+  it('@claimed-by =~ matches by pattern', () => {
+    const claimed = makeAlert({
+      activeClaim: { id: 1, fingerprint: 'abc123', clusterName: 'cluster-a', claimedBy: 'julian', claimedAt: '2026-01-01T00:00:00Z' },
+    })
+    expect(matchesLabelMatchers(claimed, [lm('@claimed-by', '=~', 'jul.*')])).toBe(true)
+    expect(matchesLabelMatchers(claimed, [lm('@claimed-by', '=~', 'mike')])).toBe(false)
   })
 })
 

--- a/frontend/src/lib/alertUtils.ts
+++ b/frontend/src/lib/alertUtils.ts
@@ -32,9 +32,14 @@ export function labelColorStyle(key: string, theme: 'dark' | 'light' = 'dark'): 
 
 /**
  * Returns an alert's labels augmented with pseudo-labels:
- * - @receiver  (comma-separated list of all receiver names)
- * - receiver   (alias for @receiver)
- * - @cluster   (cluster name)
+ * - @receiver     (comma-separated list of all receiver names)
+ * - receiver      (alias for @receiver)
+ * - @cluster      (cluster name)
+ * - @claimed-by   (active claim's claimedBy, or '' if unclaimed)
+ *
+ * `@age` is NOT included here — it's a moving target (`now - startsAt`), so
+ * it's handled as a special case directly in `matchesLabelMatchers` instead
+ * of being baked into a snapshot of static string labels.
  */
 export function getFilterableLabels(alert: EnrichedAlert): Record<string, string> {
   const labels: Record<string, string> = { ...alert.labels }
@@ -48,7 +53,22 @@ export function getFilterableLabels(alert: EnrichedAlert): Record<string, string
   labels['@receiver'] = receiverList
   labels['receiver'] = receiverList
   labels['@cluster'] = alert.clusterName
+  labels['@claimed-by'] = alert.activeClaim?.claimedBy ?? ''
   return labels
+}
+
+/**
+ * Parses a single-unit duration string (`30s`, `15m`, `2h`, `1d`) into
+ * milliseconds. Returns null for anything else — no combined units, no
+ * decimals, no negative values — consistent with `safeRegex`'s "invalid
+ * input → null, caller decides the no-match fallback" contract.
+ */
+export function parseDurationValue(input: string): number | null {
+  const match = /^(\d+)(s|m|h|d)$/.exec(input.trim())
+  if (!match) return null
+  const amount = Number(match[1])
+  const unitMs = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 }[match[2] as 's' | 'm' | 'h' | 'd']
+  return amount * unitMs
 }
 
 // ── Affected-alert identifier ──────────────────────────────────────────────
@@ -124,6 +144,19 @@ export function matchesLabelMatchers(
   if (matchers.length === 0) return true
   const labels = getFilterableLabels(alert)
   return matchers.every((m) => {
+    // @age is dynamic (now - startsAt), so it's evaluated here instead of
+    // being materialized into getFilterableLabels' static label snapshot.
+    // Only >/< are meaningful for it; every other operator is a no-match by
+    // design (decision 2, idea 2.10).
+    if (m.name === '@age') {
+      if (m.operator !== '>' && m.operator !== '<') return false
+      const thresholdMs = parseDurationValue(m.value)
+      if (thresholdMs === null) return false
+      const ageMs = Date.now() - new Date(alert.startsAt).getTime()
+      return m.operator === '>' ? ageMs > thresholdMs : ageMs < thresholdMs
+    }
+    // >/< are @age-only operators (decision 1) — never match a normal label.
+    if (m.operator === '>' || m.operator === '<') return false
     const value = labels[m.name] ?? ''
     // Special handling for receiver/@receiver: they are comma-separated lists.
     // For equality operators, check if any receiver matches.

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -169,7 +169,7 @@ export interface AlertGroup {
 
 // ── Filter / UI ───────────────────────────────────────────────────────────────
 
-export type LabelMatcherOperator = '=' | '!=' | '=~' | '!~'
+export type LabelMatcherOperator = '=' | '!=' | '=~' | '!~' | '>' | '<'
 
 export interface LabelMatcher {
   id: string


### PR DESCRIPTION
## Summary
- Adds two Karma-inspired pseudo-fields to the matcher chip filter bar: `@age` (alert age via `>`/`<`, single-unit duration like `15m`/`2h`/`1d`) and `@claimed-by` (filter by who claimed an alert; empty string = unclaimed).
- `LabelMatcherOperator` grows `>`/`<`; the operator dropdown only offers them for `@age`, and an `@age` draft with an unparseable duration is never promoted into a committed filter chip (red border + hint instead).
- Docs updated: `.agents/architecture.md` (lib/component reference) and `docs/features.md` (user-facing filter reference).

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test:unit:coverage` — 181/181 passed, 100% stmts/funcs/lines, 99.61% branch (gate: 99%)
- [x] `make e2e-mode MODE=none` — 133 passed, 2 skipped, incl. 3 new specs (D1 `@age` filters by age, D2 `@claimed-by` filters by claim, D3 invalid duration cannot commit as a chip)
- [ ] `make e2e-mode MODE=internal` / `MODE=oidc` — not run locally (feature is client-side, auth-mode independent); CI runs all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)