### PR TITLE
feat(alerts): navigate between group siblings from the detail panel

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -595,6 +595,12 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
     │   ├── AlertDetailPanel.tsx → slide-over: labels/annotations + link buttons, stats & timeline,
     │   │                          claim (useClaimController), comments (CommentsPanel), silence
     │   │                          controls + Fast-Silence, AI-prompt section;
+    │   │                          when the alert was opened from a multi-alert list/card group,
+    │   │                          `uiStore.selectedGroupKeys` holds the sibling selection keys and a
+    │   │                          fixed up/down chevron pair renders left of the sheet (position
+    │   │                          mirrors the sheet's own width breakpoints) to step through them —
+    │   │                          also bound to ArrowUp/ArrowDown globally while the panel is open
+    │   │                          (ignored while focus is in an input/textarea/contenteditable);
     │   │                          header (below the stats line, above the action buttons) embeds
     │   │                          AlertHeatmap directly — not a collapsible section, always visible;
     │   │                          close (X) is rendered inline in the header row next to the status
@@ -786,6 +792,11 @@ interface UIStore {
   silencesViewMode: ViewMode                    // silences view (key 'jarvis-silencesViewMode')
   isFullscreen: boolean                         // NOT persisted
   selectedFingerprint: string | null            // NOT persisted (detail panel target)
+  selectedGroupKeys: string[] | null             // NOT persisted; sibling selection keys of the alert-list
+                                                //   group (list/card grouped view) the current selection came
+                                                //   from — null outside a group context. Set via
+                                                //   setSelectedFingerprint(fp, groupKeys); drives the
+                                                //   up/down group-navigation arrows in AlertDetailPanel.
   detailTab: DetailTab                          // NOT persisted (detail-panel tab; synced to `tab` URL param;
                                                 //   setSelectedFingerprint/setActivePage reset it to 'details')
   filters: {

--- a/frontend/src/components/alerts/AlertCard.tsx
+++ b/frontend/src/components/alerts/AlertCard.tsx
@@ -21,7 +21,7 @@ const PAGE_SIZE = 3
 interface AlertCardProps {
   alerts: EnrichedAlert[]
   silences: Silence[]
-  onClick: (selectionKey: string) => void
+  onClick: (selectionKey: string, groupKeys?: string[] | null) => void
   selectedFingerprint?: string | null
   onCreateSilence?: (alerts: EnrichedAlert[]) => void
   showSeverityBadge?: boolean
@@ -71,13 +71,15 @@ function AlertEntry({
   isSelected,
   commonLabelKeys,
   onCreateSilence,
+  groupKeys,
 }: {
   alert: EnrichedAlert
   silences: Silence[]
-  onClick: (selectionKey: string) => void
+  onClick: (selectionKey: string, groupKeys?: string[] | null) => void
   isSelected: boolean
   commonLabelKeys: Set<string>
   onCreateSilence?: (alerts: EnrichedAlert[]) => void
+  groupKeys: string[] | null
 }) {
   const { type: silenceType, silence, remaining } = getSilenceState(alert, silences)
   const expiredSilence = silenceType === null ? getExpiredSilence(alert, silences) : null
@@ -104,8 +106,8 @@ function AlertEntry({
       tabIndex={0}
       data-testid="alert-card"
       data-fingerprint={alert.fingerprint}
-      onClick={() => onClick(makeAlertSelectionKeyForAlert(alert))}
-      onKeyDown={(e) => e.key === 'Enter' && onClick(makeAlertSelectionKeyForAlert(alert))}
+      onClick={() => onClick(makeAlertSelectionKeyForAlert(alert), groupKeys)}
+      onKeyDown={(e) => e.key === 'Enter' && onClick(makeAlertSelectionKeyForAlert(alert), groupKeys)}
       className={cn(
         'group relative flex cursor-pointer items-start gap-1 border-l-2 border-transparent px-3 py-2.5 transition-colors focus:outline-none focus-visible:outline-none',
         claim
@@ -267,6 +269,7 @@ export function AlertCard({
 
   const visible = alerts.slice(0, visibleCount)
   const claimedCount = alerts.filter((a) => a.activeClaim != null).length
+  const groupKeys = alerts.length > 1 ? alerts.map(makeAlertSelectionKeyForAlert) : null
 
   const commonLabels = getCommonLabels(alerts)
   const commonLabelKeys = new Set(Object.keys(commonLabels))
@@ -346,6 +349,7 @@ export function AlertCard({
               isSelected={matchesAlertSelectionKey(alert, selectedFingerprint)}
               commonLabelKeys={commonLabelKeys}
               onCreateSilence={onCreateSilence}
+              groupKeys={groupKeys}
             />
           ))}
         </div>

--- a/frontend/src/components/alerts/AlertDetailPanel.tsx
+++ b/frontend/src/components/alerts/AlertDetailPanel.tsx
@@ -206,7 +206,7 @@ interface AlertDetailPanelProps {
   onAddLabelMatcher: (matcher: Omit<LabelMatcher, 'id'>) => void
   runbookBaseUrl?: string
   silences: Silence[]
-  onSelectAlert?: (selectionKey: string) => void
+  onSelectAlert?: (selectionKey: string, groupKeys?: string[] | null) => void
 }
 
 export function AlertDetailPanel({
@@ -241,7 +241,37 @@ export function AlertDetailPanel({
   // to 'details' inside setSelectedFingerprint.
   const activeTab = useUIStore((s) => s.detailTab)
   const setActiveTab = useUIStore((s) => s.setDetailTab)
+  const selectedGroupKeys = useUIStore((s) => s.selectedGroupKeys)
   const fmtTime = useFormatTime()
+
+  // Up/down arrow navigation between sibling alerts of the group (list/card
+  // grouped view) the current selection came from. `selectedGroupKeys` is
+  // null outside a group context, so the nav UI stays hidden there.
+  const groupNavIndex = alert && selectedGroupKeys
+    ? selectedGroupKeys.indexOf(makeAlertSelectionKeyForAlert(alert))
+    : -1
+  const groupNavEnabled = groupNavIndex !== -1 && (selectedGroupKeys?.length ?? 0) > 1
+
+  function navigateGroup(direction: 1 | -1) {
+    if (!onSelectAlert || !selectedGroupKeys || groupNavIndex === -1) return
+    const len = selectedGroupKeys.length
+    const nextIndex = (groupNavIndex + direction + len) % len
+    onSelectAlert(selectedGroupKeys[nextIndex], selectedGroupKeys)
+  }
+
+  useEffect(() => {
+    if (!groupNavEnabled) return
+    function onKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null
+      if (target && ['INPUT', 'TEXTAREA'].includes(target.tagName)) return
+      if (target?.isContentEditable) return
+      if (e.key === 'ArrowUp') { e.preventDefault(); navigateGroup(-1) }
+      else if (e.key === 'ArrowDown') { e.preventDefault(); navigateGroup(1) }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupNavEnabled, groupNavIndex, selectedGroupKeys])
 
   const historyOffset = (historyPage - 1) * historyPageSize
   const { data: timelineData } = useAlertTimeline(
@@ -1043,6 +1073,41 @@ export function AlertDetailPanel({
         )}
 
       </Sheet>
+
+      {/* Group navigation — rendered after the Sheet and overlapping its left
+          border by 1px so the box (same bg-card) reads as a seamless extension
+          of the panel with no divider line between them. */}
+      {groupNavEnabled && (
+        <div
+          className="fixed top-12 z-50 rounded-l-md border border-r-0 border-border bg-card right-0 sm:right-[calc(37.8rem-1px)] lg:right-[calc(50.4rem-1px)]"
+          data-testid="detail-panel-group-nav"
+        >
+          {/* Same two-layer background as the sheet header (bg-muted/30 over bg-card). */}
+          <div className="flex flex-col items-center rounded-l-md bg-muted/30">
+            <button
+              type="button"
+              onClick={() => navigateGroup(-1)}
+              title="Previous alert in group (↑)"
+              aria-label="Previous alert in group"
+              className="flex h-10 w-12 items-center justify-center rounded-tl-md text-muted-foreground hover:bg-accent hover:text-foreground cursor-pointer"
+            >
+              <ChevronUp className="h-5 w-5" />
+            </button>
+            <span className="w-full py-1 text-center text-[11px] font-semibold text-muted-foreground">
+              {groupNavIndex + 1}/{selectedGroupKeys?.length}
+            </span>
+            <button
+              type="button"
+              onClick={() => navigateGroup(1)}
+              title="Next alert in group (↓)"
+              aria-label="Next alert in group"
+              className="flex h-10 w-12 items-center justify-center rounded-bl-md text-muted-foreground hover:bg-accent hover:text-foreground cursor-pointer"
+            >
+              <ChevronDown className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Silence form sheet (new silence for this alert) */}
       {showNewSilenceForm && (

--- a/frontend/src/components/alerts/AlertListView.tsx
+++ b/frontend/src/components/alerts/AlertListView.tsx
@@ -16,14 +16,14 @@ import { useSettingsStore, RESOLVED_PAGE_SIZE_OPTIONS } from '@/store/useSetting
 import { useUIStore } from '@/store/uiStore'
 import { useLoginGuard } from '@/hooks/useLoginGuard'
 import { LoginModal } from '@/components/auth/LoginModal'
-import { matchesAlertSelectionKey } from '@/lib/alertSelection'
+import { matchesAlertSelectionKey, makeAlertSelectionKeyForAlert } from '@/lib/alertSelection'
 import type { EnrichedAlert, Silence } from '@/types'
 import { cn } from '@/lib/utils'
 
 interface AlertListViewProps {
   alerts: EnrichedAlert[]
   silences: Silence[]
-  onSelectAlert: (selectionKey: string) => void
+  onSelectAlert: (selectionKey: string, groupKeys?: string[] | null) => void
   selectedFingerprint?: string | null
   stateFilter?: string
   resolvedMode?: boolean
@@ -891,7 +891,12 @@ export function AlertListView({
                           <AlertListRow
                             key={alertRowKey(alert)}
                             alert={alert}
-                            onClick={onSelectAlert}
+                            onClick={(key) =>
+                              onSelectAlert(
+                                key,
+                                group.alerts.length > 1 ? group.alerts.map(makeAlertSelectionKeyForAlert) : null,
+                              )
+                            }
                             selected={matchesAlertSelectionKey(alert, selectedFingerprint)}
                             indented
                             isLastInGroup={idx === group.alerts.length - 1}

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -31,6 +31,13 @@ interface UIStore {
   activeViewMode: ViewMode
   activePage: ActivePage
   selectedFingerprint: string | null
+  /**
+   * Selection keys of the sibling alerts in the same alert-list group as
+   * `selectedFingerprint` (list/card grouped views only), in display order.
+   * Null when the current selection didn't come from a multi-alert group —
+   * drives the group-navigation arrows in AlertDetailPanel.
+   */
+  selectedGroupKeys: string[] | null
   /** Active tab of the alert detail panel — synced to the `tab` URL param so reload/share lands on it. */
   detailTab: DetailTab
   filters: Filters
@@ -46,7 +53,7 @@ interface UIStore {
   setActiveViewMode: (mode: ViewMode) => void
   setSilencesViewMode: (mode: ViewMode) => void
   setIsFullscreen: (v: boolean) => void
-  setSelectedFingerprint: (fp: string | null) => void
+  setSelectedFingerprint: (fp: string | null, groupKeys?: string[] | null) => void
   setDetailTab: (tab: DetailTab) => void
   setFilter: (key: keyof Omit<Filters, 'labelMatchers'>, value: string) => void
   addLabelMatcher: (matcher: Omit<LabelMatcher, 'id'>) => void
@@ -108,6 +115,7 @@ export const useUIStore = create<UIStore>()(
       isFullscreen: false,
       activePage: 'alerts',
       selectedFingerprint: null,
+      selectedGroupKeys: null,
       detailTab: 'details',
       filters: defaultFilters,
       wsConnected: false,
@@ -126,11 +134,13 @@ export const useUIStore = create<UIStore>()(
         set({ silencesViewMode: mode })
       },
       setIsFullscreen: (v) => set({ isFullscreen: v }),
-      setActivePage: (page) => set({ activePage: page, selectedFingerprint: null, detailTab: 'details' }),
+      setActivePage: (page) => set({ activePage: page, selectedFingerprint: null, selectedGroupKeys: null, detailTab: 'details' }),
       // Selecting a different alert (or closing the panel) resets the tab —
       // URL hydration relies on this order: setSelectedFingerprint first,
-      // setDetailTab afterwards.
-      setSelectedFingerprint: (fp) => set({ selectedFingerprint: fp, detailTab: 'details' }),
+      // setDetailTab afterwards. groupKeys defaults to null so selections
+      // outside a group context (card grid, related-tab jumps) drop any
+      // stale group-navigation state from a previous selection.
+      setSelectedFingerprint: (fp, groupKeys = null) => set({ selectedFingerprint: fp, selectedGroupKeys: groupKeys, detailTab: 'details' }),
       setDetailTab: (tab) => set({ detailTab: tab }),
       setFilter: (key, value) =>
         set((s) => ({ filters: { ...s.filters, [key]: value } })),


### PR DESCRIPTION
## Summary

When an alert is opened from a multi-alert group (list or card grouped view), the detail panel now shows a docked up/down navigation box on its left edge to step through the group's alerts, including a position indicator (n/total).

- New `uiStore.selectedGroupKeys` field carries the sibling selection keys of the group the selection came from; set alongside `setSelectedFingerprint`, cleared for selections made outside a group context (flat views, related-tab jumps).
- `AlertListView` (grouped rows) and `AlertCard` (card grid groups) pass the sibling keys on click.
- Navigation box is docked seamlessly to the sheet's left edge (same two-layer background as the sheet header, 1px overlap hides the sheet border at the docking point) and only renders when the group has more than one alert.
- ArrowUp/ArrowDown navigate globally while the panel is open, ignored when focus is in an input, textarea, or contenteditable.

## Testing

- `pnpm test:unit:coverage` — 181 tests green, 100% coverage on `lib/alertUtils.ts`
- `pnpm build` (tsc + vite) green
- Manually verified in the dev stack: navigation via buttons and arrow keys across list groups and card groups, indicator updates, nav hidden for single-alert groups and flat views

🤖 Generated with [Claude Code](https://claude.com/claude-code)