### PR TITLE
feat(config): Helm chart HA deployment surface (PDB, topology spread)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -51,7 +51,7 @@ make e2e-screenshot NAME=card-view # regenerate ONE screenshot
 
 # ── Helm (no cluster needed — helm-unittest plugin required) ─
 helm lint charts/jarvis/           # Static chart validation
-helm unittest charts/jarvis/       # Unit tests (deployment, configmap, secret, ingress, servicemonitor, rbac)
+helm unittest charts/jarvis/       # Unit tests (deployment, configmap, secret, ingress, servicemonitor, rbac, pdb)
 
 # ── Everything via Makefile ──────────────────────────────────
 make test-all                      # backend + frontend + helm lint + helm unittest

--- a/charts/jarvis/README.md
+++ b/charts/jarvis/README.md
@@ -124,10 +124,13 @@ Tests cover four suites (`deployment`, `configmap`, `secret`, `ingress`) and run
 | `persistence.accessMode` | string | `ReadWriteOnce` | PVC access mode |
 | `persistence.size` | string | `1Gi` | PVC size |
 | `resources` | object | `{}` | Resource requests/limits |
-| `autoscaling.enabled` | bool | `false` | Enable HPA |
+| `autoscaling.enabled` | bool | `false` | Enable HPA (requires PostgreSQL — same reasoning as `replicaCount` above) |
+| `podDisruptionBudget.enabled` | bool | `false` | Create a `PodDisruptionBudget` — prevents voluntary disruptions (node drains, upgrades) from taking down every replica at once. Meaningful only with `replicaCount`/HPA `> 1` (PostgreSQL) |
+| `podDisruptionBudget.minAvailable` | int | `1` | Minimum pods that must stay available during a voluntary disruption |
 | `nodeSelector` | object | `{}` | Node selector |
 | `tolerations` | list | `[]` | Pod tolerations |
 | `affinity` | object | `{}` | Pod affinity rules |
+| `topologySpreadConstraints` | list | `[]` | Passed through verbatim to `spec.template.spec.topologySpreadConstraints` — spread replicas across nodes/zones for real HA. Meaningful only with `replicaCount`/HPA `> 1` (PostgreSQL) |
 | `extraEnv` | list | `[]` | Additional environment variables for the container |
 | `extraVolumes` | list | `[]` | Additional volumes for the Pod |
 | `extraVolumeMounts` | list | `[]` | Additional volume mounts for the container |

--- a/charts/jarvis/templates/deployment.yaml
+++ b/charts/jarvis/templates/deployment.yaml
@@ -160,3 +160,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/jarvis/templates/pdb.yaml
+++ b/charts/jarvis/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "jarvis.fullname" . }}
+  labels:
+    {{- include "jarvis.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "jarvis.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/jarvis/tests/deployment_test.yaml
+++ b/charts/jarvis/tests/deployment_test.yaml
@@ -119,6 +119,32 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: allows replicaCount > 1 with PostgreSQL even when persistence enabled
+    set:
+      persistence.enabled: true
+      replicaCount: 3
+      database.dsn: postgres://user:pass@host:5432/db
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: renders topologySpreadConstraints when set
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: omits topologySpreadConstraints by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.topologySpreadConstraints
+
   - it: defaults to RollingUpdate strategy when persistence disabled
     asserts:
       - equal:

--- a/charts/jarvis/tests/pdb_test.yaml
+++ b/charts/jarvis/tests/pdb_test.yaml
@@ -1,0 +1,33 @@
+suite: pdb
+templates:
+  - templates/pdb.yaml
+
+tests:
+  - it: renders nothing by default (podDisruptionBudget.enabled defaults false)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a PodDisruptionBudget when enabled
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: honors a custom minAvailable
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/charts/jarvis/values.yaml
+++ b/charts/jarvis/values.yaml
@@ -1,3 +1,11 @@
+# SQLite (the default database.dsn below) is the zero-config path for
+# testing, evaluation, and homelab-scale single-replica deployments — it
+# requires replicaCount: 1 (validateReplicas below fails fast on a
+# misconfiguration). For production, high availability, horizontal scaling,
+# and long-term stability, switch to PostgreSQL (database.dsn:
+# postgres://...) — replicaCount can then be any value, coordinated via
+# leader election (exactly one pod polls Alertmanager/writes history at a
+# time; every pod serves reads/API/WS equally). See docs/persistence.md.
 replicaCount: 1
 
 image:
@@ -182,15 +190,30 @@ persistence:
 updateStrategy:
   type: ""
 
+# Requires PostgreSQL (database.dsn: postgres://...) — same reasoning as
+# replicaCount > 1 above; validateReplicas fails fast if combined with
+# SQLite + persistence.enabled.
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 
+# Prevents voluntary disruptions (node drains, cluster upgrades) from taking
+# down every replica at once. Off by default — meaningful only with
+# replicaCount/HPA > 1 (PostgreSQL); harmless but pointless at replicaCount: 1.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Passed through verbatim to spec.template.spec.topologySpreadConstraints —
+# spread replicas across nodes/zones for real HA. Empty by default (no
+# opinion imposed); meaningful only with replicaCount/HPA > 1 (PostgreSQL).
+topologySpreadConstraints: []
 
 # Additional environment variables injected into the container.
 # Useful for passing token paths, feature flags, or provider-specific config.


### PR DESCRIPTION
## Summary
- Slice 5 of `tmp/fable/multi-replica.md`: chart-side polish for running Jarvis with `replicaCount > 1`/HPA against PostgreSQL. `validateReplicas` already correctly guards the SQLite path and its error text already pointed at PostgreSQL for multi-replica — nothing to change there, that guidance is simply true now that slices 0-4 landed.
- New `PodDisruptionBudget` template (`podDisruptionBudget.enabled`, default `false`; `minAvailable`, default `1`) and a `topologySpreadConstraints` passthrough value.
- `values.yaml` comments for `replicaCount`/`autoscaling` now state the SQLite-vs-PostgreSQL positioning explicitly (D6/D8). Chart README's values table and Vault-projected-token example updated to match.

## Test plan
- [x] `helm lint charts/jarvis/`
- [x] `helm unittest charts/jarvis/` — 82 tests, including new `pdb_test.yaml` and new `deployment_test.yaml` cases (`replicaCount > 1` with PostgreSQL succeeds even with persistence enabled; `topologySpreadConstraints` renders when set, omitted by default)
- [x] Backend unaffected by this slice — `go test ./...` still green
- [x] pre-commit hook (helm lint/unittest, gitleaks) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)