### PR TITLE
feat(config): leader pod label via Kubernetes API PATCH (no client-go)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -734,6 +734,60 @@ handled the HTTP request and must still reach every other pod's WS clients.
   a second test drives an oversized comment body through the same path to
   exercise the ref-fallback end-to-end, including the database refetch).
 
+### Leader pod label (`internal/leader.PodLabeler`, D7, Kubernetes only)
+
+Informational only — every pod serves all traffic regardless of leadership,
+so this is purely so `kubectl get pods -L jarvis.kj187.de/role` shows the
+current leader. No leader-only traffic routing exists or is planned.
+
+- `PodLabeler` is registered directly in `cmd/jarvis/main.go` as an
+  `Elector.Subscribe` callback (`el.Subscribe(podLabeler.OnLeadershipChange)`),
+  alongside `history.NewRecorder`'s own subscription — both fire on every
+  transition, independently (this is exactly why `Elector.Subscribe` takes a
+  callback rather than exposing a single channel).
+- On promotion: HTTP `PATCH` (merge-patch, `application/merge-patch+json`) to
+  this pod's own `/api/v1/namespaces/<ns>/pods/<name>`, setting
+  `metadata.labels."jarvis.kj187.de/role" = "leader"`. On step-down: the same
+  PATCH shape, `null`-ing the key out — a merge patch removes a key that way
+  and (unlike a JSON Patch "add") never fails if `metadata.labels` didn't
+  already exist. `PodLabeler` tracks whether *it* added the label
+  (`hasLabel`) so a step-down callback fired before ever being promoted
+  (`Elector.Subscribe` always fires once immediately with the current
+  state — see the `PGElector`/`StaticElector` note above) never issues a
+  pointless remove.
+- No client-go: a plain `net/http` client with the in-cluster
+  ServiceAccount's CA (`/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`)
+  and bearer token (`.../token`), `KUBERNETES_SERVICE_HOST`/`_PORT` (both
+  auto-injected by Kubernetes into every pod) for the API server address, and
+  the Downward API env vars `POD_NAME`/`POD_NAMESPACE` for this pod's own
+  identity.
+- Kubernetes detection: `NewPodLabeler` reads the ServiceAccount token file;
+  if it's absent (compose, bare Docker — Jarvis has no ServiceAccount mount
+  there at all) or `POD_NAME`/`POD_NAMESPACE`/`KUBERNETES_SERVICE_HOST`/`_PORT`
+  are unset, it logs why and disables itself — every subsequent
+  `OnLeadershipChange` call is then a no-op. A failed PATCH is logged and
+  never fatal, matching the "decoration, not a dependency" framing above.
+- Chart (`charts/jarvis/templates/rbac.yaml`, gated by
+  `leaderElection.podLabel.enabled`, default `true`): a `Role` (`pods`:
+  `get`, `patch` — nothing broader) + matching `RoleBinding` to the chart's
+  own `ServiceAccount`. The `ServiceAccount` itself sets
+  `automountServiceAccountToken: false` (least privilege by default), so
+  `templates/deployment.yaml` sets it back to `true` at the **pod** level
+  when the toggle is on, and always injects `POD_NAME`/`POD_NAMESPACE` via
+  `fieldRef` (harmless when the toggle is off — `NewPodLabeler` already
+  disables via the missing token file in that case, checked first).
+- Test harness: `internal/leader/podlabel_test.go` (promotion issues the add
+  merge-patch with the exact key/value, step-down after a promotion issues
+  the null merge-patch, step-down *without* a prior promotion issues no
+  request at all, a disabled `PodLabeler` never makes a request, and
+  `NewPodLabeler` disables itself gracefully when there's no ServiceAccount
+  mount — true in every non-Kubernetes test/CI environment);
+  `charts/jarvis/tests/rbac_test.yaml` +
+  new cases in `deployment_test.yaml` (helm-unittest) cover both toggle
+  states: `Role`/`RoleBinding` render with exactly the `pods: get, patch`
+  rule and nothing at all when disabled; `automountServiceAccountToken`
+  flips `true`/`false` with the toggle.
+
 ---
 
 ## Frontend Component Tree (`frontend/src/`)

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -51,7 +51,7 @@ make e2e-screenshot NAME=card-view # regenerate ONE screenshot
 
 # ── Helm (no cluster needed — helm-unittest plugin required) ─
 helm lint charts/jarvis/           # Static chart validation
-helm unittest charts/jarvis/       # Unit tests (deployment, configmap, secret, ingress)
+helm unittest charts/jarvis/       # Unit tests (deployment, configmap, secret, ingress, servicemonitor, rbac)
 
 # ── Everything via Makefile ──────────────────────────────────
 make test-all                      # backend + frontend + helm lint + helm unittest
@@ -113,7 +113,8 @@ make fixtures-unsilence            # expire test silences
 | `internal/history` | `time_fuzz_test.go` | Fuzz: `parseNullableTimeString` never panics, err/Valid contract |
 | `internal/retention` | `sweeper_test.go` | `Sweeper`: disabled config → `Start` never calls the store; context cancelled before the first sweep stops cleanly; full sweep order + per-domain cutoffs against a `fakeStore` (comments → claims → silence events → detach → events → orphan, orphan cutoff = widest of the four); domains with no effective retention are skipped; one domain's error doesn't abort the rest; `jarvis_retention_*` metrics counted; nil `*metrics.Metrics` doesn't panic; `shouldSweep()` gated by a `fakeLeaderChecker` (nil elector always sweeps, follower never sweeps, leader sweeps) |
 | `internal/leader` | `static_test.go` | `StaticElector`: always leader, `Subscribe` fires `fn(true)` synchronously |
-| `internal/leader` | `postgres_test.go` | `PGElector` (`JARVIS_TEST_POSTGRES_DSN`-gated): exactly one of two electors racing the same DSN becomes leader; killing the leader's `Run` context releases the session lock and the follower is promoted within seconds; `Subscribe` fires exactly one `[true]` transition on promotion |
+| `internal/leader` | `postgres_test.go` | `PGElector` (`JARVIS_TEST_POSTGRES_DSN`-gated): exactly one of two electors racing the same DSN becomes leader; killing the leader's `Run` context releases the session lock and the follower is promoted within seconds; `Subscribe` fires immediately with the current (not-yet-connected `false`) state, then `true` on promotion — `[false, true]` |
+| `internal/leader` | `podlabel_test.go` | `PodLabeler` (D7): promotion issues the add merge-patch (`jarvis.kj187.de/role=leader`) with the exact method/path/`Content-Type`/bearer token/body; step-down after a promotion issues the null merge-patch; step-down *without* a prior promotion issues no request (guards against `Subscribe`'s immediate-fire initial `false`); a disabled `PodLabeler` never makes a request; `NewPodLabeler` disables itself gracefully with no ServiceAccount mount (true in every non-Kubernetes test/CI environment) |
 | `internal/history` | `recorder_leader_test.go` | D3-step-4 leader gating via a `fakeElector`: a follower skips `RecordStatusChange`/`RecordResolvedForCluster` (in-memory `AlertStore` still updates); the nil-elector default and an explicit leader=true elector both still write history; `reconcileStartupResolves` only runs once promoted (`reconciledClusters` guard); the delayed claim-release goroutine re-checks leadership at fire time and skips if demoted mid-delay |
 | `internal/alertmanager` | `client_test.go` | HTTP client against `httptest.NewServer` |
 | `internal/alertmanager` | `auth_test.go` `oauth2_test.go` | Per-cluster upstream auth (basic/bearer/OAuth2) |

--- a/backend/cmd/jarvis/main.go
+++ b/backend/cmd/jarvis/main.go
@@ -76,6 +76,12 @@ func main() {
 		el = leader.NewStaticElector()
 	}
 
+	// ── Leader Pod Label (D7) ─────────────────────────────────────────────────
+	// Informational only (every pod serves all traffic already) — best-effort,
+	// never fatal; no-op outside Kubernetes (no ServiceAccount mount).
+	podLabeler := leader.NewPodLabeler(logger)
+	el.Subscribe(podLabeler.OnLeadershipChange)
+
 	// ── WS Mutation Fanout ────────────────────────────────────────────────────
 	// D4: only user-mutation broadcasts (comments, claims, silences) go
 	// through this — alert-state broadcasts ride the D3 snapshot path

--- a/backend/internal/leader/podlabel.go
+++ b/backend/internal/leader/podlabel.go
@@ -1,0 +1,151 @@
+package leader
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// Binding Constants (tmp/fable/multi-replica.md D7) — use verbatim, do not rename.
+const (
+	// PodLabelKey/PodLabelValue: jarvis.kj187.de/role=leader. Informational
+	// only — every pod serves all traffic regardless of leadership, this is
+	// purely so `kubectl get pods -L jarvis.kj187.de/role` shows who's
+	// currently leader.
+	PodLabelKey   = "jarvis.kj187.de/role"
+	PodLabelValue = "leader"
+
+	// Downward API env vars the chart injects to identify this pod.
+	envPodName      = "POD_NAME"
+	envPodNamespace = "POD_NAMESPACE"
+
+	serviceAccountDir   = "/var/run/secrets/kubernetes.io/serviceaccount"
+	serviceAccountToken = serviceAccountDir + "/token"
+	serviceAccountCA    = serviceAccountDir + "/ca.crt"
+
+	podLabelRequestTimeout = 10 * time.Second
+)
+
+// PodLabeler labels this pod jarvis.kj187.de/role=leader on promotion and
+// removes the label on graceful step-down (D7), via a direct HTTPS call to
+// the Kubernetes API server — no client-go. Registered as an
+// Elector.Subscribe callback. Outside Kubernetes (compose, bare Docker) —
+// detected by the ServiceAccount token mount's absence — every call is a
+// no-op. A failed PATCH is logged and never fatal: leadership itself lives
+// entirely in the PostgreSQL advisory lock (D2), the label is decoration.
+type PodLabeler struct {
+	client    *http.Client
+	apiServer string
+	token     string
+	namespace string
+	podName   string
+	logger    *slog.Logger
+	enabled   bool
+
+	// hasLabel tracks whether THIS process added the label, so a step-down
+	// before ever being promoted (Subscribe fires immediately with the
+	// not-yet-leader initial state — see internal/history's own note on the
+	// same Elector behavior) never issues a pointless remove PATCH.
+	hasLabel bool
+}
+
+// NewPodLabeler builds a PodLabeler using the standard in-cluster
+// ServiceAccount mount, the KUBERNETES_SERVICE_HOST/PORT env vars Kubernetes
+// injects into every pod, and the Downward API env vars POD_NAME/
+// POD_NAMESPACE (the chart sets these — see charts/jarvis/templates/deployment.yaml).
+// Disables itself (logging why) if any of these are missing, rather than
+// failing startup — the label is optional decoration.
+func NewPodLabeler(logger *slog.Logger) *PodLabeler {
+	tokenBytes, err := os.ReadFile(serviceAccountToken)
+	if err != nil {
+		// Expected outside Kubernetes (compose, bare Docker) — not an error.
+		return &PodLabeler{logger: logger, enabled: false}
+	}
+	podName := os.Getenv(envPodName)
+	namespace := os.Getenv(envPodNamespace)
+	if podName == "" || namespace == "" {
+		logger.Warn("leader pod label: disabled — POD_NAME/POD_NAMESPACE not set")
+		return &PodLabeler{logger: logger, enabled: false}
+	}
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		logger.Warn("leader pod label: disabled — KUBERNETES_SERVICE_HOST/PORT not set")
+		return &PodLabeler{logger: logger, enabled: false}
+	}
+	caCert, err := os.ReadFile(serviceAccountCA)
+	if err != nil {
+		logger.Warn("leader pod label: disabled — read ServiceAccount CA cert failed", "err", err)
+		return &PodLabeler{logger: logger, enabled: false}
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caCert)
+
+	return &PodLabeler{
+		client: &http.Client{
+			Timeout:   podLabelRequestTimeout,
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}},
+		},
+		apiServer: fmt.Sprintf("https://%s:%s", host, port),
+		token:     strings.TrimSpace(string(tokenBytes)),
+		namespace: namespace,
+		podName:   podName,
+		logger:    logger,
+		enabled:   true,
+	}
+}
+
+// OnLeadershipChange is the Elector.Subscribe callback.
+func (p *PodLabeler) OnLeadershipChange(isLeader bool) {
+	if !p.enabled {
+		return
+	}
+	if isLeader {
+		p.patch(fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, PodLabelKey, PodLabelValue))
+		p.hasLabel = true
+		return
+	}
+	if !p.hasLabel {
+		return
+	}
+	p.patch(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, PodLabelKey))
+	p.hasLabel = false
+}
+
+// patch sends a merge-patch (application/merge-patch+json) to this pod's own
+// /api/v1/namespaces/<ns>/pods/<name> — a merge patch adds/creates the
+// labels map as needed (unlike a JSON Patch "add", which fails if
+// metadata.labels doesn't already exist) and removes a key by setting it to
+// null, so the same request shape covers both promotion and step-down.
+func (p *PodLabeler) patch(body string) {
+	url := fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s", p.apiServer, p.namespace, p.podName)
+	ctx, cancel := context.WithTimeout(context.Background(), podLabelRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		p.logger.Error("leader pod label: build request failed", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+	req.Header.Set("Authorization", "Bearer "+p.token)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		p.logger.Error("leader pod label: PATCH failed", "err", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		p.logger.Error("leader pod label: PATCH non-2xx", "status", resp.StatusCode, "body", string(respBody))
+	}
+}

--- a/backend/internal/leader/podlabel_test.go
+++ b/backend/internal/leader/podlabel_test.go
@@ -1,0 +1,125 @@
+package leader
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type patchRequest struct {
+	method      string
+	path        string
+	contentType string
+	auth        string
+	body        string
+}
+
+func newPatchRecordingServer(t *testing.T) (*httptest.Server, *[]patchRequest) {
+	t.Helper()
+	var requests []patchRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests = append(requests, patchRequest{
+			method:      r.Method,
+			path:        r.URL.Path,
+			contentType: r.Header.Get("Content-Type"),
+			auth:        r.Header.Get("Authorization"),
+			body:        string(body),
+		})
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &requests
+}
+
+func TestPodLabeler_Promotion_PatchesAddLabel(t *testing.T) {
+	srv, requests := newPatchRecordingServer(t)
+	p := &PodLabeler{
+		client: srv.Client(), apiServer: srv.URL, token: "tok-123",
+		namespace: "default", podName: "jarvis-0", logger: testLogger(), enabled: true,
+	}
+
+	p.OnLeadershipChange(true)
+
+	if len(*requests) != 1 {
+		t.Fatalf("expected 1 PATCH request, got %d", len(*requests))
+	}
+	req := (*requests)[0]
+	if req.method != http.MethodPatch {
+		t.Errorf("method = %q, want PATCH", req.method)
+	}
+	if req.path != "/api/v1/namespaces/default/pods/jarvis-0" {
+		t.Errorf("path = %q, want /api/v1/namespaces/default/pods/jarvis-0", req.path)
+	}
+	if req.contentType != "application/merge-patch+json" {
+		t.Errorf("Content-Type = %q, want application/merge-patch+json", req.contentType)
+	}
+	if req.auth != "Bearer tok-123" {
+		t.Errorf("Authorization = %q, want Bearer tok-123", req.auth)
+	}
+	if !strings.Contains(req.body, `"jarvis.kj187.de/role":"leader"`) {
+		t.Errorf("body = %s, want it to set jarvis.kj187.de/role=leader", req.body)
+	}
+}
+
+func TestPodLabeler_StepDownAfterPromotion_PatchesRemoveLabel(t *testing.T) {
+	srv, requests := newPatchRecordingServer(t)
+	p := &PodLabeler{
+		client: srv.Client(), apiServer: srv.URL, token: "tok-123",
+		namespace: "default", podName: "jarvis-0", logger: testLogger(), enabled: true,
+	}
+
+	p.OnLeadershipChange(true)
+	p.OnLeadershipChange(false)
+
+	if len(*requests) != 2 {
+		t.Fatalf("expected 2 PATCH requests, got %d", len(*requests))
+	}
+	if !strings.Contains((*requests)[1].body, `"jarvis.kj187.de/role":null`) {
+		t.Errorf("step-down body = %s, want it to null out jarvis.kj187.de/role", (*requests)[1].body)
+	}
+}
+
+func TestPodLabeler_StepDownWithoutPriorPromotion_DoesNotPatch(t *testing.T) {
+	srv, requests := newPatchRecordingServer(t)
+	p := &PodLabeler{
+		client: srv.Client(), apiServer: srv.URL, token: "tok-123",
+		namespace: "default", podName: "jarvis-0", logger: testLogger(), enabled: true,
+	}
+
+	// Elector.Subscribe fires immediately with the not-yet-leader initial
+	// state — this must not try to remove a label that was never added.
+	p.OnLeadershipChange(false)
+
+	if len(*requests) != 0 {
+		t.Fatalf("expected no PATCH requests, got %d", len(*requests))
+	}
+}
+
+func TestPodLabeler_Disabled_NeverPatches(t *testing.T) {
+	srv, requests := newPatchRecordingServer(t)
+	p := &PodLabeler{client: srv.Client(), apiServer: srv.URL, logger: testLogger(), enabled: false}
+
+	p.OnLeadershipChange(true)
+	p.OnLeadershipChange(false)
+
+	if len(*requests) != 0 {
+		t.Fatalf("disabled PodLabeler must never PATCH, got %d requests", len(*requests))
+	}
+}
+
+// TestNewPodLabeler_NoServiceAccountMount_Disabled verifies the primary
+// outside-Kubernetes detection signal: without the ServiceAccount token file
+// (never present in a normal test/CI environment), NewPodLabeler disables
+// itself instead of failing.
+func TestNewPodLabeler_NoServiceAccountMount_Disabled(t *testing.T) {
+	p := NewPodLabeler(testLogger())
+	if p.enabled {
+		t.Skip("running with a real ServiceAccount mount present — nothing to assert here")
+	}
+	// Must still be safe to call.
+	p.OnLeadershipChange(true)
+	p.OnLeadershipChange(false)
+}

--- a/charts/jarvis/README.md
+++ b/charts/jarvis/README.md
@@ -80,6 +80,7 @@ Tests cover four suites (`deployment`, `configmap`, `secret`, `ingress`) and run
 | `serviceAccount.create` | bool | `true` | Create a ServiceAccount |
 | `serviceAccount.annotations` | object | `{}` | ServiceAccount annotations |
 | `serviceAccount.name` | string | `""` | ServiceAccount name (auto-generated when empty) |
+| `leaderElection.podLabel.enabled` | bool | `true` | Label the current leader pod `jarvis.kj187.de/role=leader` (informational only — every pod serves all traffic). Renders a `Role`+`RoleBinding` (`pods`: `get`, `patch`) and sets `automountServiceAccountToken: true` on the pod; meaningful only with PostgreSQL and `replicaCount`/HPA `> 1`, harmless to leave on otherwise |
 | `podAnnotations` | object | `{}` | Pod annotations |
 | `podSecurityContext` | object | `{runAsNonRoot: true, runAsUser: 65532, ...}` | Pod-level security context |
 | `securityContext` | object | `{allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, ...}` | Container-level security context |
@@ -272,7 +273,9 @@ config:
 
 ### Vault JWT auth with projected ServiceAccount token
 
-Use `serviceAccountTokenProjection` to obtain a short-lived, audience-scoped token without relying on the pod-level `automountServiceAccountToken`. Pair it with `extraEnv` to point the app at the token file and with `automountServiceAccountToken: false` to disable the default mount.
+Use `serviceAccountTokenProjection` to obtain a short-lived, audience-scoped token without relying on the pod-level `automountServiceAccountToken`. Pair it with `extraEnv` to point the app at the token file.
+
+Note: `automountServiceAccountToken` on the pod is otherwise driven by `leaderElection.podLabel.enabled` (default `true` — the leader pod label needs the default token to call the Kubernetes API, see the values table above). Set `leaderElection.podLabel.enabled: false` too if you want only the projected workload token mounted and nothing else.
 
 ```yaml
 serviceAccount:
@@ -282,12 +285,11 @@ serviceAccount:
   annotations:
     vault.hashicorp.com/role: jarvis
 
-# Disable the default automount — the projected volume below takes its place.
-podAnnotations:
-  # Kubernetes 1.24+: disable at pod level via spec field (set via values):
-  {}
-# If your cluster supports it, set automountServiceAccountToken: false on the
-# ServiceAccount instead and leave the pod annotation empty.
+# Skip mounting the default token entirely — only the projected workload
+# token below is needed.
+leaderElection:
+  podLabel:
+    enabled: false
 
 serviceAccountTokenProjection:
   enabled: true

--- a/charts/jarvis/templates/deployment.yaml
+++ b/charts/jarvis/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "jarvis.serviceAccountName" . }}
+      {{- /* Only needed for the leader pod label PATCH (D7 in tmp/fable/multi-replica.md) — the
+             ServiceAccount itself sets automountServiceAccountToken: false, so this must be
+             explicit at the pod level whenever the feature is on. */}}
+      automountServiceAccountToken: {{ .Values.leaderElection.podLabel.enabled }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -81,6 +85,17 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.existingSecret | default (include "jarvis.fullname" .) }}
                   key: {{ .Values.database.existingSecretKey }}
+            {{- /* Downward API — pod identity for the leader pod label PATCH (D7).
+                   Harmless when leaderElection.podLabel.enabled is false: PodLabeler
+                   disables itself via the missing ServiceAccount token mount first. */}}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- if ne .Values.auth.provider "none" }}
             - name: JARVIS_SECRET_KEY
               valueFrom:

--- a/charts/jarvis/templates/rbac.yaml
+++ b/charts/jarvis/templates/rbac.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.leaderElection.podLabel.enabled }}
+{{- /* Grants exactly the one-request PATCH the leader pod label needs (D7 in
+       tmp/fable/multi-replica.md) — no client-go, no broader Kubernetes API access. */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "jarvis.fullname" . }}-leader-pod-label
+  labels:
+    {{- include "jarvis.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "jarvis.fullname" . }}-leader-pod-label
+  labels:
+    {{- include "jarvis.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "jarvis.fullname" . }}-leader-pod-label
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "jarvis.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/jarvis/tests/deployment_test.yaml
+++ b/charts/jarvis/tests/deployment_test.yaml
@@ -53,6 +53,32 @@ tests:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
           value: database-url
 
+  - it: sets automountServiceAccountToken true and injects POD_NAME/POD_NAMESPACE by default (leaderElection.podLabel.enabled defaults true)
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.fieldRef.fieldPath
+          value: metadata.name
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: POD_NAMESPACE
+      - equal:
+          path: spec.template.spec.containers[0].env[2].valueFrom.fieldRef.fieldPath
+          value: metadata.namespace
+
+  - it: sets automountServiceAccountToken false when leaderElection.podLabel.enabled is false
+    set:
+      leaderElection.podLabel.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
   - it: mounts emptyDir at /data when persistence disabled
     asserts:
       - equal:

--- a/charts/jarvis/tests/rbac_test.yaml
+++ b/charts/jarvis/tests/rbac_test.yaml
@@ -1,0 +1,52 @@
+suite: rbac (leader pod label, D7 in tmp/fable/multi-replica.md)
+templates:
+  - templates/rbac.yaml
+
+tests:
+  - it: renders Role + RoleBinding by default (leaderElection.podLabel.enabled defaults true)
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding
+
+  - it: Role grants only pods get/patch — nothing broader
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: rules[0].apiGroups
+          value: [""]
+      - documentIndex: 0
+        equal:
+          path: rules[0].resources
+          value: ["pods"]
+      - documentIndex: 0
+        equal:
+          path: rules[0].verbs
+          value: ["get", "patch"]
+
+  - it: RoleBinding references the chart's ServiceAccount and the matching Role
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - documentIndex: 1
+        equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-jarvis
+      - documentIndex: 1
+        equal:
+          path: roleRef.name
+          value: RELEASE-NAME-jarvis-leader-pod-label
+
+  - it: renders nothing when leaderElection.podLabel.enabled is false
+    set:
+      leaderElection.podLabel.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/jarvis/values.yaml
+++ b/charts/jarvis/values.yaml
@@ -15,6 +15,17 @@ serviceAccount:
   annotations: {}
   name: ""
 
+leaderElection:
+  podLabel:
+    # Labels the current leader pod jarvis.kj187.de/role=leader (D7 in
+    # tmp/fable/multi-replica.md) — informational only, every pod serves all
+    # traffic regardless of leadership. Requires a Role+RoleBinding (pods:
+    # get, patch) and automountServiceAccountToken: true on the pod, both
+    # rendered only while this is true. Meaningful only with PostgreSQL
+    # (JARVIS_DB_DSN starting postgres://) and replicaCount/HPA > 1 — safe to
+    # leave on with SQLite or a single replica, it just labels the one pod.
+    enabled: true
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## Summary
- D7 in `tmp/fable/multi-replica.md` (slice 4): the current leader pod gets labeled `jarvis.kj187.de/role=leader`, so `kubectl get pods -L jarvis.kj187.de/role` shows who's leader at a glance. Purely informational — every pod already serves all traffic regardless of leadership.
- New `internal/leader.PodLabeler`, registered as a second, independent `Elector.Subscribe` callback alongside `history.Recorder`'s own. On promotion: a Kubernetes merge-patch PATCH to this pod's own `/api/v1/namespaces/<ns>/pods/<name>`; on step-down: the same shape, nulling the label back out. No client-go — a plain `net/http` client with the in-cluster ServiceAccount's CA+token and `KUBERNETES_SERVICE_HOST/_PORT`. Outside Kubernetes (no ServiceAccount mount) every call is a no-op; a failed PATCH is logged, never fatal.
- Chart: `templates/rbac.yaml` renders a `Role` (`pods`: `get`, `patch` only) + `RoleBinding`, gated by new `leaderElection.podLabel.enabled` (default `true`). `deployment.yaml` sets `automountServiceAccountToken: true` at the pod level exactly when the toggle is on (the ServiceAccount itself defaults it to `false`), and always injects `POD_NAME`/`POD_NAMESPACE` via the Downward API.

## Test plan
- [x] `go test -race ./...` — SQLite only
- [x] `go test -race ./...` with `JARVIS_TEST_POSTGRES_DSN` set — unaffected packages unchanged, full suite still green
- [x] `golangci-lint run ./...`
- [x] `helm lint charts/jarvis/` + `helm unittest charts/jarvis/` — 76 tests, including new `rbac_test.yaml` and new `deployment_test.yaml` cases covering both toggle states
- [x] pre-commit hook (tests, lint, helm, gitleaks) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)