### PR TITLE
feat(db): add optional data-retention sweeper

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -471,6 +471,54 @@ collectors and `jarvis_build_info`. `Metrics.Handler()` serves `GET /metrics`.
 
 ---
 
+## Data Retention Sweeper (`internal/retention`)
+
+Optional, env-var-only background deletion of old rows — user-facing docs:
+`docs/retention.md`; config: `Config.Retention` above.
+
+- `Sweeper` (`sweeper.go`), built via `retention.NewSweeper(store,
+  cfg.Retention, logger, m)` in `main.go`, started as `go
+  sweeper.Start(ctx)` alongside `recorder.Start(ctx)`. Its `store` param is
+  a small interface (not `*history.Store` directly) so it's testable
+  without a DB — `*history.Store` satisfies it structurally.
+- `Start` is a **no-op** when `cfg.Retention.Enabled()` is `false` (the
+  default) — no timer, no query, ever. Otherwise the first sweep runs 1
+  minute after `Start` (doesn't compete with boot), then every
+  `cfg.Retention.SweepInterval`.
+- `sweep()` runs domains in FK-safe order: comments (if
+  `EffectiveCommentsDays() > 0`) → released claims → silence events →
+  detach comment/claim survivors from soon-to-be-deleted events → events →
+  orphan fingerprints last (cutoff = the **widest** of all four effective
+  retentions, since a fingerprint may only vanish once nothing anywhere
+  still references it). One domain's error is logged and does **not**
+  abort the others.
+- `history/store_retention.go` holds the six store methods the Sweeper
+  calls, all batched (500 rows, `batchDeleteLoop`, short pause between
+  batches — Critical Invariant #8, SQLite single writer) and
+  context-cancellable:
+  `DeleteSweepableEventsBefore`, `DetachCommentsAndClaimsFromSweepableEventsBefore`,
+  `DeleteReleasedClaimsBefore`, `DeleteCommentsBefore`,
+  `DeleteSilenceEventsBefore`, `DeleteOrphanFingerprintsBefore`.
+- `sweepableEventsCondition` (shared SQL fragment, same file) decides which
+  `alert_events` rows are safe to delete: the episode is already closed
+  (`resolved`/`expired`), OR a newer event exists for the same
+  `(fingerprint, cluster_name)` (this row is superseded). It deliberately
+  does **not** use `ends_at` — no INSERT ever writes it, it's always NULL —
+  and never matches the newest row of a still-`firing`/`suppressed`
+  episode, however old, since the recorder only writes rows on status
+  *changes*.
+- Metrics: `jarvis_retention_sweeps_total`,
+  `jarvis_retention_deleted_rows_total{table}`,
+  `jarvis_retention_sweep_duration_seconds` (`docs/metrics.md`).
+- Known accepted side effect: a fingerprint's **global** `occurrence_count`
+  survives event deletion (lives on `alert_fingerprints`), but **per-cluster**
+  stats/heatmap are derived live from `alert_events` and shrink to the
+  retention window after a sweep. If a fingerprint survives only via a
+  surviving comment and later re-fires, `RecordStatusChange` finds no prior
+  event and does not increment `occurrence_count` (also doesn't reset it).
+
+---
+
 ## Frontend Component Tree (`frontend/src/`)
 
 ```
@@ -891,6 +939,7 @@ banner collapse state in AlertDetailPanel, default collapsed)
 | `JARVIS_CLUSTER_N_BASIC_AUTH_USER` `…_BASIC_AUTH_PASSWORD` `…_BEARER_TOKEN` | per-cluster upstream auth |
 | `JARVIS_CLUSTER_N_HEADER_<Name>` | arbitrary custom HTTP header sent with every upstream request (header name taken verbatim after `HEADER_`) |
 | `JARVIS_CLUSTER_N_OAUTH2_CLIENT_ID` `…_OAUTH2_CLIENT_SECRET` `…_OAUTH2_TOKEN_URL` `…_OAUTH2_SCOPES` | per-cluster OAuth2 client-credentials (takes priority over bearer/basic/headers) |
+| `JARVIS_RETENTION_DAYS` `…_EVENTS_DAYS` `…_CLAIMS_DAYS` `…_SILENCE_EVENTS_DAYS` `…_COMMENTS_DAYS` `…_SWEEP_INTERVAL` | data retention (`docs/retention.md`); `Config.Retention RetentionConfig`. All `*_DAYS` default `0` = disabled — an upgrade never silently deletes data. `EffectiveEventsDays`/`EffectiveClaimsDays`/`EffectiveSilenceEventsDays` inherit the global `Days` when their own override is `0`; `EffectiveCommentsDays` **never** inherits — only an explicit `JARVIS_RETENTION_COMMENTS_DAYS > 0` enables comment deletion. `SweepInterval` default `12h`. Negative values → startup error |
 
 ---
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -85,12 +85,14 @@ make fixtures-unsilence            # expire test silences
 | Package | Test file | What is tested |
 |---|---|---|
 | `internal/config` | `config_test.go` | Config parsing, cluster-N iteration, HOST_ALIAS logic |
+| `internal/config` | `config_retention_test.go` | Retention env vars: defaults (all disabled), global→domain inheritance, per-domain override even when global is 0, comments never inherit the global, sweep-interval parsing, negative/non-integer values → startup error |
 | `internal/config` | `config_fuzz_test.go` | Fuzz: `parseSecretKey` never panics/errors, hex round-trip |
 | `internal/db` | `db_test.go` | `Migrate` idempotent, PRAGMA settings |
 | `internal/db` | `db_fuzz_test.go` | Fuzz: `RedactDSN` never panics, password never leaks |
 | `internal/cluster` | `registry_test.go` | `NewRegistry`, `Get`, `All` — single/multi-cluster |
 | `internal/history` | `store_test.go` | `UpsertFingerprint`, `GetOrCreateActiveEvent`, grace period (60s), `occurrence_count` logic |
 | `internal/history` | `store_extra_test.go` | `GetClaimHistory`, `RecordSilenceEvent`, `GetSilenceEvents`, `GetRecentResolved`, `SeedResolved`, silence templates |
+| `internal/history` | `store_retention_test.go` | Retention delete/detach methods (`store_retention.go`): `sweepableEventsCondition` — open firing/suppressed episode head survives any age, a superseded or resolved/expired row past cutoff is deleted; batching (1200 rows/batch 500); context-cancel stops the loop; detach nulls `event_id` only on rows referencing a soon-to-be-deleted event; released-claim/comment/silence-event cutoffs (active claims always survive); orphan fingerprint sweep (survives with any remaining event/claim/comment, deletes only true orphans past `last_seen_at` cutoff); re-fire after a full event sweep does not inflate `occurrence_count` |
 | `internal/history` | `alert_store_test.go` | `Set`/`Get`/`MarkResolved`/`RemoveByFingerprint` (thread safety via goroutines) |
 | `internal/history` | `silence_store_test.go` | `SilenceStore`: Set/Get copy semantics, Upsert, MarkExpired, Reset, concurrent access |
 | `internal/history` | `lifecycle_test.go` | Integration: FiringToResolved, SuppressedExpired, GracePeriod, ReoccurrenceAfterResolution, FullCycle |
@@ -99,6 +101,7 @@ make fixtures-unsilence            # expire test silences
 | `internal/history` | `enrich_test.go` | Alert enrichment (active claim attachment) |
 | `internal/history` | `optimization_test.go` | Query/indexing optimizations |
 | `internal/history` | `time_fuzz_test.go` | Fuzz: `parseNullableTimeString` never panics, err/Valid contract |
+| `internal/retention` | `sweeper_test.go` | `Sweeper`: disabled config → `Start` never calls the store; context cancelled before the first sweep stops cleanly; full sweep order + per-domain cutoffs against a `fakeStore` (comments → claims → silence events → detach → events → orphan, orphan cutoff = widest of the four); domains with no effective retention are skipped; one domain's error doesn't abort the rest; `jarvis_retention_*` metrics counted; nil `*metrics.Metrics` doesn't panic |
 | `internal/alertmanager` | `client_test.go` | HTTP client against `httptest.NewServer` |
 | `internal/alertmanager` | `auth_test.go` `oauth2_test.go` | Per-cluster upstream auth (basic/bearer/OAuth2) |
 | `internal/api` | `alerts_test.go` | Alert list/detail handler |

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,17 @@ JARVIS_DB_DSN=/data/jarvis.db
 # Use sslmode=require (or verify-full) in production.
 # sslmode=disable is only acceptable for local ephemeral test containers.
 
+# Data retention — see docs/retention.md. Disabled by default (0): an
+# upgrade must never silently delete data. All values are in days unless noted.
+# JARVIS_RETENTION_DAYS=365                    # global default; 0 = disabled
+# JARVIS_RETENTION_EVENTS_DAYS=                # override for alert_events (unset = inherit above)
+# JARVIS_RETENTION_CLAIMS_DAYS=                 # override for released alert_claims
+# JARVIS_RETENTION_SILENCE_EVENTS_DAYS=         # override for silence_events (audit log)
+# JARVIS_RETENTION_COMMENTS_DAYS=               # comments are NEVER inherited from the global
+#                                                # value above — 0/unset keeps them forever, only
+#                                                # an explicit value here enables comment deletion
+# JARVIS_RETENTION_SWEEP_INTERVAL=12h           # default
+
 # Optional: Base URL for runbook links.
 # Applied when the "runbook" label or annotation value is NOT an absolute URL.
 # The label/annotation value is appended to form the final URL.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,7 @@ linters:
         linters:
           - gosec
         text: "G202"
+      - path: "internal/history/store_retention.go"
+        linters:
+          - gosec
+        text: "G202"

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.
 - [docs/authentication-user.md](docs/authentication-user.md) — user login: providers (none / internal / OIDC), first-run wizard, roles, sessions, Helm
 - [docs/authentication-alertmanager.md](docs/authentication-alertmanager.md) — Alertmanager upstream auth: OAuth2 client credentials, bearer token, basic auth, custom headers
 - [docs/metrics.md](docs/metrics.md) — Prometheus `/metrics` endpoint: exported metrics, scrape config, ServiceMonitor
+- [docs/retention.md](docs/retention.md) — optional data-retention sweep: what gets deleted, `JARVIS_RETENTION_*` config, sweep order
 - [AGENTS.md](AGENTS.md) — AI-agent entry point: conventions, critical invariants, task router
 - [.agents/testing.md](.agents/testing.md) — full test strategy, matrix, and CI pipeline
 - [docs/security.md](docs/security.md) — security measures

--- a/backend/cmd/jarvis/main.go
+++ b/backend/cmd/jarvis/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/db"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
+	"github.com/kj187/jarvis/backend/internal/retention"
 	"github.com/kj187/jarvis/backend/internal/static"
 	"github.com/kj187/jarvis/backend/internal/users"
 	"github.com/kj187/jarvis/backend/internal/version"
@@ -117,6 +118,11 @@ func main() {
 	recorder := history.NewRecorder(registry, alertStore, silenceStore, store, hub, cfg.PollInterval, logger, m, claimReleaseDelay)
 	m.MustRegister(metrics.NewCollector(alertStore, hub, recorder.ClusterUpStates, len(registry.All())))
 
+	// ── Retention Sweeper ─────────────────────────────────────────────────────
+	// Fully opt-in: with the default config (all JARVIS_RETENTION_* unset)
+	// sweeper.Start is a no-op — no timer, no query, ever.
+	sweeper := retention.NewSweeper(store, cfg.Retention, logger, m)
+
 	// ── HTTP Router ───────────────────────────────────────────────────────────
 	router := api.NewRouter(alertStore, silenceStore, store, hub, registry, cfg, static.StaticFiles, recorder, authProvider, userStore, m)
 
@@ -133,6 +139,7 @@ func main() {
 	defer stop()
 
 	go recorder.Start(ctx)
+	go sweeper.Start(ctx)
 
 	go func() {
 		logger.Info("jarvis started", "port", cfg.Port)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +37,73 @@ type Config struct {
 	OIDCScopes       []string
 	OIDCAdminClaim   string // claim name that controls admin role (e.g. "groups", "cognito:groups")
 	OIDCAdminValue   string // value inside that claim that grants admin (e.g. "Administrator")
+
+	Retention RetentionConfig
+}
+
+// RetentionConfig holds the data-retention sweep settings. All Days fields
+// are 0 by default — retention is opt-in, an upgrade must never silently
+// delete data. See EffectiveEventsDays/EffectiveClaimsDays/
+// EffectiveSilenceEventsDays/EffectiveCommentsDays for override semantics.
+type RetentionConfig struct {
+	// Days is the global default retention in days. 0 disables retention
+	// entirely unless a per-domain override below is set.
+	Days int
+	// EventsDays/ClaimsDays/SilenceEventsDays override Days for their
+	// domain when > 0; 0/unset inherits Days.
+	EventsDays        int
+	ClaimsDays        int
+	SilenceEventsDays int
+	// CommentsDays is deliberately NOT inherited from Days — comments carry
+	// user-written context that should survive a re-firing alert. Only an
+	// explicit value > 0 enables comment deletion.
+	CommentsDays int
+	// SweepInterval is how often the background sweeper runs.
+	SweepInterval time.Duration
+}
+
+func effectiveRetentionDays(global, override int) int {
+	if override > 0 {
+		return override
+	}
+	return global
+}
+
+// EffectiveEventsDays returns the retention window for alert_events —
+// EventsDays if set, else the global Days.
+func (r RetentionConfig) EffectiveEventsDays() int {
+	return effectiveRetentionDays(r.Days, r.EventsDays)
+}
+
+// EffectiveClaimsDays returns the retention window for released alert_claims
+// — ClaimsDays if set, else the global Days.
+func (r RetentionConfig) EffectiveClaimsDays() int {
+	return effectiveRetentionDays(r.Days, r.ClaimsDays)
+}
+
+// EffectiveSilenceEventsDays returns the retention window for silence_events
+// — SilenceEventsDays if set, else the global Days.
+func (r RetentionConfig) EffectiveSilenceEventsDays() int {
+	return effectiveRetentionDays(r.Days, r.SilenceEventsDays)
+}
+
+// EffectiveCommentsDays returns the retention window for alert_comments.
+// Unlike the other domains it never inherits the global Days — only an
+// explicit CommentsDays > 0 enables comment deletion.
+func (r RetentionConfig) EffectiveCommentsDays() int {
+	if r.CommentsDays > 0 {
+		return r.CommentsDays
+	}
+	return 0
+}
+
+// Enabled reports whether any domain has an effective retention configured,
+// i.e. whether the sweeper has any work to do at all.
+func (r RetentionConfig) Enabled() bool {
+	return r.EffectiveEventsDays() > 0 ||
+		r.EffectiveClaimsDays() > 0 ||
+		r.EffectiveSilenceEventsDays() > 0 ||
+		r.EffectiveCommentsDays() > 0
 }
 
 // OAuth2Config holds OAuth2 client credentials for per-cluster Alertmanager authentication.
@@ -137,6 +205,11 @@ func Load() (*Config, error) {
 		oidcScopes = strings.Split(raw, ",")
 	}
 
+	retention, err := parseRetention()
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
 		Port:             getEnv("JARVIS_PORT", "8080"),
 		LogLevel:         getEnv("JARVIS_LOG_LEVEL", "info"),
@@ -156,6 +229,57 @@ func Load() (*Config, error) {
 		OIDCScopes:       oidcScopes,
 		OIDCAdminClaim:   getEnv("JARVIS_OIDC_ADMIN_CLAIM", ""),
 		OIDCAdminValue:   getEnv("JARVIS_OIDC_ADMIN_VALUE", ""),
+		Retention:        retention,
+	}, nil
+}
+
+// parseRetentionDays reads a non-negative integer env var (days), defaulting
+// to 0 (disabled). Negative values are a startup error.
+func parseRetentionDays(key string) (int, error) {
+	raw := getEnv(key, "0")
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: must be an integer, got %q", key, raw)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("invalid %s: must be >= 0, got %d", key, v)
+	}
+	return v, nil
+}
+
+// parseRetention reads all JARVIS_RETENTION_* env vars into a RetentionConfig.
+func parseRetention() (RetentionConfig, error) {
+	days, err := parseRetentionDays("JARVIS_RETENTION_DAYS")
+	if err != nil {
+		return RetentionConfig{}, err
+	}
+	eventsDays, err := parseRetentionDays("JARVIS_RETENTION_EVENTS_DAYS")
+	if err != nil {
+		return RetentionConfig{}, err
+	}
+	claimsDays, err := parseRetentionDays("JARVIS_RETENTION_CLAIMS_DAYS")
+	if err != nil {
+		return RetentionConfig{}, err
+	}
+	silenceEventsDays, err := parseRetentionDays("JARVIS_RETENTION_SILENCE_EVENTS_DAYS")
+	if err != nil {
+		return RetentionConfig{}, err
+	}
+	commentsDays, err := parseRetentionDays("JARVIS_RETENTION_COMMENTS_DAYS")
+	if err != nil {
+		return RetentionConfig{}, err
+	}
+	sweepInterval, err := time.ParseDuration(getEnv("JARVIS_RETENTION_SWEEP_INTERVAL", "12h"))
+	if err != nil {
+		return RetentionConfig{}, fmt.Errorf("invalid JARVIS_RETENTION_SWEEP_INTERVAL: %w", err)
+	}
+	return RetentionConfig{
+		Days:              days,
+		EventsDays:        eventsDays,
+		ClaimsDays:        claimsDays,
+		SilenceEventsDays: silenceEventsDays,
+		CommentsDays:      commentsDays,
+		SweepInterval:     sweepInterval,
 	}, nil
 }
 

--- a/backend/internal/config/config_retention_test.go
+++ b/backend/internal/config/config_retention_test.go
@@ -1,0 +1,184 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func clearRetentionEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"JARVIS_RETENTION_DAYS",
+		"JARVIS_RETENTION_EVENTS_DAYS",
+		"JARVIS_RETENTION_CLAIMS_DAYS",
+		"JARVIS_RETENTION_SILENCE_EVENTS_DAYS",
+		"JARVIS_RETENTION_COMMENTS_DAYS",
+		"JARVIS_RETENTION_SWEEP_INTERVAL",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestLoad_Retention_Defaults(t *testing.T) {
+	clearRetentionEnv(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Retention.Days != 0 {
+		t.Errorf("Retention.Days = %d, want 0", cfg.Retention.Days)
+	}
+	if cfg.Retention.EventsDays != 0 {
+		t.Errorf("Retention.EventsDays = %d, want 0", cfg.Retention.EventsDays)
+	}
+	if cfg.Retention.ClaimsDays != 0 {
+		t.Errorf("Retention.ClaimsDays = %d, want 0", cfg.Retention.ClaimsDays)
+	}
+	if cfg.Retention.SilenceEventsDays != 0 {
+		t.Errorf("Retention.SilenceEventsDays = %d, want 0", cfg.Retention.SilenceEventsDays)
+	}
+	if cfg.Retention.CommentsDays != 0 {
+		t.Errorf("Retention.CommentsDays = %d, want 0", cfg.Retention.CommentsDays)
+	}
+	if cfg.Retention.SweepInterval != 12*time.Hour {
+		t.Errorf("Retention.SweepInterval = %v, want 12h", cfg.Retention.SweepInterval)
+	}
+
+	// Default config must disable everything, including comments.
+	if cfg.Retention.EffectiveEventsDays() != 0 {
+		t.Errorf("EffectiveEventsDays() = %d, want 0", cfg.Retention.EffectiveEventsDays())
+	}
+	if cfg.Retention.EffectiveClaimsDays() != 0 {
+		t.Errorf("EffectiveClaimsDays() = %d, want 0", cfg.Retention.EffectiveClaimsDays())
+	}
+	if cfg.Retention.EffectiveSilenceEventsDays() != 0 {
+		t.Errorf("EffectiveSilenceEventsDays() = %d, want 0", cfg.Retention.EffectiveSilenceEventsDays())
+	}
+	if cfg.Retention.EffectiveCommentsDays() != 0 {
+		t.Errorf("EffectiveCommentsDays() = %d, want 0", cfg.Retention.EffectiveCommentsDays())
+	}
+	if cfg.Retention.Enabled() {
+		t.Error("Enabled() = true, want false (fully disabled by default)")
+	}
+}
+
+func TestLoad_Retention_GlobalInheritance(t *testing.T) {
+	clearRetentionEnv(t)
+	t.Setenv("JARVIS_RETENTION_DAYS", "30")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// Events/claims/silence-events inherit the global value.
+	if got := cfg.Retention.EffectiveEventsDays(); got != 30 {
+		t.Errorf("EffectiveEventsDays() = %d, want 30", got)
+	}
+	if got := cfg.Retention.EffectiveClaimsDays(); got != 30 {
+		t.Errorf("EffectiveClaimsDays() = %d, want 30", got)
+	}
+	if got := cfg.Retention.EffectiveSilenceEventsDays(); got != 30 {
+		t.Errorf("EffectiveSilenceEventsDays() = %d, want 30", got)
+	}
+	// Comments NEVER inherit the global value.
+	if got := cfg.Retention.EffectiveCommentsDays(); got != 0 {
+		t.Errorf("EffectiveCommentsDays() = %d, want 0 (comments never inherit global)", got)
+	}
+	if !cfg.Retention.Enabled() {
+		t.Error("Enabled() = false, want true")
+	}
+}
+
+func TestLoad_Retention_PerDomainOverride(t *testing.T) {
+	clearRetentionEnv(t)
+	t.Setenv("JARVIS_RETENTION_DAYS", "0")
+	t.Setenv("JARVIS_RETENTION_EVENTS_DAYS", "90")
+	t.Setenv("JARVIS_RETENTION_CLAIMS_DAYS", "7")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// An override > 0 applies even when the global is 0 (selective retention).
+	if got := cfg.Retention.EffectiveEventsDays(); got != 90 {
+		t.Errorf("EffectiveEventsDays() = %d, want 90", got)
+	}
+	if got := cfg.Retention.EffectiveClaimsDays(); got != 7 {
+		t.Errorf("EffectiveClaimsDays() = %d, want 7", got)
+	}
+	// Silence events has no override and global is 0 → stays disabled.
+	if got := cfg.Retention.EffectiveSilenceEventsDays(); got != 0 {
+		t.Errorf("EffectiveSilenceEventsDays() = %d, want 0", got)
+	}
+	if !cfg.Retention.Enabled() {
+		t.Error("Enabled() = false, want true (events override active)")
+	}
+}
+
+func TestLoad_Retention_CommentsExplicitOptIn(t *testing.T) {
+	clearRetentionEnv(t)
+	t.Setenv("JARVIS_RETENTION_DAYS", "30")
+	t.Setenv("JARVIS_RETENTION_COMMENTS_DAYS", "180")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if got := cfg.Retention.EffectiveCommentsDays(); got != 180 {
+		t.Errorf("EffectiveCommentsDays() = %d, want 180 (explicit opt-in)", got)
+	}
+}
+
+func TestLoad_Retention_SweepInterval(t *testing.T) {
+	clearRetentionEnv(t)
+	t.Setenv("JARVIS_RETENTION_SWEEP_INTERVAL", "1h")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Retention.SweepInterval != time.Hour {
+		t.Errorf("SweepInterval = %v, want 1h", cfg.Retention.SweepInterval)
+	}
+}
+
+func TestLoad_Retention_InvalidSweepInterval(t *testing.T) {
+	clearRetentionEnv(t)
+	t.Setenv("JARVIS_RETENTION_SWEEP_INTERVAL", "not-a-duration")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want error for invalid JARVIS_RETENTION_SWEEP_INTERVAL")
+	}
+}
+
+func TestLoad_Retention_NegativeValues(t *testing.T) {
+	cases := []string{
+		"JARVIS_RETENTION_DAYS",
+		"JARVIS_RETENTION_EVENTS_DAYS",
+		"JARVIS_RETENTION_CLAIMS_DAYS",
+		"JARVIS_RETENTION_SILENCE_EVENTS_DAYS",
+		"JARVIS_RETENTION_COMMENTS_DAYS",
+	}
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			clearRetentionEnv(t)
+			t.Setenv(key, "-1")
+			if _, err := Load(); err == nil {
+				t.Fatalf("Load() error = nil, want error for negative %s", key)
+			}
+		})
+	}
+}
+
+func TestLoad_Retention_NonIntegerValue(t *testing.T) {
+	clearRetentionEnv(t)
+	t.Setenv("JARVIS_RETENTION_DAYS", "not-a-number")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want error for non-integer JARVIS_RETENTION_DAYS")
+	}
+}

--- a/backend/internal/history/store_retention.go
+++ b/backend/internal/history/store_retention.go
@@ -1,0 +1,191 @@
+package history
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// sweepableEventsCondition selects alert_events rows (aliased "e") that are
+// safe to delete during a retention sweep: either the episode is already
+// closed (resolved/expired), or a newer event exists for the same
+// (fingerprint, cluster_name) — i.e. this row has been superseded and is no
+// longer the open head of a still-firing/suppressed episode.
+//
+// Deliberately does NOT use ends_at: RecordStatusChange/
+// RecordResolvedForCluster never write it (always NULL), so a condition
+// built on it would never match anything and old firing/suppressed rows
+// would grow unbounded for flapping alerts — exactly what retention is
+// meant to prevent. The one row this predicate never matches, regardless of
+// age, is the newest row per (fingerprint, cluster_name) while its status is
+// firing/suppressed — the open head of a still-active episode, which can
+// legitimately be very old since the recorder only writes rows on status
+// *changes*.
+const sweepableEventsCondition = `
+	e.recorded_at < ?
+	AND (
+		e.status IN ('resolved', 'expired')
+		OR EXISTS (
+			SELECT 1 FROM alert_events n
+			WHERE n.fingerprint = e.fingerprint
+			  AND n.cluster_name = e.cluster_name
+			  AND (n.recorded_at > e.recorded_at
+			       OR (n.recorded_at = e.recorded_at AND n.id > e.id))
+		)
+	)
+`
+
+// batchDeleteLoop repeatedly runs a "DELETE ... WHERE id IN (SELECT ... LIMIT ?)"
+// query (the last '?' bound to batch), pausing briefly between batches, until
+// a batch affects fewer rows than batch. This keeps one retention sweep from
+// holding SQLite's single writer lock (Critical Invariant #8) for one giant
+// transaction. Returns early if ctx is cancelled (server shutdown).
+func (s *Store) batchDeleteLoop(ctx context.Context, query string, batch int, args ...interface{}) (int64, error) {
+	fullArgs := make([]interface{}, len(args)+1)
+	copy(fullArgs, args)
+	fullArgs[len(args)] = batch
+
+	var total int64
+	for {
+		select {
+		case <-ctx.Done():
+			return total, ctx.Err()
+		default:
+		}
+
+		res, err := s.exec(ctx, query, fullArgs...)
+		if err != nil {
+			return total, err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return total, err
+		}
+		total += n
+		if n < int64(batch) {
+			return total, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return total, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// DeleteSweepableEventsBefore deletes alert_events rows matching
+// sweepableEventsCondition, older than cutoff, in batches of batch rows. The
+// open head of a still-firing/suppressed episode is never deleted,
+// regardless of age — see sweepableEventsCondition's doc comment.
+func (s *Store) DeleteSweepableEventsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error) {
+	query := `
+		DELETE FROM alert_events WHERE id IN (
+			SELECT e.id FROM alert_events e
+			WHERE ` + sweepableEventsCondition + `
+			LIMIT ?
+		)
+	`
+	return s.batchDeleteLoop(ctx, query, batch, cutoff.UTC())
+}
+
+// DetachCommentsAndClaimsFromSweepableEventsBefore nulls event_id on every
+// alert_comments/alert_claims row that references an event
+// DeleteSweepableEventsBefore(cutoff, ...) is about to delete. event_id is
+// nullable precisely so a surviving comment/claim never blocks event
+// deletion. Must run before DeleteSweepableEventsBefore in the sweep order.
+func (s *Store) DetachCommentsAndClaimsFromSweepableEventsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	var total int64
+
+	commentsRes, err := s.exec(ctx, `
+		UPDATE alert_comments SET event_id = NULL WHERE event_id IN (
+			SELECT e.id FROM alert_events e WHERE `+sweepableEventsCondition+`
+		)
+	`, cutoff.UTC())
+	if err != nil {
+		return total, fmt.Errorf("detach comments from sweepable events: %w", err)
+	}
+	n, err := commentsRes.RowsAffected()
+	if err != nil {
+		return total, err
+	}
+	total += n
+
+	claimsRes, err := s.exec(ctx, `
+		UPDATE alert_claims SET event_id = NULL WHERE event_id IN (
+			SELECT e.id FROM alert_events e WHERE `+sweepableEventsCondition+`
+		)
+	`, cutoff.UTC())
+	if err != nil {
+		return total, fmt.Errorf("detach claims from sweepable events: %w", err)
+	}
+	n, err = claimsRes.RowsAffected()
+	if err != nil {
+		return total, err
+	}
+	total += n
+
+	return total, nil
+}
+
+// DeleteReleasedClaimsBefore deletes alert_claims rows released
+// (released_at IS NOT NULL) before cutoff, in batches of batch rows. Active
+// claims (released_at NULL) are never touched, regardless of age.
+func (s *Store) DeleteReleasedClaimsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error) {
+	query := `
+		DELETE FROM alert_claims WHERE id IN (
+			SELECT id FROM alert_claims
+			WHERE released_at IS NOT NULL AND released_at < ?
+			LIMIT ?
+		)
+	`
+	return s.batchDeleteLoop(ctx, query, batch, cutoff.UTC())
+}
+
+// DeleteCommentsBefore deletes alert_comments rows older than cutoff (by
+// created_at), in batches of batch rows. Only invoked by the sweeper when
+// JARVIS_RETENTION_COMMENTS_DAYS is explicitly set — comments never inherit
+// the global retention (config.RetentionConfig.EffectiveCommentsDays).
+func (s *Store) DeleteCommentsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error) {
+	query := `
+		DELETE FROM alert_comments WHERE id IN (
+			SELECT id FROM alert_comments WHERE created_at < ? LIMIT ?
+		)
+	`
+	return s.batchDeleteLoop(ctx, query, batch, cutoff.UTC())
+}
+
+// DeleteSilenceEventsBefore deletes silence_events rows older than cutoff (by
+// recorded_at), in batches of batch rows. Pure audit log — no FK to
+// alert_events/alert_fingerprints, so no detach step is needed.
+func (s *Store) DeleteSilenceEventsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error) {
+	query := `
+		DELETE FROM silence_events WHERE id IN (
+			SELECT id FROM silence_events WHERE recorded_at < ? LIMIT ?
+		)
+	`
+	return s.batchDeleteLoop(ctx, query, batch, cutoff.UTC())
+}
+
+// DeleteOrphanFingerprintsBefore deletes alert_fingerprints rows whose
+// last_seen_at is older than cutoff AND that have no remaining alert_events,
+// alert_claims, or alert_comments referencing them — a fingerprint that
+// still has comments survives, which is what lets those comments reappear
+// if the same fingerprint+cluster re-fires later. silence_events do NOT
+// block deletion here: they carry no FK to alert_fingerprints and are a
+// pure audit log with their own independent retention
+// (DeleteSilenceEventsBefore). Must run last in the sweep order, after every
+// other delete/detach, so this check reflects the post-sweep state.
+func (s *Store) DeleteOrphanFingerprintsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error) {
+	query := `
+		DELETE FROM alert_fingerprints WHERE fingerprint IN (
+			SELECT f.fingerprint FROM alert_fingerprints f
+			WHERE f.last_seen_at < ?
+			  AND NOT EXISTS (SELECT 1 FROM alert_events e WHERE e.fingerprint = f.fingerprint)
+			  AND NOT EXISTS (SELECT 1 FROM alert_claims c WHERE c.fingerprint = f.fingerprint)
+			  AND NOT EXISTS (SELECT 1 FROM alert_comments m WHERE m.fingerprint = f.fingerprint)
+			LIMIT ?
+		)
+	`
+	return s.batchDeleteLoop(ctx, query, batch, cutoff.UTC())
+}

--- a/backend/internal/history/store_retention_test.go
+++ b/backend/internal/history/store_retention_test.go
@@ -1,0 +1,587 @@
+package history
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+// backdateEvent sets an alert_events row's recorded_at directly, bypassing
+// RecordStatusChange's grace-period/idempotency logic — needed to build
+// scenarios with events older than the sweep cutoff.
+func backdateEvent(t *testing.T, s *Store, id int64, recordedAt time.Time) {
+	t.Helper()
+	if _, err := s.exec(context.Background(),
+		`UPDATE alert_events SET recorded_at = ? WHERE id = ?`, recordedAt.UTC(), id,
+	); err != nil {
+		t.Fatalf("backdate event %d: %v", id, err)
+	}
+}
+
+func backdateComment(t *testing.T, s *Store, id int64, createdAt time.Time) {
+	t.Helper()
+	if _, err := s.exec(context.Background(),
+		`UPDATE alert_comments SET created_at = ? WHERE id = ?`, createdAt.UTC(), id,
+	); err != nil {
+		t.Fatalf("backdate comment %d: %v", id, err)
+	}
+}
+
+func backdateClaimReleased(t *testing.T, s *Store, id int64, releasedAt time.Time) {
+	t.Helper()
+	if _, err := s.exec(context.Background(),
+		`UPDATE alert_claims SET released_at = ? WHERE id = ?`, releasedAt.UTC(), id,
+	); err != nil {
+		t.Fatalf("backdate claim %d: %v", id, err)
+	}
+}
+
+func backdateSilenceEvent(t *testing.T, s *Store, id int64, recordedAt time.Time) {
+	t.Helper()
+	if _, err := s.exec(context.Background(),
+		`UPDATE silence_events SET recorded_at = ? WHERE id = ?`, recordedAt.UTC(), id,
+	); err != nil {
+		t.Fatalf("backdate silence_event %d: %v", id, err)
+	}
+}
+
+func backdateFingerprintLastSeen(t *testing.T, s *Store, fingerprint string, lastSeenAt time.Time) {
+	t.Helper()
+	if _, err := s.exec(context.Background(),
+		`UPDATE alert_fingerprints SET last_seen_at = ? WHERE fingerprint = ?`, lastSeenAt.UTC(), fingerprint,
+	); err != nil {
+		t.Fatalf("backdate fingerprint %s: %v", fingerprint, err)
+	}
+}
+
+func countRows(t *testing.T, s *Store, table string) int {
+	t.Helper()
+	var n int
+	if err := s.queryRow(context.Background(), `SELECT COUNT(*) FROM `+table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+const oldCutoffDays = 30
+
+func oldCutoff() time.Time {
+	return time.Now().UTC().AddDate(0, 0, -oldCutoffDays)
+}
+
+func TestDeleteSweepableEventsBefore_OpenFiringHeadSurvives(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", map[string]string{"alertname": "TestAlert"}); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	ev, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil)
+	if err != nil {
+		t.Fatalf("RecordStatusChange: %v", err)
+	}
+	// Ancient firing row, but it's the only (= latest) event for this fingerprint+cluster.
+	backdateEvent(t, s, ev.ID, time.Now().AddDate(-1, 0, 0))
+
+	n, err := s.DeleteSweepableEventsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteSweepableEventsBefore: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted = %d, want 0 (open firing head must survive)", n)
+	}
+	if got := countRows(t, s, "alert_events"); got != 1 {
+		t.Errorf("alert_events count = %d, want 1", got)
+	}
+}
+
+func TestDeleteSweepableEventsBefore_OpenSuppressedHeadSurvives(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	ev, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusSuppressed, time.Now(), nil)
+	if err != nil {
+		t.Fatalf("RecordStatusChange: %v", err)
+	}
+	backdateEvent(t, s, ev.ID, time.Now().AddDate(-1, 0, 0))
+
+	n, err := s.DeleteSweepableEventsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteSweepableEventsBefore: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted = %d, want 0 (open suppressed head must survive)", n)
+	}
+}
+
+func TestDeleteSweepableEventsBefore_SupersededFiringRowDeleted(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	firstFiring, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil)
+	if err != nil {
+		t.Fatalf("RecordStatusChange firing: %v", err)
+	}
+	backdateEvent(t, s, firstFiring.ID, time.Now().AddDate(0, 0, -60))
+
+	if err := s.RecordResolvedForCluster("fp1", "cluster-a", time.Now()); err != nil {
+		t.Fatalf("RecordResolvedForCluster: %v", err)
+	}
+	resolvedEvent, err := s.getLastEventForCluster("fp1", "cluster-a")
+	if err != nil {
+		t.Fatalf("getLastEventForCluster: %v", err)
+	}
+	// Both rows must be older than cutoff, with the resolved row unambiguously
+	// newer than the firing row it supersedes (distinct offsets, not relying
+	// on wall-clock ordering between two near-simultaneous backdate calls).
+	backdateEvent(t, s, resolvedEvent.ID, time.Now().AddDate(0, 0, -45))
+
+	n, err := s.DeleteSweepableEventsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteSweepableEventsBefore: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("deleted = %d, want 2 (superseded firing row + old resolved row)", n)
+	}
+	if got := countRows(t, s, "alert_events"); got != 0 {
+		t.Errorf("alert_events count = %d, want 0", got)
+	}
+}
+
+func TestDeleteSweepableEventsBefore_ResolvedNewerThanCutoffSurvives(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	if _, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil); err != nil {
+		t.Fatalf("RecordStatusChange: %v", err)
+	}
+	if err := s.RecordResolvedForCluster("fp1", "cluster-a", time.Now()); err != nil {
+		t.Fatalf("RecordResolvedForCluster: %v", err)
+	}
+	// Both rows are recent (recorded "now"), well within the cutoff window.
+
+	n, err := s.DeleteSweepableEventsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteSweepableEventsBefore: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted = %d, want 0 (recent resolved episode must survive)", n)
+	}
+}
+
+func TestDeleteSweepableEventsBefore_Batching(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	// 1200 old resolved rows, all sweepable (all resolved status).
+	const total = 1200
+	for i := 0; i < total; i++ {
+		id, err := s.insertReturningID(context.Background(), `
+			INSERT INTO alert_events (fingerprint, cluster_name, alertmanager_url, status, starts_at, recorded_at)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`, "fp1", "cluster-a", "http://am", models.EventStatusResolved, time.Now(), time.Now())
+		if err != nil {
+			t.Fatalf("seed event %d: %v", i, err)
+		}
+		backdateEvent(t, s, id, time.Now().AddDate(0, 0, -60))
+	}
+
+	n, err := s.DeleteSweepableEventsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteSweepableEventsBefore: %v", err)
+	}
+	if n != total {
+		t.Errorf("deleted = %d, want %d", n, total)
+	}
+	if got := countRows(t, s, "alert_events"); got != 0 {
+		t.Errorf("alert_events count = %d, want 0", got)
+	}
+}
+
+func TestDeleteSweepableEventsBefore_ContextCancelStops(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		id, err := s.insertReturningID(context.Background(), `
+			INSERT INTO alert_events (fingerprint, cluster_name, alertmanager_url, status, starts_at, recorded_at)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`, "fp1", "cluster-a", "http://am", models.EventStatusResolved, time.Now(), time.Now())
+		if err != nil {
+			t.Fatalf("seed event %d: %v", i, err)
+		}
+		backdateEvent(t, s, id, time.Now().AddDate(0, 0, -60))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := s.DeleteSweepableEventsBefore(ctx, oldCutoff(), 500)
+	if err == nil {
+		t.Fatal("DeleteSweepableEventsBefore with a cancelled context: err = nil, want context.Canceled")
+	}
+}
+
+func TestDetachCommentsAndClaimsFromSweepableEventsBefore(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	openHead, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil)
+	if err != nil {
+		t.Fatalf("RecordStatusChange: %v", err)
+	}
+	backdateEvent(t, s, openHead.ID, time.Now().AddDate(-1, 0, 0))
+
+	if err := s.RecordResolvedForCluster("fp1", "cluster-a", time.Now()); err != nil {
+		t.Fatalf("RecordResolvedForCluster: %v", err)
+	}
+	// Now firing (openHead.ID) is superseded → sweepable; the new resolved row is the head.
+	// Add a second, older fingerprint whose sole event stays open (firing head) to attach a comment/claim to.
+	if err := s.UpsertFingerprint("fp2", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint fp2: %v", err)
+	}
+	survivingHead, _, err := s.RecordStatusChange("fp2", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil)
+	if err != nil {
+		t.Fatalf("RecordStatusChange fp2: %v", err)
+	}
+	backdateEvent(t, s, survivingHead.ID, time.Now().AddDate(-1, 0, 0))
+
+	sweepableComment, err := s.AddComment("fp1", "cluster-a", &openHead.ID, nil, "alice", "old comment")
+	if err != nil {
+		t.Fatalf("AddComment sweepable: %v", err)
+	}
+	survivingComment, err := s.AddComment("fp2", "cluster-a", &survivingHead.ID, nil, "bob", "still-open comment")
+	if err != nil {
+		t.Fatalf("AddComment surviving: %v", err)
+	}
+
+	sweepableClaim, err := s.SetClaim("fp1", "cluster-a", &openHead.ID, "alice", "")
+	if err != nil {
+		t.Fatalf("SetClaim sweepable: %v", err)
+	}
+	if _, err := s.ReleaseClaim("fp1", "cluster-a", "alice", "manual"); err != nil {
+		t.Fatalf("ReleaseClaim: %v", err)
+	}
+	survivingClaim, err := s.SetClaim("fp2", "cluster-a", &survivingHead.ID, "bob", "")
+	if err != nil {
+		t.Fatalf("SetClaim surviving: %v", err)
+	}
+
+	n, err := s.DetachCommentsAndClaimsFromSweepableEventsBefore(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("DetachCommentsAndClaimsFromSweepableEventsBefore: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("detached = %d, want 2 (1 comment + 1 claim)", n)
+	}
+
+	gotComment, err := s.GetComment("fp1", "cluster-a", sweepableComment.ID)
+	if err != nil {
+		t.Fatalf("GetComment sweepable: %v", err)
+	}
+	if gotComment.EventID != nil {
+		t.Errorf("sweepable comment EventID = %v, want nil", gotComment.EventID)
+	}
+
+	gotSurvivingComment, err := s.GetComment("fp2", "cluster-a", survivingComment.ID)
+	if err != nil {
+		t.Fatalf("GetComment surviving: %v", err)
+	}
+	if gotSurvivingComment.EventID == nil || *gotSurvivingComment.EventID != survivingHead.ID {
+		t.Errorf("surviving comment EventID = %v, want %d", gotSurvivingComment.EventID, survivingHead.ID)
+	}
+
+	var claimEventID *int64
+	if err := s.queryRow(context.Background(), `SELECT event_id FROM alert_claims WHERE id = ?`, sweepableClaim.ID).Scan(&claimEventID); err != nil {
+		t.Fatalf("query sweepable claim event_id: %v", err)
+	}
+	if claimEventID != nil {
+		t.Errorf("sweepable claim event_id = %v, want nil", claimEventID)
+	}
+
+	var survivingClaimEventID *int64
+	if err := s.queryRow(context.Background(), `SELECT event_id FROM alert_claims WHERE id = ?`, survivingClaim.ID).Scan(&survivingClaimEventID); err != nil {
+		t.Fatalf("query surviving claim event_id: %v", err)
+	}
+	if survivingClaimEventID == nil || *survivingClaimEventID != survivingHead.ID {
+		t.Errorf("surviving claim event_id = %v, want %d", survivingClaimEventID, survivingHead.ID)
+	}
+}
+
+func TestDeleteReleasedClaimsBefore(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+
+	activeClaim, err := s.SetClaim("fp1", "cluster-a", nil, "alice", "")
+	if err != nil {
+		t.Fatalf("SetClaim active: %v", err)
+	}
+
+	oldReleasedClaim, err := s.SetClaim("fp1", "cluster-a", nil, "bob", "")
+	if err != nil {
+		t.Fatalf("SetClaim old-released: %v", err)
+	}
+	if _, err := s.ReleaseClaim("fp1", "cluster-a", "bob", "manual"); err != nil {
+		t.Fatalf("ReleaseClaim old: %v", err)
+	}
+	backdateClaimReleased(t, s, oldReleasedClaim.ID, time.Now().AddDate(0, 0, -60))
+
+	recentReleasedClaim, err := s.SetClaim("fp1", "cluster-a", nil, "carol", "")
+	if err != nil {
+		t.Fatalf("SetClaim recent-released: %v", err)
+	}
+	if _, err := s.ReleaseClaim("fp1", "cluster-a", "carol", "manual"); err != nil {
+		t.Fatalf("ReleaseClaim recent: %v", err)
+	}
+
+	n, err := s.DeleteReleasedClaimsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteReleasedClaimsBefore: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted = %d, want 1 (only the old released claim)", n)
+	}
+
+	var count int
+	if err := s.queryRow(context.Background(), `SELECT COUNT(*) FROM alert_claims WHERE id = ?`, oldReleasedClaim.ID).Scan(&count); err != nil {
+		t.Fatalf("count old claim: %v", err)
+	}
+	if count != 0 {
+		t.Error("old released claim still present, want deleted")
+	}
+	if err := s.queryRow(context.Background(), `SELECT COUNT(*) FROM alert_claims WHERE id = ?`, recentReleasedClaim.ID).Scan(&count); err != nil {
+		t.Fatalf("count recent claim: %v", err)
+	}
+	if count != 1 {
+		t.Error("recent released claim missing, want present")
+	}
+	if err := s.queryRow(context.Background(), `SELECT COUNT(*) FROM alert_claims WHERE id = ?`, activeClaim.ID).Scan(&count); err != nil {
+		t.Fatalf("count active claim: %v", err)
+	}
+	if count != 1 {
+		t.Error("active claim missing, want present regardless of age")
+	}
+}
+
+func TestDeleteCommentsBefore(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+
+	oldComment, err := s.AddComment("fp1", "cluster-a", nil, nil, "alice", "old")
+	if err != nil {
+		t.Fatalf("AddComment old: %v", err)
+	}
+	backdateComment(t, s, oldComment.ID, time.Now().AddDate(0, 0, -60))
+
+	recentComment, err := s.AddComment("fp1", "cluster-a", nil, nil, "bob", "recent")
+	if err != nil {
+		t.Fatalf("AddComment recent: %v", err)
+	}
+
+	n, err := s.DeleteCommentsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteCommentsBefore: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted = %d, want 1", n)
+	}
+
+	if got, err := s.GetComment("fp1", "cluster-a", oldComment.ID); err != nil {
+		t.Errorf("GetComment old: %v", err)
+	} else if got != nil {
+		t.Error("old comment still retrievable, want deleted")
+	}
+	if got, err := s.GetComment("fp1", "cluster-a", recentComment.ID); err != nil {
+		t.Errorf("recent comment not retrievable: %v", err)
+	} else if got == nil {
+		t.Error("recent comment missing, want present")
+	}
+}
+
+func TestDeleteSilenceEventsBefore(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	oldEvent, err := s.RecordSilenceEvent("fp1", "sil-1", "cluster-a", "created", "alice", "")
+	if err != nil {
+		t.Fatalf("RecordSilenceEvent old: %v", err)
+	}
+	backdateSilenceEvent(t, s, oldEvent.ID, time.Now().AddDate(0, 0, -60))
+
+	if _, err := s.RecordSilenceEvent("fp1", "sil-2", "cluster-a", "created", "bob", ""); err != nil {
+		t.Fatalf("RecordSilenceEvent recent: %v", err)
+	}
+
+	n, err := s.DeleteSilenceEventsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteSilenceEventsBefore: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted = %d, want 1", n)
+	}
+	if got := countRows(t, s, "silence_events"); got != 1 {
+		t.Errorf("silence_events count = %d, want 1", got)
+	}
+}
+
+func TestDeleteOrphanFingerprintsBefore_SurvivesWithComment(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	if _, err := s.AddComment("fp1", "cluster-a", nil, nil, "alice", "keep me"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	backdateFingerprintLastSeen(t, s, "fp1", time.Now().AddDate(0, 0, -60))
+
+	n, err := s.DeleteOrphanFingerprintsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteOrphanFingerprintsBefore: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted = %d, want 0 (fingerprint with a comment must survive)", n)
+	}
+}
+
+func TestDeleteOrphanFingerprintsBefore_DeletesTrueOrphan(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	backdateFingerprintLastSeen(t, s, "fp1", time.Now().AddDate(0, 0, -60))
+
+	n, err := s.DeleteOrphanFingerprintsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteOrphanFingerprintsBefore: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted = %d, want 1 (fully orphaned old fingerprint)", n)
+	}
+}
+
+func TestDeleteOrphanFingerprintsBefore_RecentlySeenSurvives(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	// last_seen_at defaults to "now" — well inside the cutoff window.
+
+	n, err := s.DeleteOrphanFingerprintsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteOrphanFingerprintsBefore: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted = %d, want 0 (recently seen fingerprint must survive)", n)
+	}
+}
+
+func TestDeleteOrphanFingerprintsBefore_SurvivesWithOpenEvent(t *testing.T) {
+	s := newTestStore(t)
+	cutoff := oldCutoff()
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	if _, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil); err != nil {
+		t.Fatalf("RecordStatusChange: %v", err)
+	}
+	backdateFingerprintLastSeen(t, s, "fp1", time.Now().AddDate(0, 0, -60))
+
+	n, err := s.DeleteOrphanFingerprintsBefore(context.Background(), cutoff, 500)
+	if err != nil {
+		t.Fatalf("DeleteOrphanFingerprintsBefore: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted = %d, want 0 (fingerprint with an event must survive)", n)
+	}
+}
+
+// TestRefireAfterFullEventSweep_NoOccurrenceInflation covers Critical design
+// decision 7 of idea-3.13: if a fingerprint survives a sweep only because it
+// still has comments (all its events were deleted), a later re-fire finds no
+// previous event and is treated like a first firing — occurrence_count is
+// NOT incremented (the upsert leaves the existing count untouched). This is
+// the accepted trade-off: the count is preserved, never inflated.
+func TestRefireAfterFullEventSweep_NoOccurrenceInflation(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.UpsertFingerprint("fp1", "TestAlert", "cluster-a", nil); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+	if _, err := s.AddComment("fp1", "cluster-a", nil, nil, "alice", "old context"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	firingEvent, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil)
+	if err != nil {
+		t.Fatalf("RecordStatusChange firing: %v", err)
+	}
+	if err := s.RecordResolvedForCluster("fp1", "cluster-a", time.Now()); err != nil {
+		t.Fatalf("RecordResolvedForCluster: %v", err)
+	}
+	resolvedEvent, err := s.getLastEventForCluster("fp1", "cluster-a")
+	if err != nil {
+		t.Fatalf("getLastEventForCluster: %v", err)
+	}
+
+	statsBefore, err := s.GetStats("fp1")
+	if err != nil {
+		t.Fatalf("GetStats before sweep: %v", err)
+	}
+
+	// Simulate both events aging past the cutoff (distinct offsets, so the
+	// resolved row is unambiguously newer than the firing row it supersedes)
+	// and being swept, while the comment keeps the fingerprint alive.
+	backdateEvent(t, s, firingEvent.ID, time.Now().AddDate(0, 0, -60))
+	backdateEvent(t, s, resolvedEvent.ID, time.Now().AddDate(0, 0, -45))
+	if _, err := s.DeleteSweepableEventsBefore(context.Background(), oldCutoff(), 500); err != nil {
+		t.Fatalf("DeleteSweepableEventsBefore: %v", err)
+	}
+	if got := countRows(t, s, "alert_events"); got != 0 {
+		t.Fatalf("alert_events count = %d, want 0 (setup precondition)", got)
+	}
+
+	// Re-fire: RecordStatusChange finds no previous event for this cluster.
+	if _, _, err := s.RecordStatusChange("fp1", "cluster-a", "http://am", models.EventStatusFiring, time.Now(), nil); err != nil {
+		t.Fatalf("RecordStatusChange refire: %v", err)
+	}
+
+	statsAfter, err := s.GetStats("fp1")
+	if err != nil {
+		t.Fatalf("GetStats after refire: %v", err)
+	}
+	if statsAfter.OccurrenceCount != statsBefore.OccurrenceCount {
+		t.Errorf("OccurrenceCount after refire = %d, want unchanged %d (no inflation)", statsAfter.OccurrenceCount, statsBefore.OccurrenceCount)
+	}
+}

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -26,6 +26,10 @@ type Metrics struct {
 	WSBroadcastsTotal           *prometheus.CounterVec
 	HTTPRequestsTotal           *prometheus.CounterVec
 	HTTPRequestDuration         *prometheus.HistogramVec
+
+	RetentionSweepsTotal      prometheus.Counter
+	RetentionDeletedRowsTotal *prometheus.CounterVec
+	RetentionSweepDuration    prometheus.Histogram
 }
 
 // New creates a Metrics instance on a fresh registry, including the standard
@@ -81,6 +85,19 @@ func New(version string) *Metrics {
 			Help:    "HTTP request duration in seconds, by method, route pattern and status.",
 			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
 		}, []string{"method", "path", "status"}),
+		RetentionSweepsTotal: f.NewCounter(prometheus.CounterOpts{
+			Name: "jarvis_retention_sweeps_total",
+			Help: "Total number of data-retention sweeps run.",
+		}),
+		RetentionDeletedRowsTotal: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "jarvis_retention_deleted_rows_total",
+			Help: "Total number of rows deleted by the data-retention sweeper, by table.",
+		}, []string{"table"}),
+		RetentionSweepDuration: f.NewHistogram(prometheus.HistogramOpts{
+			Name:    "jarvis_retention_sweep_duration_seconds",
+			Help:    "Duration of a full data-retention sweep across all tables.",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60},
+		}),
 	}
 }
 

--- a/backend/internal/retention/sweeper.go
+++ b/backend/internal/retention/sweeper.go
@@ -1,0 +1,161 @@
+// Package retention implements the background data-retention sweep
+// (idea 3.13, .agents/architecture.md). Fully opt-in: with the default
+// config (config.RetentionConfig.Enabled() == false) the Sweeper's Start
+// does nothing at all — no timer, no query, ever.
+package retention
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/kj187/jarvis/backend/internal/config"
+	"github.com/kj187/jarvis/backend/internal/metrics"
+)
+
+// batchSize is the row count per DELETE batch, chosen so one sweep never
+// holds SQLite's single-writer lock (Critical Invariant #8) for a long
+// unbounded transaction.
+const batchSize = 500
+
+// startupDelay is how long Start waits before running the first sweep, so
+// it doesn't compete with the rest of server boot.
+const startupDelay = time.Minute
+
+// store is the minimal interface the Sweeper needs from *history.Store —
+// kept narrow so the Sweeper can be tested without a real DB.
+type store interface {
+	DeleteSweepableEventsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error)
+	DetachCommentsAndClaimsFromSweepableEventsBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteReleasedClaimsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error)
+	DeleteCommentsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error)
+	DeleteSilenceEventsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error)
+	DeleteOrphanFingerprintsBefore(ctx context.Context, cutoff time.Time, batch int) (int64, error)
+}
+
+// Sweeper periodically deletes old rows per the configured retention rules.
+type Sweeper struct {
+	store   store
+	cfg     config.RetentionConfig
+	logger  *slog.Logger
+	metrics *metrics.Metrics
+}
+
+// NewSweeper creates a Sweeper. m may be nil (same nil-safe pattern as
+// history.NewRecorder / ws.NewHub).
+func NewSweeper(s store, cfg config.RetentionConfig, logger *slog.Logger, m *metrics.Metrics) *Sweeper {
+	return &Sweeper{store: s, cfg: cfg, logger: logger, metrics: m}
+}
+
+// Start runs the sweep loop until ctx is cancelled. No-ops immediately if
+// retention is disabled (cfg.Enabled() == false) — an upgrade with the
+// default config must never start deleting data. The first sweep runs
+// startupDelay after Start is called; subsequent sweeps run every
+// cfg.SweepInterval.
+func (sw *Sweeper) Start(ctx context.Context) {
+	if !sw.cfg.Enabled() {
+		sw.logger.Info("retention sweeper disabled (no JARVIS_RETENTION_* configured)")
+		return
+	}
+
+	timer := time.NewTimer(startupDelay)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			sw.sweep(ctx)
+			timer.Reset(sw.cfg.SweepInterval)
+		}
+	}
+}
+
+// sweep runs one full sweep across all domains, in FK-safe order: comments,
+// claims, silence events (each independent, own/inherited retention), then
+// detach comment/claim survivors from events about to be deleted, then the
+// events themselves, then the orphan fingerprint sweep last (it must see
+// the post-sweep state of every other table).
+func (sw *Sweeper) sweep(ctx context.Context) {
+	start := time.Now()
+	logger := sw.logger.With("component", "retention")
+	var total int64
+
+	if days := sw.cfg.EffectiveCommentsDays(); days > 0 {
+		n, err := sw.store.DeleteCommentsBefore(ctx, cutoffDays(days), batchSize)
+		sw.recordResult(logger, "alert_comments", n, err)
+		total += n
+	}
+
+	if days := sw.cfg.EffectiveClaimsDays(); days > 0 {
+		n, err := sw.store.DeleteReleasedClaimsBefore(ctx, cutoffDays(days), batchSize)
+		sw.recordResult(logger, "alert_claims", n, err)
+		total += n
+	}
+
+	if days := sw.cfg.EffectiveSilenceEventsDays(); days > 0 {
+		n, err := sw.store.DeleteSilenceEventsBefore(ctx, cutoffDays(days), batchSize)
+		sw.recordResult(logger, "silence_events", n, err)
+		total += n
+	}
+
+	if days := sw.cfg.EffectiveEventsDays(); days > 0 {
+		cutoff := cutoffDays(days)
+		if _, err := sw.store.DetachCommentsAndClaimsFromSweepableEventsBefore(ctx, cutoff); err != nil {
+			logger.Error("detach comments/claims from sweepable events", "err", err)
+		}
+		n, err := sw.store.DeleteSweepableEventsBefore(ctx, cutoff, batchSize)
+		sw.recordResult(logger, "alert_events", n, err)
+		total += n
+	}
+
+	// Orphan fingerprint sweep runs last, using the widest cutoff of all
+	// configured domains: a fingerprint may only vanish once nothing
+	// references it AND it is older than everything that could still
+	// reference it.
+	if widest := sw.widestEffectiveDays(); widest > 0 {
+		n, err := sw.store.DeleteOrphanFingerprintsBefore(ctx, cutoffDays(widest), batchSize)
+		sw.recordResult(logger, "alert_fingerprints", n, err)
+		total += n
+	}
+
+	duration := time.Since(start)
+	if sw.metrics != nil {
+		sw.metrics.RetentionSweepsTotal.Inc()
+		sw.metrics.RetentionSweepDuration.Observe(duration.Seconds())
+	}
+	logger.Info("retention sweep complete", "deleted_rows", total, "duration", duration)
+}
+
+func (sw *Sweeper) recordResult(logger *slog.Logger, table string, n int64, err error) {
+	if err != nil {
+		logger.Error("retention delete failed", "table", table, "err", err)
+		return
+	}
+	if sw.metrics != nil {
+		sw.metrics.RetentionDeletedRowsTotal.WithLabelValues(table).Add(float64(n))
+	}
+	if n > 0 {
+		logger.Info("retention delete", "table", table, "deleted", n)
+	}
+}
+
+// widestEffectiveDays returns the largest effective retention across all
+// four domains — the cutoff the orphan fingerprint sweep must use.
+func (sw *Sweeper) widestEffectiveDays() int {
+	widest := sw.cfg.EffectiveEventsDays()
+	if d := sw.cfg.EffectiveClaimsDays(); d > widest {
+		widest = d
+	}
+	if d := sw.cfg.EffectiveSilenceEventsDays(); d > widest {
+		widest = d
+	}
+	if d := sw.cfg.EffectiveCommentsDays(); d > widest {
+		widest = d
+	}
+	return widest
+}
+
+func cutoffDays(days int) time.Time {
+	return time.Now().UTC().AddDate(0, 0, -days)
+}

--- a/backend/internal/retention/sweeper_test.go
+++ b/backend/internal/retention/sweeper_test.go
@@ -1,0 +1,255 @@
+package retention
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kj187/jarvis/backend/internal/config"
+	"github.com/kj187/jarvis/backend/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// fakeStore records every call made to it (name + cutoff) and returns
+// preconfigured results, so tests can assert sweep() call order and
+// per-domain cutoffs without a real DB.
+type fakeStore struct {
+	mu      sync.Mutex
+	calls   []string
+	cutoffs map[string]time.Time
+
+	commentsN, claimsN, silenceN, detachN, eventsN, orphanN int64
+	err                                                     error
+}
+
+func (f *fakeStore) record(name string, cutoff time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, name)
+	if f.cutoffs == nil {
+		f.cutoffs = make(map[string]time.Time)
+	}
+	f.cutoffs[name] = cutoff
+}
+
+func (f *fakeStore) DeleteCommentsBefore(_ context.Context, cutoff time.Time, _ int) (int64, error) {
+	f.record("DeleteCommentsBefore", cutoff)
+	return f.commentsN, f.err
+}
+
+func (f *fakeStore) DeleteReleasedClaimsBefore(_ context.Context, cutoff time.Time, _ int) (int64, error) {
+	f.record("DeleteReleasedClaimsBefore", cutoff)
+	return f.claimsN, f.err
+}
+
+func (f *fakeStore) DeleteSilenceEventsBefore(_ context.Context, cutoff time.Time, _ int) (int64, error) {
+	f.record("DeleteSilenceEventsBefore", cutoff)
+	return f.silenceN, f.err
+}
+
+func (f *fakeStore) DetachCommentsAndClaimsFromSweepableEventsBefore(_ context.Context, cutoff time.Time) (int64, error) {
+	f.record("DetachCommentsAndClaimsFromSweepableEventsBefore", cutoff)
+	return f.detachN, f.err
+}
+
+func (f *fakeStore) DeleteSweepableEventsBefore(_ context.Context, cutoff time.Time, _ int) (int64, error) {
+	f.record("DeleteSweepableEventsBefore", cutoff)
+	return f.eventsN, f.err
+}
+
+func (f *fakeStore) DeleteOrphanFingerprintsBefore(_ context.Context, cutoff time.Time, _ int) (int64, error) {
+	f.record("DeleteOrphanFingerprintsBefore", cutoff)
+	return f.orphanN, f.err
+}
+
+func (f *fakeStore) callNames() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func TestSweeper_Start_Disabled_NeverCallsStore(t *testing.T) {
+	f := &fakeStore{}
+	sw := NewSweeper(f, config.RetentionConfig{}, testLogger(), nil)
+
+	done := make(chan struct{})
+	go func() {
+		sw.Start(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Start() did not return promptly when retention is disabled")
+	}
+
+	if calls := f.callNames(); len(calls) != 0 {
+		t.Errorf("store calls = %v, want none", calls)
+	}
+}
+
+func TestSweeper_Start_ContextCancelStopsBeforeFirstSweep(t *testing.T) {
+	f := &fakeStore{}
+	cfg := config.RetentionConfig{Days: 30, SweepInterval: time.Hour}
+	sw := NewSweeper(f, cfg, testLogger(), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sw.Start(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Start() did not return promptly after context cancellation")
+	}
+
+	if calls := f.callNames(); len(calls) != 0 {
+		t.Errorf("store calls = %v, want none (cancelled before the first sweep)", calls)
+	}
+}
+
+func TestSweeper_Sweep_FullOrderAndCutoffs(t *testing.T) {
+	f := &fakeStore{}
+	cfg := config.RetentionConfig{
+		EventsDays:        90,
+		ClaimsDays:        30,
+		SilenceEventsDays: 60,
+		CommentsDays:      180,
+	}
+	sw := NewSweeper(f, cfg, testLogger(), nil)
+
+	sw.sweep(context.Background())
+
+	wantOrder := []string{
+		"DeleteCommentsBefore",
+		"DeleteReleasedClaimsBefore",
+		"DeleteSilenceEventsBefore",
+		"DetachCommentsAndClaimsFromSweepableEventsBefore",
+		"DeleteSweepableEventsBefore",
+		"DeleteOrphanFingerprintsBefore",
+	}
+	gotOrder := f.callNames()
+	if len(gotOrder) != len(wantOrder) {
+		t.Fatalf("calls = %v, want %v", gotOrder, wantOrder)
+	}
+	for i, name := range wantOrder {
+		if gotOrder[i] != name {
+			t.Errorf("call[%d] = %q, want %q (order: %v)", i, gotOrder[i], name, gotOrder)
+		}
+	}
+
+	// Orphan sweep must use the widest configured retention (180d, comments).
+	now := time.Now().UTC()
+	orphanCutoff := f.cutoffs["DeleteOrphanFingerprintsBefore"]
+	wantOrphanCutoff := now.AddDate(0, 0, -180)
+	if diff := wantOrphanCutoff.Sub(orphanCutoff); diff < -time.Minute || diff > time.Minute {
+		t.Errorf("orphan cutoff = %v, want ~%v (widest = comments 180d)", orphanCutoff, wantOrphanCutoff)
+	}
+
+	eventsCutoff := f.cutoffs["DeleteSweepableEventsBefore"]
+	wantEventsCutoff := now.AddDate(0, 0, -90)
+	if diff := wantEventsCutoff.Sub(eventsCutoff); diff < -time.Minute || diff > time.Minute {
+		t.Errorf("events cutoff = %v, want ~%v", eventsCutoff, wantEventsCutoff)
+	}
+}
+
+func TestSweeper_Sweep_SkipsDisabledDomains(t *testing.T) {
+	f := &fakeStore{}
+	// Only comments retention explicitly enabled; global + all other
+	// domains disabled.
+	cfg := config.RetentionConfig{CommentsDays: 180}
+	sw := NewSweeper(f, cfg, testLogger(), nil)
+
+	sw.sweep(context.Background())
+
+	wantOrder := []string{
+		"DeleteCommentsBefore",
+		"DeleteOrphanFingerprintsBefore", // widest effective retention is comments' 180d
+	}
+	gotOrder := f.callNames()
+	if len(gotOrder) != len(wantOrder) {
+		t.Fatalf("calls = %v, want %v", gotOrder, wantOrder)
+	}
+	for i, name := range wantOrder {
+		if gotOrder[i] != name {
+			t.Errorf("call[%d] = %q, want %q (order: %v)", i, gotOrder[i], name, gotOrder)
+		}
+	}
+}
+
+func TestSweeper_Sweep_ErrorInOneDomainDoesNotAbortOthers(t *testing.T) {
+	f := &fakeStore{err: errors.New("boom")}
+	cfg := config.RetentionConfig{Days: 30}
+	sw := NewSweeper(f, cfg, testLogger(), nil)
+
+	sw.sweep(context.Background())
+
+	wantOrder := []string{
+		"DeleteReleasedClaimsBefore",
+		"DeleteSilenceEventsBefore",
+		"DetachCommentsAndClaimsFromSweepableEventsBefore",
+		"DeleteSweepableEventsBefore",
+		"DeleteOrphanFingerprintsBefore",
+	}
+	gotOrder := f.callNames()
+	if len(gotOrder) != len(wantOrder) {
+		t.Fatalf("calls = %v, want %v (a single domain's error must not abort the rest)", gotOrder, wantOrder)
+	}
+}
+
+func TestSweeper_Sweep_MetricsCounted(t *testing.T) {
+	f := &fakeStore{
+		claimsN:  2,
+		silenceN: 3,
+		eventsN:  5,
+		orphanN:  1,
+	}
+	cfg := config.RetentionConfig{Days: 30}
+	m := metrics.New("test")
+	sw := NewSweeper(f, cfg, testLogger(), m)
+
+	sw.sweep(context.Background())
+
+	if got := testutil.ToFloat64(m.RetentionSweepsTotal); got != 1 {
+		t.Errorf("RetentionSweepsTotal = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.RetentionDeletedRowsTotal.WithLabelValues("alert_claims")); got != 2 {
+		t.Errorf("RetentionDeletedRowsTotal{alert_claims} = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.RetentionDeletedRowsTotal.WithLabelValues("silence_events")); got != 3 {
+		t.Errorf("RetentionDeletedRowsTotal{silence_events} = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(m.RetentionDeletedRowsTotal.WithLabelValues("alert_events")); got != 5 {
+		t.Errorf("RetentionDeletedRowsTotal{alert_events} = %v, want 5", got)
+	}
+	if got := testutil.ToFloat64(m.RetentionDeletedRowsTotal.WithLabelValues("alert_fingerprints")); got != 1 {
+		t.Errorf("RetentionDeletedRowsTotal{alert_fingerprints} = %v, want 1", got)
+	}
+	if got := testutil.CollectAndCount(m.RetentionSweepDuration); got != 1 {
+		t.Errorf("RetentionSweepDuration sample count = %d, want 1", got)
+	}
+}
+
+func TestSweeper_NilMetrics_DoesNotPanic(t *testing.T) {
+	f := &fakeStore{eventsN: 1}
+	cfg := config.RetentionConfig{Days: 30}
+	sw := NewSweeper(f, cfg, testLogger(), nil)
+
+	sw.sweep(context.Background()) // must not panic with m == nil
+}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,6 +39,9 @@ sync with reality.
 | `jarvis_ws_broadcasts_total` | `type` | A WebSocket event is broadcast to clients |
 | `jarvis_http_requests_total` | `method`, `path`, `status` | Every HTTP request (labeled by route pattern, not raw URL) |
 | `jarvis_http_request_duration_seconds` | `method`, `path`, `status` | Histogram of HTTP request duration |
+| `jarvis_retention_sweeps_total` | — | A data-retention sweep completes (see [docs/retention.md](retention.md)). Only increments while retention is enabled — stays 0 forever on a default install |
+| `jarvis_retention_deleted_rows_total` | `table` | Rows deleted by the retention sweeper, by table (`alert_events`, `alert_claims`, `alert_comments`, `silence_events`, `alert_fingerprints`) |
+| `jarvis_retention_sweep_duration_seconds` | — | Histogram of a full sweep's duration across all tables |
 
 Runtime metrics (`go_*`, `process_*`) are included via the standard Prometheus
 Go/process collectors.

--- a/docs/retention.md
+++ b/docs/retention.md
@@ -1,0 +1,116 @@
+# Data Retention
+
+Jarvis stores every alert lifecycle event, comment, claim, and silence
+action forever by default. On a long-running install this can grow the
+database indefinitely. Data retention gives an admin an **optional**,
+env-var-only way to bound that growth with a background sweep — there is no
+UI or API for it, consistent with the rest of Jarvis's server configuration.
+
+**Disabled by default.** With no `JARVIS_RETENTION_*` variable set, nothing
+is ever deleted — an upgrade never silently removes data.
+
+## What gets swept
+
+| Table | Deleted when | Kept regardless of age |
+|---|---|---|
+| `alert_events` | Superseded by a newer event for the same alert+cluster, or the episode is already closed (`resolved`/`expired`), and older than the cutoff | The most recent event of a still-`firing`/`suppressed` alert — its open episode head, however old |
+| `alert_claims` | Released (not active) and older than the cutoff (by release time) | Any currently active claim |
+| `alert_comments` | Older than the cutoff — **only if you explicitly opt in** | Everything, by default |
+| `silence_events` | Older than the cutoff (pure audit log, by record time) | Nothing special — audit log has no exceptions |
+| `alert_fingerprints` | No events, claims, or comments reference it anymore, and it hasn't been seen recently | A fingerprint with a surviving comment, claim, or event of any age |
+
+**Comments are the deliberate exception.** They are never deleted by the
+global retention setting — only an explicit
+`JARVIS_RETENTION_COMMENTS_DAYS` enables it. The reasoning: if an alert goes
+quiet for months and then fires again with the same fingerprint and
+cluster, any comments left on it (root-cause notes, links to a ticket,
+context for the next responder) should still be there. Deleting comments
+by default would erase exactly the context that makes a recurring alert
+faster to triage the second time.
+
+## Configuration
+
+All values are in days unless noted; set in `.env` or the container's
+environment (see `.env.example`).
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `JARVIS_RETENTION_DAYS` | `0` (disabled) | Global default retention window |
+| `JARVIS_RETENTION_EVENTS_DAYS` | inherits global | Override for `alert_events` |
+| `JARVIS_RETENTION_CLAIMS_DAYS` | inherits global | Override for released `alert_claims` |
+| `JARVIS_RETENTION_SILENCE_EVENTS_DAYS` | inherits global | Override for `silence_events` |
+| `JARVIS_RETENTION_COMMENTS_DAYS` | `0` (kept forever) | Comments — **never** inherits the global value; only an explicit value here enables deletion |
+| `JARVIS_RETENTION_SWEEP_INTERVAL` | `12h` | How often the background sweep runs |
+
+An override of `0`/unset for events, claims, or silence events falls back to
+the global `JARVIS_RETENTION_DAYS`. An override greater than `0` applies
+even when the global is `0`, so you can enable retention for a single
+domain without touching the others (e.g. only trim the silence audit log).
+
+Negative values are rejected at startup.
+
+### Examples
+
+```bash
+# Recommended production baseline: keep a year of history everywhere
+# except comments, which stay forever.
+JARVIS_RETENTION_DAYS=365
+
+# Same, but also purge comments after 6 months.
+JARVIS_RETENTION_DAYS=365
+JARVIS_RETENTION_COMMENTS_DAYS=180
+
+# Trim only the silence audit log, leave everything else untouched.
+JARVIS_RETENTION_SILENCE_EVENTS_DAYS=90
+```
+
+## How the sweep works
+
+A single background loop (`internal/retention.Sweeper`) starts 1 minute
+after Jarvis boots (so it doesn't compete with startup), then runs every
+`JARVIS_RETENTION_SWEEP_INTERVAL`. Each domain is deleted in batches of 500
+rows with a short pause in between, so a large sweep never holds the
+SQLite single-writer lock for one long transaction.
+
+Order matters, because of foreign keys and the fingerprint-orphan check:
+
+1. Comments (if explicitly enabled)
+2. Released claims
+3. Silence events
+4. Detach any surviving comment/claim from an event about to be deleted
+   (their `event_id` reference is cleared, not the comment/claim itself)
+5. Events
+6. Orphaned fingerprints — using the **widest** of all the cutoffs above, so
+   a fingerprint only disappears once nothing anywhere still references it
+
+## Known effect on per-cluster statistics
+
+An alert's **global** occurrence count survives event deletion — it lives
+on the fingerprint row, not on individual events. Its **per-cluster**
+stats (occurrence count, first/last seen, the firing heatmap) are derived
+directly from `alert_events`, so after a sweep they only reflect the
+retention window, not the alert's entire history. This is the accepted
+trade-off of retention: those views show fewer old entries, by design.
+
+If a fingerprint's events are fully swept but it survives only because a
+comment is still attached, and the alert re-fires later, Jarvis has no
+prior event to compare against — the re-fire is treated like a first
+firing and the occurrence count is **not** incremented (it also isn't
+reset; the existing count is simply left alone).
+
+## Observability
+
+Every sweep logs a summary line (rows deleted per table, duration) and
+updates three Prometheus metrics — see
+[docs/metrics.md](metrics.md#event-counters):
+`jarvis_retention_sweeps_total`, `jarvis_retention_deleted_rows_total{table=...}`,
+`jarvis_retention_sweep_duration_seconds`.
+
+## Non-goals (v1)
+
+- No `VACUUM`/file compaction — SQLite reuses freed pages internally, which
+  is enough to bound growth; the file itself won't shrink.
+- No admin UI or API to trigger a sweep manually or change retention at
+  runtime — env-var configuration only.
+- No per-cluster or per-alertname retention rules.
+- No archiving/export before deletion.


### PR DESCRIPTION
## Summary
- Opt-in background sweep (`JARVIS_RETENTION_*` env vars, disabled by default) that deletes old `alert_events`, released `alert_claims`, `silence_events`, and orphaned `alert_fingerprints` in batches — bounds DB growth on long-running installs
- Comments are deliberately excluded from the global retention setting; only an explicit `JARVIS_RETENTION_COMMENTS_DAYS` enables their deletion, so a re-firing alert keeps prior context
- `alert_events` deletion never touches the open head of a still-firing/suppressed episode, regardless of age — the never-written `ends_at` column is intentionally not used for this decision
- New Prometheus metrics (`jarvis_retention_sweeps_total`, `jarvis_retention_deleted_rows_total{table}`, `jarvis_retention_sweep_duration_seconds`) and docs (`docs/retention.md`)

## Test plan
- [x] `go test -race -count=1 ./...` — all backend packages green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New unit tests: config parsing/inheritance, store delete/detach methods (batching, episode-head survival, orphan sweep), sweeper ordering/cutoffs/metrics
- [x] No API/frontend surface change — no `pnpm build` needed