### PR TITLE
feat(config): ServiceMonitor relabelings, annotations, honorLabels

### DIFF
--- a/charts/jarvis/README.md
+++ b/charts/jarvis/README.md
@@ -92,6 +92,10 @@ Tests cover four suites (`deployment`, `configmap`, `secret`, `ingress`) and run
 | `metrics.serviceMonitor.interval` | string | `30s` | Scrape interval |
 | `metrics.serviceMonitor.scrapeTimeout` | string | `10s` | Scrape timeout |
 | `metrics.serviceMonitor.labels` | object | `{}` | Extra labels on the `ServiceMonitor` (e.g. to match a `kube-prometheus-stack` release selector) |
+| `metrics.serviceMonitor.annotations` | object | `{}` | Extra annotations on the `ServiceMonitor` |
+| `metrics.serviceMonitor.relabelings` | list | `[]` | Prometheus Operator `Endpoint.relabelings` (target relabeling before scrape) |
+| `metrics.serviceMonitor.metricRelabelings` | list | `[]` | Prometheus Operator `Endpoint.metricRelabelings` (metric relabeling after scrape) |
+| `metrics.serviceMonitor.honorLabels` | bool | `false` | `Endpoint.honorLabels` — keep `false` unless you specifically want Jarvis's own metric labels (e.g. `cluster`) to win over scrape-time labels on a collision |
 | `metrics.podAnnotations` | bool | `false` | Add `prometheus.io/scrape`, `prometheus.io/port`, `prometheus.io/path` pod annotations instead (annotation-based scraping) |
 | `ingress.enabled` | bool | `false` | Enable Ingress |
 | `ingress.className` | string | `""` | Ingress class name |

--- a/charts/jarvis/templates/servicemonitor.yaml
+++ b/charts/jarvis/templates/servicemonitor.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,4 +21,15 @@ spec:
       path: /metrics
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/jarvis/tests/servicemonitor_test.yaml
+++ b/charts/jarvis/tests/servicemonitor_test.yaml
@@ -58,3 +58,69 @@ tests:
       - equal:
           path: metadata.labels.release
           value: kube-prometheus-stack
+
+  - it: omits relabelings and metricRelabelings by default
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - isNull:
+          path: spec.endpoints[0].relabelings
+      - isNull:
+          path: spec.endpoints[0].metricRelabelings
+
+  - it: applies custom relabelings
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.relabelings:
+        - sourceLabels: ["__meta_kubernetes_pod_node_name"]
+          targetLabel: node
+    asserts:
+      - equal:
+          path: spec.endpoints[0].relabelings[0].sourceLabels[0]
+          value: __meta_kubernetes_pod_node_name
+      - equal:
+          path: spec.endpoints[0].relabelings[0].targetLabel
+          value: node
+
+  - it: applies custom metricRelabelings
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.metricRelabelings:
+        - sourceLabels: ["__name__"]
+          regex: "go_.*"
+          action: drop
+    asserts:
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].regex
+          value: "go_.*"
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].action
+          value: drop
+
+  - it: omits annotations and honorLabels by default
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - isNull:
+          path: metadata.annotations
+      - isNull:
+          path: spec.endpoints[0].honorLabels
+
+  - it: applies custom annotations
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.annotations:
+        argocd.argoproj.io/sync-options: Prune=false
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: Prune=false
+
+  - it: sets honorLabels when enabled
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.honorLabels: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].honorLabels
+          value: true

--- a/charts/jarvis/values.yaml
+++ b/charts/jarvis/values.yaml
@@ -64,6 +64,18 @@ metrics:
     interval: 30s
     scrapeTimeout: 10s
     labels: {}
+    annotations: {}
+    # Prometheus Operator Endpoint.relabelings / metricRelabelings — passed
+    # through verbatim (same shape as the upstream CRD), e.g. to drop noisy
+    # metrics or rewrite target labels before/after scraping.
+    relabelings: []
+    metricRelabelings: []
+    # Endpoint.honorLabels. Keep false (default): on a label collision, the
+    # scrape-time label wins and Jarvis's own label (e.g. "cluster", the
+    # Alertmanager cluster name — see backend/internal/metrics/metrics.go) is
+    # renamed to exported_<name> instead of being silently dropped. Only set
+    # true if you specifically want Jarvis's own labels to take precedence.
+    honorLabels: false
   # Alternative to serviceMonitor for annotation-based scraping setups.
   podAnnotations: false
 


### PR DESCRIPTION
## Summary
- Add optional `metrics.serviceMonitor.relabelings` / `metricRelabelings` values, passed through verbatim to the ServiceMonitor endpoint's Prometheus Operator fields.
- Add optional `metrics.serviceMonitor.annotations` (analogous to the existing `labels`) and `metrics.serviceMonitor.honorLabels`.
- `honorLabels` defaults to `false`: Jarvis exports its own `cluster` label (Alertmanager cluster name), which would silently lose to an externally relabeled `cluster` label if `honorLabels` were `true`.
- All new fields default to a no-op — existing deployments render an identical ServiceMonitor.

## Test plan
- [x] `helm unittest charts/jarvis` — 88/88 passing (new servicemonitor cases for relabelings, metricRelabelings, annotations, honorLabels)
- [x] `helm lint charts/jarvis` — clean