### PR TITLE
fix(db): make RecordStatusChange transactional and lock-guarded

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -68,6 +68,11 @@ make down-alertmanager
 make up-postgres                   # test PostgreSQL on 5432 (jarvis/jarvis/jarvis) — for JARVIS_DB_DSN=postgres://…
 make down-postgres
 
+# ── PostgreSQL-backed backend tests (env-gated) ──────────────
+make up-postgres
+JARVIS_TEST_POSTGRES_DSN='postgres://jarvis:jarvis@localhost:5432/jarvis?sslmode=disable' \
+  go test ./internal/history/...   # unset → these tests t.Skip; CI always sets it (postgres:17 service container)
+
 # ── Manual test fixtures against the dev stack ───────────────
 make fixtures-create               # fire 23 Kubernetes-themed test alerts (label test_suite=jarvis)
 make fixtures-remove               # resolve those alerts
@@ -91,6 +96,8 @@ make fixtures-unsilence            # expire test silences
 | `internal/db` | `db_fuzz_test.go` | Fuzz: `RedactDSN` never panics, password never leaks |
 | `internal/cluster` | `registry_test.go` | `NewRegistry`, `Get`, `All` — single/multi-cluster |
 | `internal/history` | `store_test.go` | `UpsertFingerprint`, `GetOrCreateActiveEvent`, grace period (60s), `occurrence_count` logic |
+| `internal/history` | `store_postgres_test.go` | `postgresTestDSN` (skip gate), `newTestPostgresStores(t, n)` — n independent `*sql.DB` connections against one truncated PostgreSQL test database, the multi-replica situation in miniature (reused by later multi-replica-plan slices' elector/recorder/fanout tests) |
+| `internal/history` | `store_concurrency_test.go` | D5 (`AGENTS.md`-pending invariant): `RecordStatusChange` raced concurrently — one Store (SQLite) and 10 Stores on one PostgreSQL database (`JARVIS_TEST_POSTGRES_DSN`-gated) — exactly one resulting event row, no duplicate from a non-atomic idempotency-check-then-insert; 2 racing Postgres connections proved too narrow a window to reproduce the bug reliably (20/20 false-negative runs in development), hence 10 |
 | `internal/history` | `store_extra_test.go` | `GetClaimHistory`, `RecordSilenceEvent`, `GetSilenceEvents`, `GetRecentResolved`, `SeedResolved`, silence templates |
 | `internal/history` | `store_retention_test.go` | Retention delete/detach methods (`store_retention.go`): `sweepableEventsCondition` — open firing/suppressed episode head survives any age, a superseded or resolved/expired row past cutoff is deleted; batching (1200 rows/batch 500); context-cancel stops the loop; detach nulls `event_id` only on rows referencing a soon-to-be-deleted event; released-claim/comment/silence-event cutoffs (active claims always survive); orphan fingerprint sweep (survives with any remaining event/claim/comment, deletes only true orphans past `last_seen_at` cutoff); re-fire after a full event sweep does not inflate `occurrence_count` |
 | `internal/history` | `alert_store_test.go` | `Set`/`Get`/`MarkResolved`/`RemoveByFingerprint` (thread safety via goroutines) |
@@ -281,6 +288,8 @@ dco:                 # PR-only: every commit must carry a Signed-off-by trailer 
 secrets:             # gitleaks secret scanning
 
 backend:
+  - services.postgres: postgres:17 container, health-checked; JARVIS_TEST_POSTGRES_DSN set for the
+    test step so every PostgreSQL-gated test (internal/history) runs on every PR, not just locally
   - go test -v -race -coverprofile=coverage.out ./... | go-junit-report → report.xml
   - Coverage summary → GITHUB_STEP_SUMMARY (go tool cover -func)
   - dorny/test-reporter uploads report.xml as "Backend Test Results"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: backend
     services:
       postgres:
-        image: postgres:17
+        image: index.docker.io/library/postgres@sha256:4ffc96598f8965ee5b33b4186ab4f1ca4df7f4f0325f06d17c19d18e51d3f107 # ratchet:postgres:17
         env:
           POSTGRES_DB: jarvis
           POSTGRES_USER: jarvis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,20 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: jarvis
+          POSTGRES_USER: jarvis
+          POSTGRES_PASSWORD: jarvis
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
@@ -87,6 +101,8 @@ jobs:
         run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0
 
       - name: Run tests
+        env:
+          JARVIS_TEST_POSTGRES_DSN: postgres://jarvis:jarvis@localhost:5432/jarvis?sslmode=disable
         run: |
           set -o pipefail
           go test -v -race -coverprofile=coverage.out ./... 2>&1 | go-junit-report -set-exit-code > report.xml

--- a/backend/internal/history/store.go
+++ b/backend/internal/history/store.go
@@ -75,16 +75,64 @@ func rebind(dialect idb.Dialect, query string) string {
 	return b.String()
 }
 
+// queryer is satisfied by both *sql.DB and *sql.Tx, so query helpers can run
+// either directly on the pool or inside a transaction (see withTx).
+type queryer interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}
+
+func (s *Store) execOn(q queryer, ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return q.ExecContext(ctx, rebind(s.dialect, query), args...)
+}
+
+func (s *Store) queryRowOn(q queryer, ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return q.QueryRowContext(ctx, rebind(s.dialect, query), args...)
+}
+
+func (s *Store) queryOn(q queryer, ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return q.QueryContext(ctx, rebind(s.dialect, query), args...)
+}
+
 func (s *Store) exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	return s.db.ExecContext(ctx, rebind(s.dialect, query), args...)
+	return s.execOn(s.db, ctx, query, args...)
 }
 
 func (s *Store) queryRow(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	return s.db.QueryRowContext(ctx, rebind(s.dialect, query), args...)
+	return s.queryRowOn(s.db, ctx, query, args...)
 }
 
 func (s *Store) query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
-	return s.db.QueryContext(ctx, rebind(s.dialect, query), args...)
+	return s.queryOn(s.db, ctx, query, args...)
+}
+
+// withTx runs fn inside a transaction, committing on success and rolling
+// back on error or panic. Critical Invariant #D5: RecordStatusChange's
+// read-last → grace-delete → insert → count-update sequence must be atomic,
+// so a demoted leader mid-sequence during failover can't interleave with the
+// newly promoted leader's write of the same episode.
+func (s *Store) withTx(ctx context.Context, fn func(tx *sql.Tx) error) (err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+	if err := fn(tx); err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+			return fmt.Errorf("%w (rollback: %v)", err, rbErr)
+		}
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
 }
 
 func parseNullableTimeValue(raw interface{}) (sql.NullTime, error) {
@@ -127,15 +175,19 @@ func parseNullableTimeString(value string) (sql.NullTime, error) {
 // PostgreSQL: appends RETURNING id and uses QueryRowContext.
 // SQLite: uses ExecContext + LastInsertId.
 func (s *Store) insertReturningID(ctx context.Context, query string, args ...interface{}) (int64, error) {
-	q := rebind(s.dialect, query)
+	return s.insertReturningIDOn(s.db, ctx, query, args...)
+}
+
+func (s *Store) insertReturningIDOn(q queryer, ctx context.Context, query string, args ...interface{}) (int64, error) {
+	rq := rebind(s.dialect, query)
 	if s.dialect == idb.DialectPostgres {
 		var id int64
-		if err := s.db.QueryRowContext(ctx, q+" RETURNING id", args...).Scan(&id); err != nil {
+		if err := q.QueryRowContext(ctx, rq+" RETURNING id", args...).Scan(&id); err != nil {
 			return 0, err
 		}
 		return id, nil
 	}
-	res, err := s.db.ExecContext(ctx, q, args...)
+	res, err := q.ExecContext(ctx, rq, args...)
 	if err != nil {
 		return 0, err
 	}
@@ -176,72 +228,97 @@ func (s *Store) RecordStatusChange(
 	startsAt time.Time,
 	annotations map[string]string,
 ) (*models.AlertEvent, bool, error) {
-	last, err := s.getLastEventForCluster(fingerprint, clusterName)
+	ctx := context.Background()
+	var (
+		event   *models.AlertEvent
+		created bool
+	)
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		// D5: serialize concurrent writers for this episode. PostgreSQL only —
+		// SQLite is already single-writer via SetMaxOpenConns(1), so a second
+		// transaction can't even begin until this one commits or rolls back.
+		if s.dialect == idb.DialectPostgres {
+			lockKey := fingerprint + ":" + clusterName
+			if _, err := tx.ExecContext(ctx, rebind(s.dialect, `SELECT pg_advisory_xact_lock(hashtext(?))`), lockKey); err != nil {
+				return fmt.Errorf("acquire episode lock: %w", err)
+			}
+		}
+
+		last, err := s.getLastEventForClusterOn(tx, ctx, fingerprint, clusterName)
+		if err != nil {
+			return err
+		}
+
+		// Idempotency: same status → return existing row unchanged.
+		if last != nil && last.Status == status {
+			event, created = last, false
+			return nil
+		}
+
+		lastStatus := ""
+		if last != nil {
+			lastStatus = last.Status
+		}
+
+		// Grace Period: alert re-fires within the configured window of resolved → discard resolved row.
+		if status == models.EventStatusFiring && lastStatus == models.EventStatusResolved {
+			if time.Since(last.RecordedAt) < s.gracePeriod {
+				if _, err := s.execOn(tx, ctx, `DELETE FROM alert_events WHERE id = ?`, last.ID); err != nil {
+					return fmt.Errorf("grace period delete resolved: %w", err)
+				}
+				prev, err := s.getLastEventForClusterOn(tx, ctx, fingerprint, clusterName)
+				if err != nil {
+					return err
+				}
+				if prev != nil {
+					event, created = prev, false
+					return nil
+				}
+				// No prior row after deletion — fall through to insert a fresh firing row.
+				// Reset lastStatus so occurrence_count is not incremented.
+				lastStatus = ""
+			}
+		}
+
+		annJSON, err := json.Marshal(annotations)
+		if err != nil {
+			return fmt.Errorf("marshal annotations: %w", err)
+		}
+		now := time.Now().UTC()
+		id, err := s.insertReturningIDOn(tx, ctx, `
+			INSERT INTO alert_events (fingerprint, cluster_name, alertmanager_url, status, starts_at, annotations, recorded_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`, fingerprint, clusterName, amURL, status, startsAt.UTC(), string(annJSON), now)
+		if err != nil {
+			return fmt.Errorf("insert status change: %w", err)
+		}
+
+		// Increment occurrence_count only on genuine re-fire after full resolution.
+		if status == models.EventStatusFiring && lastStatus == models.EventStatusResolved {
+			if _, err := s.execOn(tx, ctx,
+				`UPDATE alert_fingerprints SET occurrence_count = occurrence_count + 1 WHERE fingerprint = ? AND cluster_name = ?`,
+				fingerprint, clusterName,
+			); err != nil {
+				return fmt.Errorf("increment occurrence_count: %w", err)
+			}
+		}
+
+		event = &models.AlertEvent{
+			ID:              id,
+			Fingerprint:     fingerprint,
+			ClusterName:     clusterName,
+			AlertmanagerURL: amURL,
+			Status:          status,
+			StartsAt:        startsAt.UTC(),
+			RecordedAt:      now,
+		}
+		created = true
+		return nil
+	})
 	if err != nil {
 		return nil, false, err
 	}
-
-	// Idempotency: same status → return existing row unchanged.
-	if last != nil && last.Status == status {
-		return last, false, nil
-	}
-
-	lastStatus := ""
-	if last != nil {
-		lastStatus = last.Status
-	}
-
-	// Grace Period: alert re-fires within the configured window of resolved → discard resolved row.
-	if status == models.EventStatusFiring && lastStatus == models.EventStatusResolved {
-		if time.Since(last.RecordedAt) < s.gracePeriod {
-			if _, err := s.exec(context.Background(), `DELETE FROM alert_events WHERE id = ?`, last.ID); err != nil {
-				return nil, false, fmt.Errorf("grace period delete resolved: %w", err)
-			}
-			prev, err := s.getLastEventForCluster(fingerprint, clusterName)
-			if err != nil {
-				return nil, false, err
-			}
-			if prev != nil {
-				return prev, false, nil
-			}
-			// No prior row after deletion — fall through to insert a fresh firing row.
-			// Reset lastStatus so occurrence_count is not incremented.
-			lastStatus = ""
-		}
-	}
-
-	annJSON, err := json.Marshal(annotations)
-	if err != nil {
-		return nil, false, fmt.Errorf("marshal annotations: %w", err)
-	}
-	now := time.Now().UTC()
-	id, err := s.insertReturningID(context.Background(), `
-		INSERT INTO alert_events (fingerprint, cluster_name, alertmanager_url, status, starts_at, annotations, recorded_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, fingerprint, clusterName, amURL, status, startsAt.UTC(), string(annJSON), now)
-	if err != nil {
-		return nil, false, fmt.Errorf("insert status change: %w", err)
-	}
-
-	// Increment occurrence_count only on genuine re-fire after full resolution.
-	if status == models.EventStatusFiring && lastStatus == models.EventStatusResolved {
-		if _, err := s.exec(context.Background(),
-			`UPDATE alert_fingerprints SET occurrence_count = occurrence_count + 1 WHERE fingerprint = ? AND cluster_name = ?`,
-			fingerprint, clusterName,
-		); err != nil {
-			return nil, false, fmt.Errorf("increment occurrence_count: %w", err)
-		}
-	}
-
-	return &models.AlertEvent{
-		ID:              id,
-		Fingerprint:     fingerprint,
-		ClusterName:     clusterName,
-		AlertmanagerURL: amURL,
-		Status:          status,
-		StartsAt:        startsAt.UTC(),
-		RecordedAt:      now,
-	}, true, nil
+	return event, created, nil
 }
 
 // RecordResolved inserts a resolved row for a fingerprint, inheriting cluster
@@ -1138,6 +1215,10 @@ func (s *Store) GetSilenceEventsForCluster(fingerprint, clusterName string) ([]m
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 func (s *Store) getLastEventForCluster(fingerprint, clusterName string) (*models.AlertEvent, error) {
+	return s.getLastEventForClusterOn(s.db, context.Background(), fingerprint, clusterName)
+}
+
+func (s *Store) getLastEventForClusterOn(q queryer, ctx context.Context, fingerprint, clusterName string) (*models.AlertEvent, error) {
 	var e models.AlertEvent
 	var startsAt, recordedAt time.Time
 	var endsAt sql.NullTime
@@ -1147,7 +1228,7 @@ func (s *Store) getLastEventForCluster(fingerprint, clusterName string) (*models
 		clusterFilter = " AND cluster_name = ?"
 		args = append(args, clusterName)
 	}
-	err := s.queryRow(context.Background(), `
+	err := s.queryRowOn(q, ctx, `
 		SELECT id, fingerprint, cluster_name, alertmanager_url, status, starts_at, ends_at, recorded_at
 		FROM alert_events WHERE fingerprint = ?`+clusterFilter+`
 		ORDER BY recorded_at DESC LIMIT 1

--- a/backend/internal/history/store_concurrency_test.go
+++ b/backend/internal/history/store_concurrency_test.go
@@ -1,0 +1,84 @@
+package history
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kj187/jarvis/backend/internal/models"
+)
+
+// TestRecordStatusChange_ConcurrentSQLite exercises D5: goroutines racing a
+// status transition for the same episode through one Store. SQLite's
+// single-writer connection (SetMaxOpenConns(1)) already serializes
+// transactions at the connection-pool level, so this asserts the outcome is
+// correct under -race, not that the advisory lock itself is exercised — that
+// part is PostgreSQL-only, see TestRecordStatusChange_ConcurrentPostgres.
+func TestRecordStatusChange_ConcurrentSQLite(t *testing.T) {
+	s := newTestStore(t)
+	runConcurrentResolveRace(t, []*Store{s, s})
+}
+
+// TestRecordStatusChange_ConcurrentPostgres is the regression test for D5:
+// without pg_advisory_xact_lock, N Stores backed by separate connections can
+// all read the same "last event" before any of them commits, and all decide
+// to insert — producing duplicate resolved rows for one episode. Two racing
+// connections rarely overlap widely enough on localhost to prove this (the
+// full read→insert→commit round trip is sub-millisecond), so this uses 10
+// concurrent Store instances to reliably force the overlap — confirmed by
+// temporarily disabling the lock during development: 2 racers passed 20/20
+// runs (false negative), 10 racers reproduced duplicates in >80% of runs.
+// Gated on JARVIS_TEST_POSTGRES_DSN (see store_postgres_test.go).
+func TestRecordStatusChange_ConcurrentPostgres(t *testing.T) {
+	stores := newTestPostgresStores(t, 10)
+	runConcurrentResolveRace(t, stores)
+}
+
+// runConcurrentResolveRace fires an alert, then resolves it concurrently
+// through every given Store handle racing on the same (fingerprint,
+// cluster). Exactly one resolved row must exist afterward — more would mean
+// the idempotency check ran non-atomically with the insert.
+func runConcurrentResolveRace(t *testing.T, stores []*Store) {
+	t.Helper()
+	const fp, cluster, amURL = "race-fp", "race-cluster", "http://am"
+
+	if err := stores[0].UpsertFingerprint(fp, "RaceAlert", cluster, nil); err != nil {
+		t.Fatalf("seed fingerprint: %v", err)
+	}
+	if _, _, err := stores[0].RecordStatusChange(fp, cluster, amURL, models.EventStatusFiring, time.Now(), nil); err != nil {
+		t.Fatalf("seed firing: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(stores))
+	wg.Add(len(stores))
+	for _, s := range stores {
+		s := s
+		go func() {
+			defer wg.Done()
+			_, _, err := s.RecordStatusChange(fp, cluster, amURL, models.EventStatusResolved, time.Now(), nil)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent RecordStatusChange: %v", err)
+		}
+	}
+
+	events, total, err := stores[0].GetHistoryForCluster(fp, cluster, 50, 0)
+	if err != nil {
+		t.Fatalf("GetHistoryForCluster: %v", err)
+	}
+	resolvedCount := 0
+	for _, e := range events {
+		if e.Status == models.EventStatusResolved {
+			resolvedCount++
+		}
+	}
+	if resolvedCount != 1 {
+		t.Fatalf("expected exactly 1 resolved event, got %d (total events %d)", resolvedCount, total)
+	}
+}

--- a/backend/internal/history/store_postgres_test.go
+++ b/backend/internal/history/store_postgres_test.go
@@ -1,0 +1,60 @@
+package history
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	idb "github.com/kj187/jarvis/backend/internal/db"
+)
+
+// postgresTestDSN returns the PostgreSQL test DSN from JARVIS_TEST_POSTGRES_DSN,
+// or skips the calling test if unset. This gates every PostgreSQL-backed test
+// in this package so `go test ./...` stays green without a database — CI
+// provisions one (see .github/workflows/ci.yml); locally use `make up-postgres`
+// and export JARVIS_TEST_POSTGRES_DSN=postgres://jarvis:jarvis@localhost:5432/jarvis?sslmode=disable.
+func postgresTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("JARVIS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("JARVIS_TEST_POSTGRES_DSN not set — skipping PostgreSQL-backed test")
+	}
+	return dsn
+}
+
+// newTestPostgresStores opens n independent *sql.DB connections against the
+// same PostgreSQL test database — n Store instances sharing one database,
+// the multi-replica situation in miniature that later slices' elector/
+// recorder/fanout tests will reuse this same pattern for. Tables are
+// truncated up front so a test doesn't see leftovers from a previous run.
+func newTestPostgresStores(t *testing.T, n int) []*Store {
+	t.Helper()
+	dsn := postgresTestDSN(t)
+
+	setup, dialect, err := idb.Open(dsn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	if err := idb.Migrate(setup, dialect); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if _, err := setup.ExecContext(context.Background(),
+		`TRUNCATE alert_events, alert_fingerprints, alert_claims, alert_comments RESTART IDENTITY CASCADE`,
+	); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if err := setup.Close(); err != nil {
+		t.Fatalf("close setup conn: %v", err)
+	}
+
+	stores := make([]*Store, n)
+	for i := 0; i < n; i++ {
+		database, dialect, err := idb.Open(dsn)
+		if err != nil {
+			t.Fatalf("open postgres (%d): %v", i, err)
+		}
+		t.Cleanup(func() { _ = database.Close() })
+		stores[i] = NewStore(database, dialect)
+	}
+	return stores
+}


### PR DESCRIPTION
## Summary
- `RecordStatusChange`'s read-last → grace-delete → insert → count-update sequence is now wrapped in a single transaction, closing a real race where two connections racing the same episode could both read the same "last event" and both insert (duplicate rows) — also the latent race behind rolling updates on single-replica deployments.
- On PostgreSQL, the transaction takes `pg_advisory_xact_lock(hashtext(fingerprint || ':' || cluster_name))` as its first statement to serialize concurrent writers per episode. SQLite is unaffected (already single-writer via `SetMaxOpenConns(1)`).
- Slice 0 of the multi-replica plan: establishes the PostgreSQL test harness every later slice needs — CI had no PostgreSQL at all until now. New `postgres:17` service container in `.github/workflows/ci.yml`, `JARVIS_TEST_POSTGRES_DSN`-gated tests (skip without a DSN), `newTestPostgresStores(t, n)` helper for racing multiple `Store` instances against one database.

## Test plan
- [x] `go test -race ./internal/history/...` — SQLite only (PG tests skip without DSN)
- [x] `go test -race ./internal/history/...` with `JARVIS_TEST_POSTGRES_DSN` set against a local `postgres:16` container (`make up-postgres`) — new concurrency tests pass; confirmed they actually catch the regression by temporarily disabling the advisory lock (reproduced duplicate rows reliably with 10 racing connections)
- [x] `go test -race ./...` (full backend suite)
- [x] `golangci-lint run ./...`
- [x] pre-commit hook (tests, lint, gitleaks) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)