### PR TITLE
feat(frontend): explain refresh in tooltip incl. backend poll interval

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -345,7 +345,7 @@ WS     /ws                                       full_protect?  (origin checked 
 #        session cookie via RequireAuth — /ws streams the full alert snapshot)
 
 # ── Status / Version ─────────────────────────────────────────────────────────
-GET    /api/v1/status                            full_protect?  → { status, clusters, alerts, ws_clients, leader }
+GET    /api/v1/status                            full_protect?  → { status, clusters, alerts, ws_clients, leader, poll_interval_seconds }
 #        leader: this pod's current leader-election state (internal/leader) — always true on SQLite
 GET    /api/v1/info                              full_protect?  → { version }
 

--- a/backend/internal/api/clusters.go
+++ b/backend/internal/api/clusters.go
@@ -69,10 +69,11 @@ func (s *Server) getClusters(c echo.Context) error {
 func (s *Server) getStatus(c echo.Context) error {
 	totalAlerts := len(s.alertStore.Get())
 	return c.JSON(http.StatusOK, map[string]interface{}{
-		"status":     "ok",
-		"clusters":   len(s.registry.All()),
-		"alerts":     totalAlerts,
-		"ws_clients": s.hub.ClientCount(),
-		"leader":     s.pollTrigger.IsLeader(),
+		"status":                "ok",
+		"clusters":              len(s.registry.All()),
+		"alerts":                totalAlerts,
+		"ws_clients":            s.hub.ClientCount(),
+		"leader":                s.pollTrigger.IsLeader(),
+		"poll_interval_seconds": s.cfg.PollInterval.Seconds(),
 	})
 }

--- a/backend/internal/api/clusters_test.go
+++ b/backend/internal/api/clusters_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -180,6 +181,53 @@ func TestGetClusters_AllMembersDown_Unhealthy(t *testing.T) {
 	got := getClustersResponse(t, srv)
 	if got[0].Healthy {
 		t.Error("Healthy = true, want false (all members down)")
+	}
+}
+
+func TestGetStatus_IncludesPollIntervalSeconds(t *testing.T) {
+	database, dialect, err := idb.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := idb.Migrate(database, dialect); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	hub := ws.NewHub(nil, nil, metrics.New("test"))
+	go hub.Run()
+
+	srv := NewServer(
+		&history.AlertStore{},
+		history.NewSilenceStore(),
+		history.NewStore(database, dialect),
+		hub,
+		cluster.NewRegistry(nil),
+		&config.Config{PollInterval: 45 * time.Second},
+		&fakeTriggerer{},
+		auth.NoneProvider{},
+		users.NewStore(database, dialect),
+		fanout.NoopFanout{},
+	)
+
+	e := echo.New()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := srv.getStatus(c); err != nil {
+		t.Fatalf("getStatus: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["poll_interval_seconds"] != float64(45) {
+		t.Errorf("poll_interval_seconds = %v, want 45", got["poll_interval_seconds"])
 	}
 }
 

--- a/frontend/e2e/functional/none/app-shell.spec.ts
+++ b/frontend/e2e/functional/none/app-shell.spec.ts
@@ -114,7 +114,7 @@ test('A3 mobile hamburger (<768px) reveals header controls', async ({ page }) =>
   // Controls now visible after opening hamburger.
   // DOM has two "Refresh now" buttons: desktop (CSS-hidden at <768px) + mobile panel.
   // Use .last() to target the mobile panel button that's actually visible.
-  await expect(page.getByTitle('Refresh now').last()).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Refresh now' }).last()).toBeVisible()
 })
 
 test('A4 WebSocket indicator is visible and green when connected', async ({ page }) => {
@@ -134,7 +134,7 @@ test('A5 manual refresh works', async ({ page, am, jarvis }) => {
   await waitForActiveAlerts(jarvis, JARVIS_BASE_URL, kubernetesAlerts.length)
   await page.goto('/?state=active')
 
-  const refreshBtn = page.getByTitle('Refresh now')
+  const refreshBtn = page.getByRole('button', { name: 'Refresh now' })
   await expect(refreshBtn).toBeVisible()
   await refreshBtn.click()
   await expect(refreshBtn).toBeVisible()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -295,6 +295,7 @@ export function fetchStatus(): Promise<{
   clusters: number
   alerts: number
   ws_clients: number
+  poll_interval_seconds: number
 }> {
   return request('/status')
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -12,8 +12,24 @@ import { useUIStore } from '@/store/uiStore'
 import { useAuthStore } from '@/store/authStore'
 import { useSettingsStore } from '@/store/useSettingsStore'
 import { useQuery } from '@tanstack/react-query'
-import { fetchClusters } from '@/api/client'
+import { fetchClusters, fetchStatus } from '@/api/client'
 import { FALLBACK_REFETCH_INTERVAL_MS } from '@/lib/refetch'
+import { Tooltip } from '@/components/ui/tooltip'
+
+function formatPollInterval(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const rest = seconds % 60
+  return rest > 0 ? `${minutes}m ${rest}s` : `${minutes}m`
+}
+
+function refreshTooltip(pollIntervalSeconds: number | undefined): string {
+  const interval = pollIntervalSeconds !== undefined ? formatPollInterval(pollIntervalSeconds) : null
+  return (
+    'Reloads the current snapshot from the Jarvis backend. Does not trigger a new Alertmanager poll — new data only ' +
+    `appears once the backend's own poll${interval ? ` (every ${interval})` : ''} runs (already pushed to you live via WebSocket).`
+  )
+}
 
 // ── Header ────────────────────────────────────────────────────────────────────
 
@@ -63,6 +79,13 @@ export function Header() {
     queryFn: fetchClusters,
     refetchInterval: FALLBACK_REFETCH_INTERVAL_MS,
   })
+
+  const { data: status } = useQuery({
+    queryKey: ['status'],
+    queryFn: fetchStatus,
+    refetchInterval: FALLBACK_REFETCH_INTERVAL_MS,
+  })
+  const refreshTooltipText = refreshTooltip(status?.poll_interval_seconds)
 
   const [silenceFormOpen, setSilenceFormOpen] = useState(false)
   const [silenceActiveTab, setSilenceActiveTab] = useState<'silence' | 'templates'>('silence')
@@ -224,9 +247,11 @@ export function Header() {
             {wsConnected ? <Wifi className="h-4 w-4 text-green-500" /> : <WifiOff className="h-4 w-4 text-red-500" />}
           </div>
 
-          <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={handleRefresh} title="Refresh now" disabled={refreshing}>
-            <RefreshCw className={`h-4 w-4 ${isSpinning ? 'animate-spin' : ''}`} />
-          </Button>
+          <Tooltip content={refreshTooltipText} side="bottom">
+            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={handleRefresh} aria-label="Refresh now" disabled={refreshing}>
+              <RefreshCw className={`h-4 w-4 ${isSpinning ? 'animate-spin' : ''}`} />
+            </Button>
+          </Tooltip>
           <div className="w-px h-5 bg-border shrink-0 mx-0.5" />
           <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => updateSettings({ theme: theme === 'dark' ? 'light' : 'dark' })} title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'} aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
             {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
@@ -293,9 +318,11 @@ export function Header() {
               <div className={`h-2 w-2 rounded-full ${healthyCount === clusters.length ? 'bg-green-500' : 'bg-red-500'}`} />
               <span className="text-muted-foreground tabular-nums">{healthyCount}/{clusters.length}</span>
             </div>
-            <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleRefresh} title="Refresh now" disabled={refreshing}>
-              <RefreshCw className={`h-4 w-4 ${isSpinning ? 'animate-spin' : ''}`} />
-            </Button>
+            <Tooltip content={refreshTooltipText} side="bottom">
+              <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleRefresh} aria-label="Refresh now" disabled={refreshing}>
+                <RefreshCw className={`h-4 w-4 ${isSpinning ? 'animate-spin' : ''}`} />
+              </Button>
+            </Tooltip>
             <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => updateSettings({ theme: theme === 'dark' ? 'light' : 'dark' })} title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
               {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </Button>


### PR DESCRIPTION
## Summary

The header refresh button silently reloaded the current snapshot while users expected it to trigger a fresh Alertmanager poll. This PR makes the behavior transparent:

- Replaces the bare `title` attribute on both refresh buttons (desktop + mobile) with a proper `Tooltip` explaining that refresh reloads the Jarvis snapshot and does **not** trigger a new Alertmanager poll
- The tooltip shows the backend's actual poll interval (e.g. "every 30s"), fetched from the new `poll_interval_seconds` field on `GET /api/v1/status`
- E2E specs updated to select the button by accessible name instead of `title`

## Test plan

- [x] `go test ./internal/api/...` — new `TestGetStatus_IncludesPollIntervalSeconds`
- [x] `pnpm build` green