### PR TITLE
fix(db): cap PostgreSQL connection pool to stop RDS slot exhaustion

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -308,7 +308,7 @@ CREATE TABLE IF NOT EXISTS poll_snapshots (
 );
 ```
 
-**SQLite settings** (on open): `SetMaxOpenConns(1)`, `PRAGMA journal_mode=WAL`, `PRAGMA foreign_keys=ON`, `PRAGMA busy_timeout=5000`. PostgreSQL uses the default pool (no `SetMaxOpenConns(1)`).
+**SQLite settings** (on open): `SetMaxOpenConns(1)`, `PRAGMA journal_mode=WAL`, `PRAGMA foreign_keys=ON`, `PRAGMA busy_timeout=5000`. PostgreSQL uses a capped pool: `JARVIS_DB_MAX_OPEN_CONNS` (default 10) sets MaxOpen **and** MaxIdle (so bursts reuse connections instead of churning them), plus `ConnMaxLifetime=30m` / `ConnMaxIdleTime=5m` — never unbounded, never `SetMaxOpenConns(1)` (Critical Invariant #8).
 
 ---
 
@@ -1208,6 +1208,7 @@ consumed snapshot (D3).
 |---|---|
 | `JARVIS_PORT` `JARVIS_LOG_LEVEL` `JARVIS_LOG_REQUESTS` `JARVIS_POLL_INTERVAL` | server basics — defaults: `8080`, `info`, `false`, `15s`. `JARVIS_POLL_INTERVAL` also drives the grace period: `main.go` sets `Store`'s grace period to `max(60s, 2×JARVIS_POLL_INTERVAL)` and `Recorder.claimReleaseDelay` to stay comfortably above it (Critical Invariant #1, `AGENTS.md`) |
 | `JARVIS_DB_DSN` | `postgres://` or `postgresql://` → PostgreSQL, anything else → SQLite file path. Default `/data/jarvis.db`. Never logged raw (`db.RedactDSN()`) |
+| `JARVIS_DB_MAX_OPEN_CONNS` | PostgreSQL pool cap per pod (default `10`, must be ≥ 1; MaxIdle = MaxOpen). Ignored for SQLite (always 1). Size pods × cap below the server's `max_connections` |
 | `JARVIS_RUNBOOK_BASE_URL` | prefix for non-URL `runbook` values |
 | `JARVIS_ALLOWED_ORIGINS` | CORS + WS origin allow-list (no `*`), comma-separated |
 | `JARVIS_AUTH_PROVIDER` `JARVIS_AUTH_MODE` | auth; provider default `none`; mode defaults to `write_protect` when provider ≠ none |

--- a/.agents/lessons.md
+++ b/.agents/lessons.md
@@ -9,6 +9,26 @@ instead of duplicating.
 
 ---
 
+## Go's default database/sql pool is unbounded — it exhausted RDS connection slots in production
+
+**Symptom**: `stats`/`heatmap` requests returned 500 with
+`FATAL: remaining connection slots are reserved for roles with privileges
+of the "pg_use_reserved_connections" role (SQLSTATE 53300)` — the RDS
+instance had no free connection slots left, across multiple pods at once.
+**Cause**: `openPostgres` never configured the pool. `database/sql`
+defaults are `MaxOpenConns=0` (unlimited) and `MaxIdleConns=2`: every
+request burst opened as many connections as there were parallel queries,
+then closed almost all of them again (churn), multiplied by the number of
+pods — until the server's `max_connections` was gone. SQLite never hits
+this because invariant #8 forces `SetMaxOpenConns(1)`.
+**Rule**: Never ship a `database/sql` pool with default settings against a
+shared PostgreSQL. Cap it (`JARVIS_DB_MAX_OPEN_CONNS`, default 10) and set
+`MaxIdleConns = MaxOpenConns` so bursts reuse connections instead of
+churning them. Full sizing guidance (leader-election + fanout connections,
+reserved slots): `docs/persistence.md → Connection-pool cap`.
+
+---
+
 ## A fixed 60s grace period can't absorb a missed poll once the poll interval itself is ≥ 60s
 
 **Symptom**: Not yet observed in production — found by inspection while

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ JARVIS_POLL_INTERVAL=15s
 #   PostgreSQL: a postgres:// URL
 JARVIS_DB_DSN=/data/jarvis.db
 # JARVIS_DB_DSN=postgres://jarvis:secret@postgres:5432/jarvis?sslmode=require
+# PostgreSQL connection-pool cap per pod (ignored for SQLite). Keep
+# replicas × cap well below the server's max_connections.
+# JARVIS_DB_MAX_OPEN_CONNS=10
 # Use sslmode=require (or verify-full) in production.
 # sslmode=disable is only acceptable for local ephemeral test containers.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,10 @@ Tool-specific entry points map to the same files (no duplicated content):
 7. **`cursor: pointer` on all clickable elements** — globally in CSS:
    `a, button, [role="button"] { cursor: pointer }`.
 8. **SQLite single writer**: `SetMaxOpenConns(1)` + WAL mode — only for the
-   SQLite dialect. PostgreSQL uses the default pool. Never add
-   `SetMaxOpenConns(1)` for PostgreSQL.
+   SQLite dialect. PostgreSQL uses a **capped** pool
+   (`JARVIS_DB_MAX_OPEN_CONNS`, default 10, MaxIdle = MaxOpen) — never
+   unbounded (an unbounded pool exhausted RDS connection slots in
+   production, SQLSTATE 53300) and never `SetMaxOpenConns(1)`.
 9. **`JARVIS_DB_DSN` never logged raw**: `db.RedactDSN()` must wrap the DSN
    before any log call. Password stays out of logs.
 10. **`rebind()` in `history/store.go`**: All SQL queries use `?`

--- a/backend/cmd/jarvis/main.go
+++ b/backend/cmd/jarvis/main.go
@@ -42,13 +42,13 @@ func main() {
 	slog.SetDefault(logger)
 
 	// ── Database ──────────────────────────────────────────────────────────────
-	database, dialect, err := db.Open(cfg.DBDSN)
+	database, dialect, err := db.Open(cfg.DBDSN, db.WithMaxOpenConns(cfg.DBMaxOpenConns))
 	if err != nil {
 		logger.Error("open database", "dialect", db.DetectDialect(cfg.DBDSN), "err", err)
 		os.Exit(1)
 	}
 	defer func() { _ = database.Close() }()
-	logger.Info("database connected", "dialect", dialect, "dsn", db.RedactDSN(cfg.DBDSN))
+	logger.Info("database connected", "dialect", dialect, "dsn", db.RedactDSN(cfg.DBDSN), "max_open_conns", cfg.DBMaxOpenConns)
 
 	if err := db.Migrate(database, dialect); err != nil {
 		logger.Error("migrate database", "err", err)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -20,6 +20,11 @@ type Config struct {
 	// DBDSN is the database connection string. Starts with "postgres://" or
 	// "postgresql://" for PostgreSQL; anything else is treated as a SQLite file path.
 	DBDSN          string
+	// DBMaxOpenConns caps the PostgreSQL connection pool per pod (idle
+	// connections are kept up to the same cap). Ignored for SQLite, which is
+	// always single-connection. Size it so pods × DBMaxOpenConns stays well
+	// below the server's max_connections.
+	DBMaxOpenConns int
 	RunbookBaseURL string
 	AllowedOrigins []string
 	Clusters       []ClusterConfig
@@ -210,12 +215,22 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 
+	dbMaxOpenConnsRaw := getEnv("JARVIS_DB_MAX_OPEN_CONNS", "10")
+	dbMaxOpenConns, err := strconv.Atoi(dbMaxOpenConnsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JARVIS_DB_MAX_OPEN_CONNS: must be an integer, got %q", dbMaxOpenConnsRaw)
+	}
+	if dbMaxOpenConns < 1 {
+		return nil, fmt.Errorf("invalid JARVIS_DB_MAX_OPEN_CONNS: must be >= 1, got %d", dbMaxOpenConns)
+	}
+
 	return &Config{
 		Port:             getEnv("JARVIS_PORT", "8080"),
 		LogLevel:         getEnv("JARVIS_LOG_LEVEL", "info"),
 		LogRequests:      getEnvBool("JARVIS_LOG_REQUESTS", false),
 		PollInterval:     pollInterval,
 		DBDSN:            getEnv("JARVIS_DB_DSN", "/data/jarvis.db"),
+		DBMaxOpenConns:   dbMaxOpenConns,
 		RunbookBaseURL:   getEnv("JARVIS_RUNBOOK_BASE_URL", ""),
 		AllowedOrigins:   allowedOrigins,
 		Clusters:         clusters,

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -512,5 +512,38 @@ func TestLoad_ClusterOAuth2_AbsentWhenClientIDEmpty(t *testing.T) {
 	}
 }
 
+func TestLoad_DBMaxOpenConns_Default(t *testing.T) {
+	t.Setenv("JARVIS_DB_MAX_OPEN_CONNS", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DBMaxOpenConns != 10 {
+		t.Errorf("DBMaxOpenConns = %d, want 10", cfg.DBMaxOpenConns)
+	}
+}
+
+func TestLoad_DBMaxOpenConns_Custom(t *testing.T) {
+	t.Setenv("JARVIS_DB_MAX_OPEN_CONNS", "25")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DBMaxOpenConns != 25 {
+		t.Errorf("DBMaxOpenConns = %d, want 25", cfg.DBMaxOpenConns)
+	}
+}
+
+func TestLoad_DBMaxOpenConns_Invalid(t *testing.T) {
+	for _, raw := range []string{"0", "-3", "ten"} {
+		t.Setenv("JARVIS_DB_MAX_OPEN_CONNS", raw)
+		if _, err := Load(); err == nil {
+			t.Errorf("Load() with JARVIS_DB_MAX_OPEN_CONNS=%q: expected error, got nil", raw)
+		}
+	}
+}
+
 // Ensure test cleanup resets env properly via t.Setenv.
 var _ = os.Setenv

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "modernc.org/sqlite"
@@ -45,12 +46,49 @@ func RedactDSN(dsn string) string {
 	return redacted
 }
 
+// Pool defaults for PostgreSQL. An unbounded pool exhausted the connection
+// slots of a shared RDS instance in production (SQLSTATE 53300): every
+// request burst opened fresh connections (database/sql default MaxIdleConns
+// of 2 closed them right after), multiplied by the number of pods. MaxIdle
+// equals MaxOpen so burst connections are reused instead of churned.
+const (
+	defaultMaxOpenConns    = 10
+	defaultConnMaxLifetime = 30 * time.Minute
+	defaultConnMaxIdleTime = 5 * time.Minute
+)
+
+type poolConfig struct {
+	maxOpenConns int
+}
+
+func defaultPoolConfig() poolConfig {
+	return poolConfig{maxOpenConns: defaultMaxOpenConns}
+}
+
+// Option customizes how Open configures the connection pool.
+type Option func(*poolConfig)
+
+// WithMaxOpenConns caps the PostgreSQL connection pool (per process; idle
+// connections are kept up to the same cap). Values < 1 are ignored. SQLite
+// is unaffected — it is always single-connection.
+func WithMaxOpenConns(n int) Option {
+	return func(c *poolConfig) {
+		if n >= 1 {
+			c.maxOpenConns = n
+		}
+	}
+}
+
 // Open opens a database connection for the given DSN and returns the
 // connection and its dialect. Use RedactDSN before logging the DSN.
-func Open(dsn string) (*sql.DB, Dialect, error) {
+func Open(dsn string, opts ...Option) (*sql.DB, Dialect, error) {
+	cfg := defaultPoolConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	switch DetectDialect(dsn) {
 	case DialectPostgres:
-		return openPostgres(dsn)
+		return openPostgres(dsn, cfg)
 	default:
 		return openSQLite(dsn)
 	}
@@ -95,11 +133,16 @@ func openSQLite(path string) (*sql.DB, Dialect, error) {
 	return database, DialectSQLite, nil
 }
 
-func openPostgres(dsn string) (*sql.DB, Dialect, error) {
+func openPostgres(dsn string, cfg poolConfig) (*sql.DB, Dialect, error) {
 	database, err := sql.Open("pgx", dsn)
 	if err != nil {
 		return nil, DialectPostgres, fmt.Errorf("open postgres: %w", err)
 	}
+
+	database.SetMaxOpenConns(cfg.maxOpenConns)
+	database.SetMaxIdleConns(cfg.maxOpenConns)
+	database.SetConnMaxLifetime(defaultConnMaxLifetime)
+	database.SetConnMaxIdleTime(defaultConnMaxIdleTime)
 
 	if err := database.PingContext(context.Background()); err != nil {
 		_ = database.Close()

--- a/backend/internal/db/db_test.go
+++ b/backend/internal/db/db_test.go
@@ -21,6 +21,56 @@ func TestOpen_InMemory(t *testing.T) {
 	}
 }
 
+func TestOpen_SQLite_IgnoresMaxOpenConns(t *testing.T) {
+	// SQLite must stay single-writer (AGENTS.md invariant 8) no matter what
+	// pool size the caller asks for.
+	database, _, err := Open(":memory:", WithMaxOpenConns(50))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	if got := database.Stats().MaxOpenConnections; got != 1 {
+		t.Errorf("MaxOpenConnections = %d, want 1", got)
+	}
+}
+
+// TestOpen_Postgres_PoolLimits is env-gated (JARVIS_TEST_POSTGRES_DSN):
+// an unbounded pool exhausted RDS connection slots in production
+// (SQLSTATE 53300), so openPostgres must always cap the pool.
+func TestOpen_Postgres_PoolLimits(t *testing.T) {
+	dsn := os.Getenv("JARVIS_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("JARVIS_TEST_POSTGRES_DSN not set — skipping PostgreSQL-backed test")
+	}
+
+	t.Run("default", func(t *testing.T) {
+		database, _, err := openPostgres(dsn, defaultPoolConfig())
+		if err != nil {
+			t.Fatalf("openPostgres() error: %v", err)
+		}
+		defer func() { _ = database.Close() }()
+
+		if got := database.Stats().MaxOpenConnections; got != defaultMaxOpenConns {
+			t.Errorf("MaxOpenConnections = %d, want %d", got, defaultMaxOpenConns)
+		}
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		cfg := defaultPoolConfig()
+		WithMaxOpenConns(3)(&cfg)
+		database, _, err := openPostgres(dsn, cfg)
+		if err != nil {
+			t.Fatalf("openPostgres() error: %v", err)
+		}
+		defer func() { _ = database.Close() }()
+
+		if got := database.Stats().MaxOpenConnections; got != 3 {
+			t.Errorf("MaxOpenConnections = %d, want 3", got)
+		}
+	})
+}
+
 func TestDetectDialect(t *testing.T) {
 	cases := []struct {
 		dsn  string
@@ -114,7 +164,7 @@ func TestMigrate_Postgres_PollSnapshotsTableExists(t *testing.T) {
 	// always PostgreSQL, and Open's SQLite branch reaching os.MkdirAll(path)
 	// on a value derived from JARVIS_TEST_POSTGRES_DSN otherwise trips gosec's
 	// taint analysis (G703) even though that branch can never execute here.
-	database, dialect, err := openPostgres(dsn)
+	database, dialect, err := openPostgres(dsn, defaultPoolConfig())
 	if err != nil {
 		t.Fatalf("openPostgres() error: %v", err)
 	}

--- a/charts/jarvis/README.md
+++ b/charts/jarvis/README.md
@@ -114,6 +114,7 @@ Tests cover four suites (`deployment`, `configmap`, `secret`, `ingress`) and run
 | `database.dsn` | string | `/data/jarvis.db` | Database DSN (SQLite path or `postgres://` URL; PostgreSQL recommended for production) |
 | `database.existingSecret` | string | `""` | Use an existing Secret for the DSN instead |
 | `database.existingSecretKey` | string | `dsn` | Key in the existing Secret |
+| `database.maxOpenConns` | int | `10` | PostgreSQL connection-pool cap per pod (`JARVIS_DB_MAX_OPEN_CONNS`); ignored for SQLite. Keep `replicaCount × maxOpenConns` well below the server's `max_connections` |
 | `auth.provider` | string | `none` | Authentication mode: `none`, `internal`, or `oidc` |
 | `auth.mode` | string | `""` | Protection level when provider ≠ `none`: `write_protect` (default) or `full_protect` |
 | `auth.secretKey` | string | `""` | JWT signing key (min 32 random bytes). Use `auth.existingSecret` in production. |

--- a/charts/jarvis/templates/configmap.yaml
+++ b/charts/jarvis/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
   JARVIS_PORT: "8080"
   JARVIS_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   JARVIS_POLL_INTERVAL: {{ .Values.config.pollInterval | quote }}
+  JARVIS_DB_MAX_OPEN_CONNS: {{ .Values.database.maxOpenConns | quote }}
   {{- if .Values.config.runbookBaseURL }}
   JARVIS_RUNBOOK_BASE_URL: {{ .Values.config.runbookBaseURL | quote }}
   {{- end }}

--- a/charts/jarvis/tests/configmap_test.yaml
+++ b/charts/jarvis/tests/configmap_test.yaml
@@ -32,6 +32,20 @@ tests:
           path: data.JARVIS_POLL_INTERVAL
           value: 30s
 
+  - it: sets JARVIS_DB_MAX_OPEN_CONNS to 10 by default
+    asserts:
+      - equal:
+          path: data.JARVIS_DB_MAX_OPEN_CONNS
+          value: "10"
+
+  - it: sets JARVIS_DB_MAX_OPEN_CONNS from database.maxOpenConns
+    set:
+      database.maxOpenConns: 25
+    asserts:
+      - equal:
+          path: data.JARVIS_DB_MAX_OPEN_CONNS
+          value: "25"
+
   - it: includes JARVIS_RUNBOOK_BASE_URL when set
     set:
       config.runbookBaseURL: https://wiki.example.com/runbooks/

--- a/charts/jarvis/values.yaml
+++ b/charts/jarvis/values.yaml
@@ -185,6 +185,11 @@ database:
   # When set, `dsn` above is ignored.
   existingSecret: ""
   existingSecretKey: dsn
+  # Max open connections to PostgreSQL per pod (JARVIS_DB_MAX_OPEN_CONNS).
+  # Idle connections are kept up to the same cap. Ignored for SQLite.
+  # Size it so replicaCount × maxOpenConns stays well below the server's
+  # max_connections (minus reserved slots).
+  maxOpenConns: 10
 
 # Persistent storage for the SQLite database file.
 # Ignored when using PostgreSQL (database.dsn starts with "postgres://").

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -42,6 +42,17 @@ JARVIS_DB_DSN=postgres://jarvis:secret@postgres:5432/jarvis?sslmode=require
   test container.
 - **Redaction**: the password in `JARVIS_DB_DSN` is redacted (`db.RedactDSN`)
   before it ever reaches a log line — the raw DSN is never logged.
+- **Connection-pool cap**: `JARVIS_DB_MAX_OPEN_CONNS` (default `10`) caps
+  the PostgreSQL pool per pod; idle connections are kept up to the same cap
+  so request bursts reuse connections instead of churning them
+  (`ConnMaxLifetime=30m`, `ConnMaxIdleTime=5m`). Each pod additionally holds
+  one dedicated connection for leader election and one for the
+  LISTEN/NOTIFY WS fanout. Size it so
+  `replicas × (JARVIS_DB_MAX_OPEN_CONNS + 2)` stays well below the server's
+  `max_connections` minus its reserved slots — an unbounded pool has
+  exhausted the connection slots of a shared RDS instance in production
+  (`FATAL: remaining connection slots are reserved …`, SQLSTATE 53300).
+  Ignored for SQLite, which is always single-connection.
 - **Local PostgreSQL for testing**: `make up-postgres` starts a disposable
   container on port 5432 (`jarvis`/`jarvis`/`jarvis`); point
   `JARVIS_DB_DSN=postgres://jarvis:jarvis@localhost:5432/jarvis?sslmode=disable`


### PR DESCRIPTION
## Summary

The PostgreSQL pool ran with `database/sql` defaults: `MaxOpenConns=0` (unlimited) and `MaxIdleConns=2`. A burst of parallel requests (e.g. alert-detail `stats`/`heatmap`) opened as many connections as there were parallel queries; multiplied by the number of pods, this exhausted the connection slots of a shared RDS instance in production (`SQLSTATE 53300`), and `stats`/`heatmap` requests failed with 500.

- `openPostgres` now always caps the pool: `JARVIS_DB_MAX_OPEN_CONNS` (default 10, must be `>= 1`) sets both `MaxOpenConns` and `MaxIdleConns` so bursts reuse connections instead of churning them, plus `ConnMaxLifetime=30m` / `ConnMaxIdleTime=5m`
- SQLite stays hard-pinned at a single connection regardless of the option (Critical Invariant #8 — verified by test)
- Helm chart exposes the cap as `database.maxOpenConns` (default 10) → `JARVIS_DB_MAX_OPEN_CONNS`
- Docs synced: `AGENTS.md` invariant #8, `.agents/architecture.md`, `docs/persistence.md` (sizing guidance: `replicas × (cap + 2)` below the server's `max_connections`), chart README, `.env.example`, new `.agents/lessons.md` entry

## Test plan

- [x] `go test ./...` (backend) — SQLite
- [x] `go test ./...` against a real PostgreSQL (`make up-postgres`) — new pool-limit tests (`TestOpen_Postgres_PoolLimits`, `TestOpen_SQLite_IgnoresMaxOpenConns`), plus full existing suite
- [x] `make helm-lint` + `make helm-test` (90 tests incl. 2 new configmap cases)