### PR TITLE
feat(ws): cross-pod mutation fanout via PostgreSQL LISTEN/NOTIFY

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -664,6 +664,76 @@ polls; followers reconstruct their stores from PostgreSQL instead.
   change), and a follower's `Trigger()` reaches the leader well under the
   configured poll interval.
 
+### Cross-pod WS mutation fanout (`internal/fanout`, D4, PostgreSQL only)
+
+Snapshot distribution (D3, above) keeps alert-state broadcasts consistent
+across pods for free — every pod already derives `alerts_update`/the
+poll-time `silences_update` from its own poll or consumed snapshot. It does
+**not** cover mutation-driven broadcasts (a comment added, a claim set, a
+silence created/deleted via the API) — those originate on whichever pod
+handled the HTTP request and must still reach every other pod's WS clients.
+`internal/fanout` is the separate, narrower mechanism for exactly that.
+
+- `Fanout` interface: `Publish(ctx, message []byte, ref Ref)`,
+  `Run(ctx, onMessage func([]byte), onRef func(Ref))`. `Ref{Type,
+  Fingerprint, ClusterName, ID}` identifies a mutation well enough for the
+  receiving pod to look the row back up itself.
+- `NoopFanout` (SQLite dialect): `Publish` does nothing, `Run` blocks on
+  `ctx.Done()` — single replica, no other pod to fan out to.
+- `PGFanout` (PostgreSQL dialect): publishes via `pg_notify('jarvis_ws',
+  ...)` on the existing pooled `*sql.DB` (NOTIFY is a cheap statement, no
+  dedicated connection needed to publish); `Run` opens its own dedicated
+  LISTEN connection (same TCP-keepalive bound as D2/D3: idle 5s/interval
+  3s/count 3). The wire envelope is `{origin, message?, ref?}` — `origin` is
+  a random `uuid.NewString()` generated once per `PGFanout` instance, and
+  `consume` skips any notification whose `origin` matches its own (echo
+  suppression: without this, a pod would receive its own `Publish` back from
+  PostgreSQL, since NOTIFY delivers to every listening session including the
+  one that sent it — not just "other" ones). Fire-and-forget: unlike
+  snapshot distribution there is no durable resync fallback here; a missed
+  NOTIFY just skips that one live update; the next natural refetch still
+  converges.
+- Payload-size fallback: PostgreSQL's NOTIFY payload limit is ~8000 bytes.
+  If the encoded envelope with the full `message` would exceed
+  `maxNotifyPayloadBytes` (7800, a safety margin under that limit — reachable
+  in practice for `comment_added`, whose body can be up to 10,000 characters),
+  `Publish` sends `ref` alone instead. The receiving pod's `onRef` callback
+  refetches the authoritative row from the shared PostgreSQL database and
+  reconstructs the exact broadcast the originating pod would have sent — no
+  frontend changes needed, since the delivered WS message ends up
+  byte-equivalent either way.
+- `ws.Hub` gained `BuildEventJSON` (pure encode, no broadcast) and
+  `BroadcastRaw` (broadcast pre-encoded bytes, reads the event type back out
+  of the bytes for the `jarvis_ws_broadcasts_total` label) alongside the
+  existing `BroadcastJSON` (now a thin wrapper over both). `api.Server`'s new
+  `broadcastAndFanout(ctx, eventType, payload, ref)` is the single call site
+  every user-mutation handler uses: it builds once, broadcasts locally via
+  `BroadcastRaw`, and publishes via `fanout.Publish` — used by `addComment`
+  (`comments.go`), `setClaim`/`releaseClaim`/`updateClaimNote` (`claims.go`),
+  and `applySilenceWriteThrough` (`silences.go`, shared by silence
+  create/delete). Silence templates currently have no WS broadcast at all
+  (checked during D4 implementation) — nothing to fan out there yet.
+- Receiving side: `api.HandleFanoutMessage(hub)` (re-broadcasts bytes
+  unchanged) and `api.HandleFanoutRef(store, hub, logger)` (switches on
+  `ref.Type`: `comment_added` → `store.GetComment`, `claim_set`/
+  `claim_released` → `store.GetActiveClaim`, `silences_update` → re-broadcast
+  the empty struct directly, no lookup needed) are wired in
+  `cmd/jarvis/main.go` as `go wsFanout.Run(ctx, api.HandleFanoutMessage(hub),
+  api.HandleFanoutRef(store, hub, logger))`, alongside the elector/recorder/
+  sweeper goroutines. `wsFanout` itself is chosen the same way as `el` —
+  `fanout.NewPGFanout(database, cfg.DBDSN, logger)` on PostgreSQL,
+  `fanout.NoopFanout{}` on SQLite — and passed into `api.NewRouter`/
+  `api.NewServer`.
+- Test harness: `internal/fanout/postgres_test.go` (two `PGFanout` instances,
+  one database — delivery to the other instance only, echo suppression,
+  small-message inline delivery, oversized-message ref fallback, all
+  `JARVIS_TEST_POSTGRES_DSN`-gated) and
+  `internal/api/fanout_integration_test.go` (two full "pods" — own `Store`,
+  `Hub`, `PGFanout` each, sharing one database — a real `addComment` HTTP
+  call reaches both pods' WS clients exactly once, no echo double-delivery;
+  a second test drives an oversized comment body through the same path to
+  exercise the ref-fallback end-to-end, including the database refetch).
+
 ---
 
 ## Frontend Component Tree (`frontend/src/`)
@@ -1056,6 +1126,14 @@ banner collapse state in AlertDetailPanel, default collapsed)
 | `claim_released` | `{ fingerprint, clusterName, releasedBy }` | set `activeClaim` to `undefined` + invalidate claim queries |
 | `comment_added` | `{ fingerprint, comment }` | invalidate comments query by prefix key `['comments', fingerprint, clusterName]` — matches every paged query key (`..., page]`) for that alert, so whichever page is mounted refetches; local `page` state is untouched (see `CommentsPanel.tsx` above for the page>1 "jump to latest" affordance) |
 | `silences_update` | `{}` (pure invalidation signal) | `invalidateQueries(['silences'])` → refetch from the in-memory snapshot. Broadcast by the recorder when the silence snapshot diff changed vs. the previous poll, and by every silence mutation write-through (`applySilenceWriteThrough`) |
+
+`claim_set`/`claim_released`/`comment_added`/the write-through `silences_update`
+are mutation-driven and — on PostgreSQL, multi-replica — fanned out to every
+other pod via `internal/fanout` (D4, see the Leader Election section above)
+so a browser tab connected to any pod sees the same live update. The
+poll-driven `alerts_update` and the recorder's own `silences_update` are
+**not** fanned out — every pod already derives those from its own poll or
+consumed snapshot (D3).
 
 ---
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -128,9 +128,13 @@ make fixtures-unsilence            # expire test silences
 | `internal/api` | `admin_handler_test.go` | admin user CRUD + role/self guards |
 | `internal/api` | `clusters_test.go` | Cluster health from cached poll up-state (up/degraded/all-down/no-poll-yet), zero live `/api/v2/status` calls, single-member `members` omission |
 | `internal/api` | `router_test.go` | Route registration, `/groups` before `/:fingerprint/*`, protection modes |
+| `internal/api` | `fanout_dispatch.go` / (covered by `fanout_integration_test.go`) | `HandleFanoutMessage`/`HandleFanoutRef` — receiving-side dispatch for cross-pod WS mutation fanout (D4) |
+| `internal/api` | `fanout_integration_test.go` | D4 integration (`JARVIS_TEST_POSTGRES_DSN`-gated): two full "pods" — own `Store`/`Hub`/`fanout.PGFanout` each, sharing one database — a real `addComment` HTTP call reaches both pods' WS clients exactly once (no echo double-delivery); a second test drives a 9000-char comment body through the same path to exercise the oversized-message Ref fallback end-to-end, including the database refetch on the receiving pod |
 | `internal/auth` | `jwt_test.go` `internal_provider_test.go` `middleware_test.go` | JWT sign/verify, RequireAuth/RequireAdmin |
 | `internal/users` | `store_test.go` | User CRUD, OIDC upsert, bcrypt |
-| `internal/ws` | `hub_test.go` | Broadcast, client register/unregister, slow client drop, `jarvis_ws_broadcasts_total` |
+| `internal/ws` | `hub_test.go` | Broadcast, client register/unregister, slow client drop, `jarvis_ws_broadcasts_total`, `BuildEventJSON`+`BroadcastRaw` produce the same metric label as `BroadcastJSON` |
+| `internal/fanout` | `postgres_test.go` | `PGFanout` (`JARVIS_TEST_POSTGRES_DSN`-gated): delivers to the other instance only (echo suppression via `origin`), small messages delivered inline, oversized messages (> `maxNotifyPayloadBytes`) fall back to a `Ref` instead |
+| `internal/fanout` | `noop_test.go` | `NoopFanout`: `Publish` is a no-op, `Run` blocks until `ctx` is cancelled |
 | `internal/metrics` | `collector_test.go` | `storeCollector` scrape-time output (`testutil.CollectAndCompare`), nil `clusterUp`, `jarvis_build_info`, duplicate-registration panic |
 | `internal/metrics` | `echo_test.go` | HTTP middleware: route-pattern label (not raw path), 404 → `unmatched`, skip list (`/metrics`/`/health`/`/ws`) |
 

--- a/backend/cmd/jarvis/main.go
+++ b/backend/cmd/jarvis/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	"github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/leader"
 	"github.com/kj187/jarvis/backend/internal/metrics"
@@ -73,6 +74,17 @@ func main() {
 		recorderDSN = cfg.DBDSN
 	} else {
 		el = leader.NewStaticElector()
+	}
+
+	// ── WS Mutation Fanout ────────────────────────────────────────────────────
+	// D4: only user-mutation broadcasts (comments, claims, silences) go
+	// through this — alert-state broadcasts ride the D3 snapshot path
+	// instead. NoopFanout on SQLite (single replica, no other pod to fan out to).
+	var wsFanout fanout.Fanout
+	if dialect == db.DialectPostgres {
+		wsFanout = fanout.NewPGFanout(database, cfg.DBDSN, logger)
+	} else {
+		wsFanout = fanout.NoopFanout{}
 	}
 
 	// ── Stores ────────────────────────────────────────────────────────────────
@@ -141,7 +153,7 @@ func main() {
 	sweeper := retention.NewSweeper(store, cfg.Retention, logger, m, el)
 
 	// ── HTTP Router ───────────────────────────────────────────────────────────
-	router := api.NewRouter(alertStore, silenceStore, store, hub, registry, cfg, static.StaticFiles, recorder, authProvider, userStore, m)
+	router := api.NewRouter(alertStore, silenceStore, store, hub, registry, cfg, static.StaticFiles, recorder, authProvider, userStore, m, wsFanout)
 
 	server := &http.Server{
 		Addr:         ":" + cfg.Port,
@@ -158,6 +170,7 @@ func main() {
 	go el.Run(ctx)
 	go recorder.Start(ctx)
 	go sweeper.Start(ctx)
+	go wsFanout.Run(ctx, api.HandleFanoutMessage(hub), api.HandleFanoutRef(store, hub, logger))
 
 	go func() {
 		logger.Info("jarvis started", "port", cfg.Port)

--- a/backend/internal/api/alerts_test.go
+++ b/backend/internal/api/alerts_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/models"
@@ -39,7 +40,7 @@ func newTestServer(t *testing.T) (*Server, *history.AlertStore) {
 	registry := cluster.NewRegistry(nil)
 	cfg := &config.Config{}
 
-	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NoneProvider{}, userStore), alertStore
+	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NoneProvider{}, userStore, fanout.NoopFanout{}), alertStore
 }
 
 func TestGetAlerts_Empty(t *testing.T) {

--- a/backend/internal/api/auth_handler_test.go
+++ b/backend/internal/api/auth_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/users"
@@ -44,7 +45,7 @@ func newAuthServer(t *testing.T) (*Server, *users.Store) {
 	registry := cluster.NewRegistry(nil)
 	cfg := &config.Config{AuthProvider: "internal", SecretKey: testSecretKey}
 
-	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, provider, userStore), userStore
+	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, provider, userStore, fanout.NoopFanout{}), userStore
 }
 
 func createTestUser(t *testing.T, store *users.Store, username, password, role string) *users.User {

--- a/backend/internal/api/claims.go
+++ b/backend/internal/api/claims.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/kj187/jarvis/backend/internal/auth"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/models"
 	"github.com/labstack/echo/v4"
@@ -75,11 +76,11 @@ func (s *Server) setClaim(c echo.Context) error {
 
 	s.alertStore.SetActiveClaim(fp, cluster, claim)
 
-	s.hub.BroadcastJSON(models.WSTypeClaimSet, map[string]interface{}{
+	s.broadcastAndFanout(c.Request().Context(), models.WSTypeClaimSet, map[string]interface{}{
 		"fingerprint": fp,
 		"clusterName": cluster,
 		"claim":       claim,
-	})
+	}, fanout.Ref{Type: models.WSTypeClaimSet, Fingerprint: fp, ClusterName: cluster})
 
 	return c.JSON(http.StatusCreated, claim)
 }
@@ -113,11 +114,11 @@ func (s *Server) releaseClaim(c echo.Context) error {
 
 	s.alertStore.ClearActiveClaim(fp, cluster)
 
-	s.hub.BroadcastJSON(models.WSTypeClaimReleased, map[string]interface{}{
+	s.broadcastAndFanout(c.Request().Context(), models.WSTypeClaimReleased, map[string]interface{}{
 		"fingerprint": fp,
 		"clusterName": cluster,
 		"releasedBy":  by,
-	})
+	}, fanout.Ref{Type: models.WSTypeClaimReleased, Fingerprint: fp, ClusterName: cluster, ID: by})
 
 	return c.NoContent(http.StatusNoContent)
 }
@@ -169,11 +170,11 @@ func (s *Server) updateClaimNote(c echo.Context) error {
 
 	s.alertStore.SetActiveClaim(fp, cluster, claim)
 
-	s.hub.BroadcastJSON(models.WSTypeClaimSet, map[string]interface{}{
+	s.broadcastAndFanout(c.Request().Context(), models.WSTypeClaimSet, map[string]interface{}{
 		"fingerprint": fp,
 		"clusterName": cluster,
 		"claim":       claim,
-	})
+	}, fanout.Ref{Type: models.WSTypeClaimSet, Fingerprint: fp, ClusterName: cluster})
 
 	return c.JSON(http.StatusOK, claim)
 }

--- a/backend/internal/api/claims_test.go
+++ b/backend/internal/api/claims_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/models"
@@ -41,7 +42,7 @@ func newTestServerFull(t *testing.T) (*Server, *history.AlertStore, *history.Sto
 	registry := cluster.NewRegistry(nil)
 	cfg := &config.Config{}
 
-	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NoneProvider{}, userStore), alertStore, store
+	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NoneProvider{}, userStore, fanout.NoopFanout{}), alertStore, store
 }
 
 // seedFP inserts a fingerprint row so FK constraints in claims/comments pass.

--- a/backend/internal/api/clusters_test.go
+++ b/backend/internal/api/clusters_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/models"
@@ -39,7 +40,7 @@ func newTestServerWithRegistry(t *testing.T, registry *cluster.Registry) *Server
 	hub := ws.NewHub(nil, nil, metrics.New("test"))
 	go hub.Run()
 
-	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, &config.Config{}, nil, auth.NoneProvider{}, userStore)
+	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, &config.Config{}, nil, auth.NoneProvider{}, userStore, fanout.NoopFanout{})
 }
 
 // healthMockAM serves an empty alert list (so FetchAlerts marks the member up)

--- a/backend/internal/api/comments.go
+++ b/backend/internal/api/comments.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/kj187/jarvis/backend/internal/auth"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/models"
 	"github.com/labstack/echo/v4"
 )
@@ -86,10 +87,10 @@ func (s *Server) addComment(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to add comment")
 	}
 
-	s.hub.BroadcastJSON("comment_added", map[string]interface{}{
+	s.broadcastAndFanout(c.Request().Context(), "comment_added", map[string]interface{}{
 		"fingerprint": fp,
 		"comment":     comment,
-	})
+	}, fanout.Ref{Type: "comment_added", Fingerprint: fp, ClusterName: cluster, ID: strconv.FormatInt(comment.ID, 10)})
 
 	return c.JSON(http.StatusCreated, comment)
 }

--- a/backend/internal/api/fanout_dispatch.go
+++ b/backend/internal/api/fanout_dispatch.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"log/slog"
+	"strconv"
+
+	"github.com/kj187/jarvis/backend/internal/fanout"
+	"github.com/kj187/jarvis/backend/internal/history"
+	"github.com/kj187/jarvis/backend/internal/models"
+	"github.com/kj187/jarvis/backend/internal/ws"
+)
+
+// HandleFanoutMessage returns the callback for Fanout.Run's onMessage: a
+// message published by another pod is re-broadcast to this pod's own WS
+// clients unchanged.
+func HandleFanoutMessage(hub *ws.Hub) func(message []byte) {
+	return func(message []byte) {
+		hub.BroadcastRaw(message)
+	}
+}
+
+// HandleFanoutRef returns the callback for Fanout.Run's onRef: another pod's
+// mutation broadcast was too large to embed in a single NOTIFY payload (D4,
+// tmp/fable/multi-replica.md), so only a Ref arrived. Every pod shares the
+// same PostgreSQL database, so this pod refetches the authoritative row via
+// store and reconstructs the exact broadcast the originating pod would have
+// sent, then broadcasts that reconstruction to its own clients.
+func HandleFanoutRef(store *history.Store, hub *ws.Hub, logger *slog.Logger) func(ref fanout.Ref) {
+	return func(ref fanout.Ref) {
+		switch ref.Type {
+		case "comment_added":
+			id, err := strconv.ParseInt(ref.ID, 10, 64)
+			if err != nil {
+				logger.Error("fanout: invalid comment ref id", "ref", ref, "err", err)
+				return
+			}
+			comment, err := store.GetComment(ref.Fingerprint, ref.ClusterName, id)
+			if err != nil {
+				logger.Error("fanout: refetch comment for ref", "ref", ref, "err", err)
+				return
+			}
+			if comment == nil {
+				return
+			}
+			hub.BroadcastJSON("comment_added", map[string]interface{}{
+				"fingerprint": ref.Fingerprint,
+				"comment":     comment,
+			})
+
+		case models.WSTypeClaimSet:
+			claim, err := store.GetActiveClaim(ref.Fingerprint, ref.ClusterName)
+			if err != nil {
+				logger.Error("fanout: refetch claim for ref", "ref", ref, "err", err)
+				return
+			}
+			if claim == nil {
+				return
+			}
+			hub.BroadcastJSON(models.WSTypeClaimSet, map[string]interface{}{
+				"fingerprint": ref.Fingerprint,
+				"clusterName": ref.ClusterName,
+				"claim":       claim,
+			})
+
+		case models.WSTypeClaimReleased:
+			hub.BroadcastJSON(models.WSTypeClaimReleased, map[string]interface{}{
+				"fingerprint": ref.Fingerprint,
+				"clusterName": ref.ClusterName,
+				"releasedBy":  ref.ID,
+			})
+
+		case models.WSTypeSilencesUpdate:
+			hub.BroadcastJSON(models.WSTypeSilencesUpdate, struct{}{})
+
+		default:
+			logger.Warn("fanout: unknown ref type", "ref", ref)
+		}
+	}
+}

--- a/backend/internal/api/fanout_integration_test.go
+++ b/backend/internal/api/fanout_integration_test.go
@@ -1,0 +1,261 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+
+	"github.com/kj187/jarvis/backend/internal/auth"
+	"github.com/kj187/jarvis/backend/internal/cluster"
+	"github.com/kj187/jarvis/backend/internal/config"
+	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
+	"github.com/kj187/jarvis/backend/internal/history"
+	"github.com/kj187/jarvis/backend/internal/metrics"
+	"github.com/kj187/jarvis/backend/internal/users"
+	"github.com/kj187/jarvis/backend/internal/ws"
+)
+
+// TestFanout_CommentMutation_ReachesBothPodsExactlyOnce is the D4 integration
+// test the multi-replica plan asks for: two full "pods" — each its own
+// Store, Hub, and PGFanout — sharing one PostgreSQL database. A mutation
+// handled by pod A's HTTP handler must reach pod B's WS clients (converged
+// via fanout) exactly once, and pod A's own WS clients exactly once (no
+// echo double-delivery from A's own Publish reaching its own Run loop).
+func TestFanout_CommentMutation_ReachesBothPodsExactlyOnce(t *testing.T) {
+	dsn := os.Getenv("JARVIS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("JARVIS_TEST_POSTGRES_DSN not set — skipping PostgreSQL-backed test")
+	}
+
+	setup, dialect, err := idb.Open(dsn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	if err := idb.Migrate(setup, dialect); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if _, err := setup.ExecContext(context.Background(),
+		`TRUNCATE alert_events, alert_fingerprints, alert_claims, alert_comments RESTART IDENTITY CASCADE`,
+	); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if err := setup.Close(); err != nil {
+		t.Fatalf("close setup conn: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	podA := newFanoutTestPod(t, dsn, logger)
+	podB := newFanoutTestPod(t, dsn, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go podA.fanout.Run(ctx, HandleFanoutMessage(podA.hub), HandleFanoutRef(podA.store, podA.hub, logger))
+	go podB.fanout.Run(ctx, HandleFanoutMessage(podB.hub), HandleFanoutRef(podB.store, podB.hub, logger))
+	time.Sleep(300 * time.Millisecond) // let both LISTEN connections establish
+
+	clientA := connectWSClient(t, podA.hub)
+	clientB := connectWSClient(t, podB.hub)
+
+	if err := podA.store.UpsertFingerprint("1234567890abcdef", "TestAlert", "c1", map[string]string{"alertname": "TestAlert"}); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+
+	// Drive the real HTTP handler on pod A.
+	e := echo.New()
+	body := strings.NewReader(`{"authorName":"alice","body":"hello from pod A"}`)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/?cluster=c1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("fingerprint")
+	c.SetParamValues("1234567890abcdef")
+	if err := podA.server.addComment(c); err != nil {
+		t.Fatalf("addComment: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("addComment status = %d, want 201, body=%s", rec.Code, rec.Body.String())
+	}
+
+	msgB := readWSMessage(t, clientB, 5*time.Second)
+	assertCommentAddedMessage(t, msgB, "hello from pod A")
+
+	msgA := readWSMessage(t, clientA, 5*time.Second)
+	assertCommentAddedMessage(t, msgA, "hello from pod A")
+
+	// Neither client may receive a second copy (no echo double-delivery, no
+	// duplicate cross-pod fanout).
+	assertNoFurtherMessage(t, clientA, 300*time.Millisecond)
+	assertNoFurtherMessage(t, clientB, 300*time.Millisecond)
+}
+
+// TestFanout_OversizedComment_UsesRefFallback exercises the D4 reference
+// fallback end-to-end: a comment body long enough to push the encoded
+// envelope past maxNotifyPayloadBytes must still converge to pod B — not by
+// embedding the full message, but via a Ref that pod B resolves by
+// refetching the comment from the (shared) database.
+func TestFanout_OversizedComment_UsesRefFallback(t *testing.T) {
+	dsn := os.Getenv("JARVIS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("JARVIS_TEST_POSTGRES_DSN not set — skipping PostgreSQL-backed test")
+	}
+
+	setup, dialect, err := idb.Open(dsn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	if err := idb.Migrate(setup, dialect); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if _, err := setup.ExecContext(context.Background(),
+		`TRUNCATE alert_events, alert_fingerprints, alert_claims, alert_comments RESTART IDENTITY CASCADE`,
+	); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if err := setup.Close(); err != nil {
+		t.Fatalf("close setup conn: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	podA := newFanoutTestPod(t, dsn, logger)
+	podB := newFanoutTestPod(t, dsn, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go podA.fanout.Run(ctx, HandleFanoutMessage(podA.hub), HandleFanoutRef(podA.store, podA.hub, logger))
+	go podB.fanout.Run(ctx, HandleFanoutMessage(podB.hub), HandleFanoutRef(podB.store, podB.hub, logger))
+	time.Sleep(300 * time.Millisecond)
+
+	clientB := connectWSClient(t, podB.hub)
+
+	if err := podA.store.UpsertFingerprint("1234567890abcdef", "TestAlert", "c1", map[string]string{"alertname": "TestAlert"}); err != nil {
+		t.Fatalf("UpsertFingerprint: %v", err)
+	}
+
+	// maxCommentBodyLen is 10,000 chars — comfortably past
+	// fanout.maxNotifyPayloadBytes (7800) once JSON-wrapped, so this must hit
+	// the Ref fallback rather than embedding the full message.
+	hugeBody := strings.Repeat("x", 9000)
+	e := echo.New()
+	reqBody, err := json.Marshal(map[string]string{"authorName": "alice", "body": hugeBody})
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/?cluster=c1", strings.NewReader(string(reqBody)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("fingerprint")
+	c.SetParamValues("1234567890abcdef")
+	if err := podA.server.addComment(c); err != nil {
+		t.Fatalf("addComment: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("addComment status = %d, want 201, body=%s", rec.Code, rec.Body.String())
+	}
+
+	msgB := readWSMessage(t, clientB, 5*time.Second)
+	assertCommentAddedMessage(t, msgB, hugeBody)
+}
+
+type fanoutTestPod struct {
+	store  *history.Store
+	hub    *ws.Hub
+	fanout *fanout.PGFanout
+	server *Server
+}
+
+func newFanoutTestPod(t *testing.T, dsn string, logger *slog.Logger) *fanoutTestPod {
+	t.Helper()
+	database, dialect, err := idb.Open(dsn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	store := history.NewStore(database, dialect)
+	hub := ws.NewHub(nil, logger, metrics.New("test-fanout"))
+	go hub.Run()
+	f := fanout.NewPGFanout(database, dsn, logger)
+
+	alertStore := &history.AlertStore{}
+	silenceStore := history.NewSilenceStore()
+	registry := cluster.NewRegistry(nil)
+	userStore := users.NewStore(database, dialect)
+	srv := NewServer(alertStore, silenceStore, store, hub, registry, &config.Config{}, nil, auth.NoneProvider{}, userStore, f)
+
+	return &fanoutTestPod{store: store, hub: hub, fanout: f, server: srv}
+}
+
+func connectWSClient(t *testing.T, hub *ws.Hub) *websocket.Conn {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(hub.ServeWS))
+	t.Cleanup(srv.Close)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	// Give the hub time to register the client before anything broadcasts.
+	time.Sleep(50 * time.Millisecond)
+	return conn
+}
+
+func readWSMessage(t *testing.T, conn *websocket.Conn, timeout time.Duration) []byte {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read ws message: %v", err)
+	}
+	return msg
+}
+
+func assertNoFurtherMessage(t *testing.T, conn *websocket.Conn, wait time.Duration) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(wait)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	_, msg, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatalf("unexpected extra message (double delivery): %s", msg)
+	}
+}
+
+func assertCommentAddedMessage(t *testing.T, msg []byte, wantBody string) {
+	t.Helper()
+	var event struct {
+		Type    string `json:"type"`
+		Payload struct {
+			Fingerprint string `json:"fingerprint"`
+			Comment     struct {
+				Body string `json:"body"`
+			} `json:"comment"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(msg, &event); err != nil {
+		t.Fatalf("unmarshal ws message: %v (raw: %s)", err, msg)
+	}
+	if event.Type != "comment_added" {
+		t.Fatalf("event type = %q, want comment_added (raw: %s)", event.Type, msg)
+	}
+	if event.Payload.Comment.Body != wantBody {
+		t.Errorf("comment body = %q, want %q", event.Payload.Comment.Body, wantBody)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/auth"
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/users"
@@ -55,6 +56,7 @@ func NewRouter(
 	authProvider auth.Provider,
 	userStore *users.Store,
 	m *metrics.Metrics,
+	f fanout.Fanout,
 ) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
@@ -118,7 +120,7 @@ func NewRouter(
 		}))
 	}
 
-	srv := NewServer(alertStore, silenceStore, store, hub, registry, cfg, recorder, authProvider, userStore)
+	srv := NewServer(alertStore, silenceStore, store, hub, registry, cfg, recorder, authProvider, userStore, f)
 
 	// Wire JWT secret key into auth middleware.
 	if len(cfg.SecretKey) > 0 {

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/users"
@@ -38,7 +39,7 @@ func newTestRouter(t *testing.T, origins []string) *httptest.Server {
 	registry := cluster.NewRegistry(nil)
 	cfg := &config.Config{AllowedOrigins: origins}
 
-	e := NewRouter(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, embed.FS{}, &fakeTriggerer{}, auth.NoneProvider{}, userStore, metrics.New("test"))
+	e := NewRouter(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, embed.FS{}, &fakeTriggerer{}, auth.NoneProvider{}, userStore, metrics.New("test"), fanout.NoopFanout{})
 	return httptest.NewServer(e)
 }
 
@@ -195,7 +196,7 @@ func newTestRouterWithAuthMode(t *testing.T, authMode string) *httptest.Server {
 		SecretKey:    []byte("aaaabbbbccccddddeeeeffffgggghhhh"),
 	}
 
-	e := NewRouter(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, embed.FS{}, &fakeTriggerer{}, provider, userStore, metrics.New("test"))
+	e := NewRouter(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, embed.FS{}, &fakeTriggerer{}, provider, userStore, metrics.New("test"), fanout.NoopFanout{})
 	return httptest.NewServer(e)
 }
 

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -8,6 +9,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/auth"
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/users"
 	"github.com/kj187/jarvis/backend/internal/ws"
@@ -32,6 +34,7 @@ type Server struct {
 	pollTrigger  pollTriggerer
 	authProvider auth.Provider
 	userStore    *users.Store
+	fanout       fanout.Fanout
 }
 
 // NewServer creates a new Server with the given dependencies.
@@ -45,6 +48,7 @@ func NewServer(
 	pollTrigger pollTriggerer,
 	authProvider auth.Provider,
 	userStore *users.Store,
+	f fanout.Fanout,
 ) *Server {
 	return &Server{
 		alertStore:   alertStore,
@@ -56,7 +60,30 @@ func NewServer(
 		pollTrigger:  pollTrigger,
 		authProvider: authProvider,
 		userStore:    userStore,
+		fanout:       f,
 	}
+}
+
+// broadcastAndFanout builds a WS event once, broadcasts it to this pod's own
+// clients, and publishes it to every other pod via fanout (D4,
+// tmp/fable/multi-replica.md) — the single call site every user-mutation
+// handler (comments, claims, silences) uses instead of hub.BroadcastJSON
+// directly, so cross-pod delivery is never forgotten when a new mutation
+// broadcast is added. Snapshot-driven broadcasts (alerts_update, the
+// poll-time silences_update in history.Recorder) do NOT go through this —
+// every pod already derives those from its own poll or consumed snapshot
+// (D3), so fanning them out too would be redundant.
+func (s *Server) broadcastAndFanout(ctx context.Context, eventType string, payload interface{}, ref fanout.Ref) {
+	data, err := ws.BuildEventJSON(eventType, payload)
+	if err != nil {
+		// BuildEventJSON's failure modes are the same as BroadcastJSON's
+		// (marshal error) — fall back to it so local clients still get
+		// best-effort delivery even though fanout is skipped this once.
+		s.hub.BroadcastJSON(eventType, payload)
+		return
+	}
+	s.hub.BroadcastRaw(data)
+	s.fanout.Publish(ctx, data, ref)
 }
 
 // POST /api/v1/poll — triggers an immediate Alertmanager poll.

--- a/backend/internal/api/setup_test.go
+++ b/backend/internal/api/setup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/users"
@@ -39,7 +40,7 @@ func newSetupServer(t *testing.T) (*Server, *users.Store) {
 	registry := cluster.NewRegistry(nil)
 	cfg := &config.Config{AuthProvider: "internal"}
 
-	srv := NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NewInternalProvider(userStore), userStore)
+	srv := NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NewInternalProvider(userStore), userStore, fanout.NoopFanout{})
 	return srv, userStore
 }
 

--- a/backend/internal/api/silences.go
+++ b/backend/internal/api/silences.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	amclient "github.com/kj187/jarvis/backend/internal/alertmanager"
 	"github.com/kj187/jarvis/backend/internal/auth"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/models"
 	"github.com/labstack/echo/v4"
 )
@@ -47,7 +48,7 @@ func (s *Server) applySilenceWriteThrough(cluster string, upsert *amclient.Getta
 	if expireID != "" {
 		s.silenceStore.MarkExpired(cluster, expireID)
 	}
-	s.hub.BroadcastJSON(models.WSTypeSilencesUpdate, struct{}{})
+	s.broadcastAndFanout(context.Background(), models.WSTypeSilencesUpdate, struct{}{}, fanout.Ref{Type: models.WSTypeSilencesUpdate})
 	if s.pollTrigger != nil {
 		s.pollTrigger.Trigger()
 	}

--- a/backend/internal/api/silences_test.go
+++ b/backend/internal/api/silences_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kj187/jarvis/backend/internal/cluster"
 	"github.com/kj187/jarvis/backend/internal/config"
 	idb "github.com/kj187/jarvis/backend/internal/db"
+	"github.com/kj187/jarvis/backend/internal/fanout"
 	"github.com/kj187/jarvis/backend/internal/history"
 	"github.com/kj187/jarvis/backend/internal/metrics"
 	"github.com/kj187/jarvis/backend/internal/users"
@@ -44,7 +45,7 @@ func newTestServerWithAM(t *testing.T, amURL string) *Server {
 		{Name: "testcluster", AlertmanagerURL: amURL, AlertmanagerLinkURL: amURL},
 	})
 	cfg := &config.Config{}
-	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NoneProvider{}, userStore)
+	return NewServer(alertStore, history.NewSilenceStore(), store, hub, registry, cfg, nil, auth.NoneProvider{}, userStore, fanout.NoopFanout{})
 }
 
 // fakeTriggerer records poll-trigger requests from mutation handlers.

--- a/backend/internal/fanout/fanout.go
+++ b/backend/internal/fanout/fanout.go
@@ -1,0 +1,44 @@
+// Package fanout implements cross-pod WebSocket mutation fanout (D4,
+// tmp/fable/multi-replica.md): a mutation handled by one pod (a comment,
+// claim, or silence write) must also reach WS clients connected to every
+// other pod. Only user-mutation broadcasts go through this — alert-state
+// broadcasts (alerts_update, the poll-driven silences_update) ride the D3
+// snapshot distribution path instead, since every pod already derives those
+// from its own poll or consumed snapshot.
+package fanout
+
+import "context"
+
+// Ref identifies a mutation well enough for the receiving pod to look the
+// full row back up itself, when the encoded message didn't fit in a single
+// NOTIFY payload (~8000 bytes — PostgreSQL's limit). Type selects which
+// domain (and therefore which store lookup) applies; the rest are that
+// domain's natural identifying fields (comments: Fingerprint+ClusterName+ID;
+// claims: Fingerprint+ClusterName; silences: Type alone, since its payload
+// is always the empty struct and never needs a real lookup).
+type Ref struct {
+	Type        string `json:"type"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	ClusterName string `json:"clusterName,omitempty"`
+	ID          string `json:"id,omitempty"`
+}
+
+// Fanout publishes an already-encoded WS message to every other pod and
+// delivers messages published by other pods back to this one. Implementations
+// must suppress a pod's own Publish calls from reaching its own onMessage/onRef
+// callbacks (origin echo suppression) — Publish already both-broadcasts
+// locally (via the caller's own ws.Hub) and fans out, so echoing it back
+// would double-deliver to this pod's own clients.
+type Fanout interface {
+	// Publish sends message to every other pod's Run callback. ref is used
+	// instead of message when message is too large to fit in a single NOTIFY
+	// payload — the receiving pod must then look the full data back up
+	// itself using ref's fields.
+	Publish(ctx context.Context, message []byte, ref Ref)
+
+	// Run drives the receive loop until ctx is cancelled — call in its own
+	// goroutine. onMessage is invoked with the exact bytes another pod
+	// published; onRef is invoked instead when that pod's message was too
+	// large to embed.
+	Run(ctx context.Context, onMessage func(message []byte), onRef func(ref Ref))
+}

--- a/backend/internal/fanout/noop.go
+++ b/backend/internal/fanout/noop.go
@@ -1,0 +1,14 @@
+package fanout
+
+import "context"
+
+// NoopFanout is the SQLite-dialect Fanout: SQLite deployments are single
+// replica by design (Critical Invariant #8), so there is never another pod
+// to fan out to.
+type NoopFanout struct{}
+
+func (NoopFanout) Publish(context.Context, []byte, Ref) {}
+
+// Run blocks until ctx is cancelled — there is no receive loop to run, but
+// callers can still treat every Fanout uniformly (go f.Run(ctx, ...)).
+func (NoopFanout) Run(ctx context.Context, _ func([]byte), _ func(Ref)) { <-ctx.Done() }

--- a/backend/internal/fanout/noop_test.go
+++ b/backend/internal/fanout/noop_test.go
@@ -1,0 +1,36 @@
+package fanout
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNoopFanout_PublishIsNoOp(t *testing.T) {
+	var f NoopFanout
+	// Must not panic or block.
+	f.Publish(context.Background(), []byte("x"), Ref{Type: "comment_added"})
+}
+
+func TestNoopFanout_RunBlocksUntilCancelled(t *testing.T) {
+	var f NoopFanout
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		f.Run(ctx, func([]byte) { t.Error("onMessage must never be called") }, func(Ref) { t.Error("onRef must never be called") })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Run returned before ctx was cancelled")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}

--- a/backend/internal/fanout/postgres.go
+++ b/backend/internal/fanout/postgres.go
@@ -1,0 +1,162 @@
+package fanout
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Binding Constants (tmp/fable/multi-replica.md D4) — use verbatim, do not rename.
+const (
+	// NotifyChannel is the pg_notify channel WS mutation fanout uses.
+	NotifyChannel = "jarvis_ws"
+
+	// maxNotifyPayloadBytes leaves headroom under PostgreSQL's ~8000-byte
+	// NOTIFY payload limit for the envelope's own JSON overhead (origin ID,
+	// field names, escaping) — a message that would push the encoded
+	// envelope past this is sent as a Ref instead.
+	maxNotifyPayloadBytes = 7800
+
+	// listenRetryInterval and the TCP keepalive bounds mirror
+	// internal/leader's Binding Constants (D2): the same hard-node-failure
+	// detection bound applies to every dedicated PostgreSQL connection.
+	listenRetryInterval = 5 * time.Second
+	keepAliveIdle       = 5 * time.Second
+	keepAliveInterval   = 3 * time.Second
+	keepAliveCount      = 3
+)
+
+// envelope is the wire format published on NotifyChannel: Origin identifies
+// the publishing pod (echo suppression — see PGFanout.consume), and exactly
+// one of Message/Ref is set (the reference fallback for oversized messages).
+type envelope struct {
+	Origin  string          `json:"origin"`
+	Message json.RawMessage `json:"message,omitempty"`
+	Ref     *Ref            `json:"ref,omitempty"`
+}
+
+// PGFanout is the PostgreSQL-dialect Fanout.
+type PGFanout struct {
+	db     *sql.DB // pooled connection — NOTIFY is a cheap statement, no dedicated connection needed to publish
+	dsn    string  // dedicated LISTEN connection (never the pool — pool connections get recycled)
+	logger *slog.Logger
+	origin string
+}
+
+// NewPGFanout creates a PGFanout. db is the existing pooled *sql.DB (used
+// only to issue NOTIFY); dsn is used to open the dedicated LISTEN connection
+// in Run.
+func NewPGFanout(db *sql.DB, dsn string, logger *slog.Logger) *PGFanout {
+	return &PGFanout{db: db, dsn: dsn, logger: logger, origin: uuid.NewString()}
+}
+
+func (f *PGFanout) Publish(ctx context.Context, message []byte, ref Ref) {
+	env := envelope{Origin: f.origin, Message: message}
+	full, err := json.Marshal(env)
+	if err != nil {
+		f.logger.Error("fanout: marshal envelope failed", "err", err)
+		return
+	}
+	if len(full) > maxNotifyPayloadBytes {
+		env = envelope{Origin: f.origin, Ref: &ref}
+		full, err = json.Marshal(env)
+		if err != nil {
+			f.logger.Error("fanout: marshal reference envelope failed", "err", err)
+			return
+		}
+	}
+	if _, err := f.db.ExecContext(ctx, `SELECT pg_notify('`+NotifyChannel+`', $1)`, string(full)); err != nil {
+		f.logger.Error("fanout: publish failed", "err", err)
+	}
+}
+
+func (f *PGFanout) Run(ctx context.Context, onMessage func([]byte), onRef func(Ref)) {
+	for ctx.Err() == nil {
+		conn, err := f.dial(ctx)
+		if err != nil {
+			f.logger.Error("fanout: connect failed, retrying", "err", err)
+			sleepCtx(ctx, listenRetryInterval)
+			continue
+		}
+		f.consume(ctx, conn, onMessage, onRef)
+	}
+}
+
+// dial opens a dedicated (non-pooled) connection with aggressive TCP
+// keepalives (D2) and issues LISTEN on it.
+func (f *PGFanout) dial(ctx context.Context) (*pgx.Conn, error) {
+	cfg, err := pgx.ParseConfig(f.dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse dsn: %w", err)
+	}
+	dialer := &net.Dialer{
+		KeepAliveConfig: net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     keepAliveIdle,
+			Interval: keepAliveInterval,
+			Count:    keepAliveCount,
+		},
+	}
+	cfg.DialFunc = dialer.DialContext
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := conn.Exec(ctx, "LISTEN "+NotifyChannel); err != nil {
+		_ = conn.Close(context.Background())
+		return nil, fmt.Errorf("listen %s: %w", NotifyChannel, err)
+	}
+	return conn, nil
+}
+
+// consume owns conn for its lifetime, dispatching every notification not
+// originated by this same PGFanout instance. Fanout is best-effort/fire-and-
+// forget (unlike D3's snapshot distribution, there is no durable resync
+// fallback here — a missed NOTIFY just means that one live update doesn't
+// reach the other pod's clients; their next natural refetch still converges).
+// Returns (closing conn) when ctx is cancelled or the connection is lost —
+// the caller's Run loop then redials.
+func (f *PGFanout) consume(ctx context.Context, conn *pgx.Conn, onMessage func([]byte), onRef func(Ref)) {
+	defer func() { _ = conn.Close(context.Background()) }()
+
+	for {
+		n, err := conn.WaitForNotification(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			f.logger.Warn("fanout: connection lost, reconnecting", "err", err)
+			return
+		}
+		var env envelope
+		if err := json.Unmarshal([]byte(n.Payload), &env); err != nil {
+			f.logger.Error("fanout: unmarshal envelope failed", "err", err)
+			continue
+		}
+		if env.Origin == f.origin {
+			continue // echo suppression: this pod's own Publish
+		}
+		if env.Ref != nil {
+			onRef(*env.Ref)
+			continue
+		}
+		onMessage(env.Message)
+	}
+}
+
+// sleepCtx sleeps for d or returns early if ctx is cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}

--- a/backend/internal/fanout/postgres_test.go
+++ b/backend/internal/fanout/postgres_test.go
@@ -1,0 +1,181 @@
+package fanout
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	idb "github.com/kj187/jarvis/backend/internal/db"
+)
+
+func postgresTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("JARVIS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("JARVIS_TEST_POSTGRES_DSN not set — skipping PostgreSQL-backed test")
+	}
+	return dsn
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newTestPGFanout(t *testing.T, dsn string) (*PGFanout, *sql.DB) {
+	t.Helper()
+	db, _, err := idb.Open(dsn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewPGFanout(db, dsn, testLogger()), db
+}
+
+// waitFor polls cond every 20ms until it returns true or timeout elapses,
+// failing the test in the latter case.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", timeout)
+}
+
+// collector is a thread-safe sink for onMessage/onRef callbacks.
+type collector struct {
+	mu       sync.Mutex
+	messages [][]byte
+	refs     []Ref
+}
+
+func (c *collector) onMessage(msg []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = append(c.messages, msg)
+}
+
+func (c *collector) onRef(ref Ref) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refs = append(c.refs, ref)
+}
+
+func (c *collector) messageCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.messages)
+}
+
+func (c *collector) refCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.refs)
+}
+
+func (c *collector) lastMessage() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.messages) == 0 {
+		return nil
+	}
+	return c.messages[len(c.messages)-1]
+}
+
+func (c *collector) lastRef() Ref {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.refs[len(c.refs)-1]
+}
+
+func TestPGFanout_DeliversToOtherInstanceOnly(t *testing.T) {
+	dsn := postgresTestDSN(t)
+	fanoutA, _ := newTestPGFanout(t, dsn)
+	fanoutB, _ := newTestPGFanout(t, dsn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	collA := &collector{}
+	collB := &collector{}
+	go fanoutA.Run(ctx, collA.onMessage, collA.onRef)
+	go fanoutB.Run(ctx, collB.onMessage, collB.onRef)
+
+	// Give both LISTEN connections time to establish before publishing.
+	time.Sleep(300 * time.Millisecond)
+
+	fanoutA.Publish(context.Background(), []byte(`{"type":"comment_added"}`), Ref{Type: "comment_added"})
+
+	waitFor(t, 5*time.Second, func() bool { return collB.messageCount() == 1 })
+	// A must NOT see its own publish (echo suppression) — give it a further
+	// beat to (incorrectly) receive it, if suppression were broken.
+	time.Sleep(300 * time.Millisecond)
+	if collA.messageCount() != 0 {
+		t.Errorf("publisher must not receive its own message, got %d", collA.messageCount())
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(collB.lastMessage(), &got); err != nil {
+		t.Fatalf("unmarshal delivered message: %v", err)
+	}
+	if got["type"] != "comment_added" {
+		t.Errorf("delivered message = %v, want type=comment_added", got)
+	}
+}
+
+func TestPGFanout_OversizedMessage_FallsBackToRef(t *testing.T) {
+	dsn := postgresTestDSN(t)
+	fanoutA, _ := newTestPGFanout(t, dsn)
+	fanoutB, _ := newTestPGFanout(t, dsn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	collB := &collector{}
+	go fanoutA.Run(ctx, func([]byte) {}, func(Ref) {})
+	go fanoutB.Run(ctx, collB.onMessage, collB.onRef)
+	time.Sleep(300 * time.Millisecond)
+
+	huge := []byte(`{"body":"` + strings.Repeat("x", maxNotifyPayloadBytes) + `"}`)
+	ref := Ref{Type: "comment_added", Fingerprint: "fp1", ClusterName: "a", ID: "42"}
+	fanoutA.Publish(context.Background(), huge, ref)
+
+	waitFor(t, 5*time.Second, func() bool { return collB.refCount() == 1 })
+	if collB.messageCount() != 0 {
+		t.Errorf("oversized publish must not deliver as a message, got %d messages", collB.messageCount())
+	}
+	if got := collB.lastRef(); got != ref {
+		t.Errorf("delivered ref = %+v, want %+v", got, ref)
+	}
+}
+
+func TestPGFanout_SmallMessage_DeliveredInline(t *testing.T) {
+	dsn := postgresTestDSN(t)
+	fanoutA, _ := newTestPGFanout(t, dsn)
+	fanoutB, _ := newTestPGFanout(t, dsn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	collB := &collector{}
+	go fanoutA.Run(ctx, func([]byte) {}, func(Ref) {})
+	go fanoutB.Run(ctx, collB.onMessage, collB.onRef)
+	time.Sleep(300 * time.Millisecond)
+
+	fanoutA.Publish(context.Background(), []byte(`{"small":true}`), Ref{Type: "claim_set"})
+
+	waitFor(t, 5*time.Second, func() bool { return collB.messageCount() == 1 })
+	if collB.refCount() != 0 {
+		t.Errorf("small publish must not fall back to a ref, got %d refs", collB.refCount())
+	}
+}

--- a/backend/internal/ws/hub.go
+++ b/backend/internal/ws/hub.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -96,20 +97,49 @@ func (h *Hub) Run() {
 	}
 }
 
-// BroadcastJSON encodes a typed WS event and queues it for broadcast.
-func (h *Hub) BroadcastJSON(eventType string, payload interface{}) {
+// BuildEventJSON encodes a typed WS event exactly as BroadcastJSON does,
+// without queuing it — callers that also need to fan the same bytes out to
+// other pods (D4, tmp/fable/multi-replica.md: internal/fanout) build once
+// with this and pass the result to both BroadcastRaw and Fanout.Publish, so
+// every pod's clients receive byte-identical messages regardless of which
+// pod originated the mutation.
+func BuildEventJSON(eventType string, payload interface{}) ([]byte, error) {
 	p, err := json.Marshal(payload)
 	if err != nil {
-		h.logger.Error("marshal ws payload", "err", err)
-		return
+		return nil, fmt.Errorf("marshal ws payload: %w", err)
 	}
 	event := models.WSEvent{Type: eventType, Payload: p}
 	data, err := json.Marshal(event)
 	if err != nil {
-		h.logger.Error("marshal ws event", "err", err)
+		return nil, fmt.Errorf("marshal ws event: %w", err)
+	}
+	return data, nil
+}
+
+// BroadcastJSON encodes a typed WS event and queues it for broadcast to this
+// pod's own clients only — see BroadcastRaw for the cross-pod-fanout case.
+func (h *Hub) BroadcastJSON(eventType string, payload interface{}) {
+	data, err := BuildEventJSON(eventType, payload)
+	if err != nil {
+		h.logger.Error("build ws event", "type", eventType, "err", err)
 		return
 	}
+	h.BroadcastRaw(data)
+}
+
+// BroadcastRaw queues an already-encoded WS event (see BuildEventJSON) for
+// broadcast to this pod's own clients — used directly by fanout consumers
+// that received the bytes from another pod, so they don't need to
+// re-marshal a typed payload value, only pass the bytes through. The event
+// type for the WSBroadcastsTotal metric label is read back out of data
+// itself (models.WSEvent.Type), so callers never need to track it separately.
+func (h *Hub) BroadcastRaw(data []byte) {
 	if h.metrics != nil {
+		var event models.WSEvent
+		eventType := "unknown"
+		if err := json.Unmarshal(data, &event); err == nil {
+			eventType = event.Type
+		}
 		h.metrics.WSBroadcastsTotal.WithLabelValues(eventType).Inc()
 	}
 	h.broadcast <- data

--- a/backend/internal/ws/hub_test.go
+++ b/backend/internal/ws/hub_test.go
@@ -134,3 +134,25 @@ func TestHub_BroadcastJSON_IncrementsMetric(t *testing.T) {
 		t.Errorf("comment_added broadcasts = %v, want 1", got)
 	}
 }
+
+// TestBuildEventJSON_BroadcastRaw_MatchesBroadcastJSON verifies the D4
+// fanout building blocks: BuildEventJSON + BroadcastRaw must deliver a
+// byte-identical message to BroadcastJSON's own encoding, and BroadcastRaw
+// must still label the WSBroadcastsTotal metric correctly by reading the
+// type back out of the encoded bytes (fanout consumers never carry the
+// original typed payload, only bytes from another pod).
+func TestBuildEventJSON_BroadcastRaw_MatchesBroadcastJSON(t *testing.T) {
+	m := metrics.New("test")
+	hub := NewHub(nil, slog.Default(), m)
+	go hub.Run()
+
+	data, err := BuildEventJSON("claim_set", map[string]string{"fingerprint": "fp1"})
+	if err != nil {
+		t.Fatalf("BuildEventJSON: %v", err)
+	}
+	hub.BroadcastRaw(data)
+
+	if got := testutil.ToFloat64(m.WSBroadcastsTotal.WithLabelValues("claim_set")); got != 1 {
+		t.Errorf("claim_set broadcasts after BroadcastRaw = %v, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary
- D4 in `tmp/fable/multi-replica.md` (slice 3): a mutation handled by one pod (a comment added, a claim set/released, a silence created/deleted) now reaches every other pod's WS clients too. Snapshot distribution (D3) already covers alert-state broadcasts — this is the separate, narrower mechanism for user-mutation broadcasts.
- New `internal/fanout` package: `Fanout` interface with `PGFanout` (publishes via `pg_notify('jarvis_ws', ...)`, LISTENs on a dedicated connection with the same TCP-keepalive bound as the elector/snapshot listeners, origin-ID echo suppression) and `NoopFanout` (SQLite). PostgreSQL's ~8000-byte NOTIFY payload limit is guarded by a reference fallback (`{type, fingerprint, clusterName, id}`) — reachable in practice for comments (bodies up to 10,000 chars) — the receiving pod refetches the authoritative row from the shared database and reconstructs the exact broadcast.
- `ws.Hub` gains `BuildEventJSON`/`BroadcastRaw`; `api.Server`'s new `broadcastAndFanout` is the single call site every user-mutation handler uses — wired into comments, claims, and silences. Silence templates have no WS broadcast at all currently, so nothing to wire there.

## Test plan
- [x] `go test -race ./...` — SQLite only
- [x] `go test -race ./...` with `JARVIS_TEST_POSTGRES_DSN` set (`make up-postgres`) — new `internal/fanout` suite (delivery/echo-suppression/size-fallback) + new `internal/api/fanout_integration_test.go`: two full pods (own Store/Hub/PGFanout each) — a real `addComment` HTTP call reaches both pods' WS clients exactly once with no echo double-delivery; a second test drives a 9000-char comment body through the same path to exercise the ref fallback end-to-end
- [x] `golangci-lint run ./...`
- [x] pre-commit hook (tests, lint, gitleaks) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)