### PR TITLE
fix(db): stop self-healing PostgreSQL reconnects and transient AM 503s from paging

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1300,11 +1300,25 @@ with its own `*alertmanager.Client`); `Cluster.AlertmanagerURL` /
   retrying once against the next member on transport failure or a 5xx
   response — never to all members, since gossip already replicates and
   posting to every member would create duplicates. Does NOT retry a 4xx
-  (`isRetryableWriteError` in `poll.go`): Alertmanager already evaluated and
-  rejected the request on its merits, so a second member would reject it
+  (`isRetryableUpstreamError` in `poll.go`): Alertmanager already evaluated
+  and rejected the request on its merits, so a second member would reject it
   identically — retrying only adds latency and, for the non-idempotent
   create, risks a duplicate if the first response was lost after
   Alertmanager had already applied the write.
+- `Cluster.FetchAlerts` / `FetchSilences` apply the same
+  `isRetryableUpstreamError` policy on the read side: a per-member fetch
+  that fails with a transport error or 5xx gets one immediate retry (after
+  `fetchRetryDelay`, 250ms) against that same member before being counted as
+  a failure; a 4xx is definitive and never retried. This absorbs a single
+  transient upstream blip (e.g. a service-mesh sidecar resetting the
+  connection) without it ever reaching `poll()`'s error
+  logging/`PollErrorsTotal` — only a fetch that fails twice in a row is a
+  real, loggable problem. To make the 4xx distinction visible to reads,
+  `alertmanager.Client.get` returns `*AMError` for any non-2xx (it used to
+  return a plain formatted error; only the write methods built `AMError`).
+  The `onDuration` metric callback reports the total fetch duration
+  including a retry — deliberate, it reflects the member's true
+  contribution to poll latency.
 - Enrichment (`cluster/enrich.go`, `enrichMerged`) — moved here from
   `history` — builds `EnrichedAlert` (incl. `@receiver` label) from merged
   alerts; lives in `cluster` because `history` imports `cluster` (not the

--- a/.agents/lessons.md
+++ b/.agents/lessons.md
@@ -9,6 +9,66 @@ instead of duplicating.
 
 ---
 
+## Hourly PostgreSQL LISTEN reconnects and occasional single-poll 503s are expected noise, not bugs — but they were logged loud enough to trip infra error-count alerting
+
+**Symptom**: Production (2-replica, PostgreSQL) logs showed `fanout:
+connection lost, reconnecting` / `listen: connection lost, reconnecting`
+(`err":"unexpected EOF"`) on a near-exact ~60-minute cadence per pod, plus
+occasional `fetch silences failed ... alertmanager returned 503 ...
+upstream connect error or disconnect/reset before headers` for one cluster
+every few hours. Both were logged at `Warn`, and the infra's log-based
+alerting fired once enough of these accumulated — even though neither
+represented a real outage.
+**Cause**: The per-connection survival pattern in the logs pins it down to
+an **application-idle timeout of exactly 1h that TCP keepalives don't
+reset**: the leader pod lost its `fanout` (jarvis_ws) *and* `listen`
+(jarvis_trigger) connections hourly — both channels are silent unless a
+user mutates something; the follower lost *only* `fanout` — its snapshot
+LISTEN receives a NOTIFY every poll interval (real payload) and survived;
+the elector connections (a real query every 5s) never dropped, so
+leadership never flapped. The aggressive TCP keepalives (5s idle/3s
+interval/3 count, D2) were flowing on all of them, so whatever killed the
+idle ones counts only application data, not TCP-level keepalive ACKs —
+and Envoy's TCP-proxy default `idle_timeout` is exactly 1 hour, with the
+mesh already proven in the path (see below). "unexpected EOF" = an active
+close, not a silent drop; keepalives tuned for silent failures can't
+prevent it. Separately, the 503 came from an Envoy/Istio-shaped error
+string ("upstream connect error … reset reason: connection termination"),
+i.e. a service-mesh sidecar in front of that cluster's Alertmanager
+occasionally resetting a connection — a one-off blip, not a sustained
+failure, but `FetchAlerts`/`FetchSilences` had no retry on the read side
+(only the write path, `CreateSilence`/`DeleteSilence`, retried on a
+5xx/transport error). Related latent bug found while fixing this: the
+write path's 4xx/5xx distinction never worked for reads because
+`alertmanager.Client.get` returned a plain `fmt.Errorf` for non-2xx —
+only the write methods built `*AMError`. `get` now returns `*AMError`
+too, so `isRetryableUpstreamError` can actually see the status code.
+**Rule**: A reconnect loop that already self-heals immediately (the `Run`/
+`listenLoop` loops in `internal/fanout/postgres.go` and
+`internal/history/recorder_snapshot.go` redial and re-`LISTEN` right away)
+doesn't need `Warn` — logged at `Info`, still visible on inspection, no
+longer countable as an "error" by naive log-volume alerting. For upstream
+reads, apply the same retry-once policy the write path already had:
+`isRetryableUpstreamError` (renamed from `isRetryableWriteError` — it now
+covers both) gates one immediate retry (`fetchRetryDelay`, 250ms) in
+`Cluster.FetchAlerts`/`FetchSilences` before a per-member failure counts —
+see `.agents/architecture.md`. General principle: log level should track
+*operator actionability*, not just "an error occurred" — a self-healing
+retry loop and a transient blip that a one-shot retry absorbs are both
+"nothing wild," and treating them as `Warn`/`Error` just teaches the infra
+alerting (and the on-call human) to ignore real signals mixed in with them.
+Open option if the hourly reconnects should disappear entirely instead of
+being tolerated: send real payload on the idle LISTEN connections (a
+periodic `SELECT 1`/Ping between `WaitForNotification` calls — the
+snapshot listener's survival proves payload resets the timer), or raise
+the mesh sidecar's idle timeout for the PostgreSQL egress. Tolerating them
+is safe for `listen:` (trigger misses only delay reconciliation to the
+next poll; snapshots have the periodic-resync fallback), and near-safe for
+`fanout:` (fire-and-forget, no resync — a WS mutation broadcast landing in
+the sub-second redial window is lost until the browser's next refetch).
+
+---
+
 ## Go's default database/sql pool is unbounded — it exhausted RDS connection slots in production
 
 **Symptom**: `stats`/`heatmap` requests returned 500 with

--- a/backend/internal/alertmanager/client.go
+++ b/backend/internal/alertmanager/client.go
@@ -16,10 +16,12 @@ type Client struct {
 	httpClient *http.Client
 }
 
-// AMError wraps a non-2xx response from Alertmanager, preserving the status
-// code so callers can distinguish AM-side rejections (4xx — e.g. an invalid
-// matcher or a duplicate/expired silence ID; safe to relay to the user) from
-// transport/server failures (5xx, network errors — kept as a generic error).
+// AMError wraps any non-2xx response from Alertmanager (reads and writes
+// alike), preserving the status code so callers can distinguish AM-side
+// rejections (4xx — e.g. an invalid matcher or a duplicate/expired silence
+// ID; safe to relay to the user, never worth retrying) from transport/server
+// failures (5xx, network errors — retryable, see
+// cluster.isRetryableUpstreamError).
 type AMError struct {
 	StatusCode int
 	Body       string
@@ -148,7 +150,7 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("alertmanager returned %d for %s: %s", resp.StatusCode, path, string(b))
+		return &AMError{StatusCode: resp.StatusCode, Body: string(b)}
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {

--- a/backend/internal/cluster/poll.go
+++ b/backend/internal/cluster/poll.go
@@ -24,6 +24,20 @@ type FetchDurationFunc func(member string, seconds float64)
 // overlap, a slow poll just delays the next tick.
 const fetchRetryDelay = 250 * time.Millisecond
 
+// fetchWithRetry calls fetch once and, on a retryable error (see
+// isRetryableUpstreamError), waits fetchRetryDelay and calls it exactly once
+// more — shared by FetchAlerts and FetchSilences so a single transient
+// upstream blip self-heals silently instead of failing that member's fetch
+// for the poll cycle.
+func fetchWithRetry[T any](ctx context.Context, fetch func() (T, error)) (T, error) {
+	v, err := fetch()
+	if err != nil && ctx.Err() == nil && isRetryableUpstreamError(err) {
+		sleepCtx(ctx, fetchRetryDelay)
+		v, err = fetch()
+	}
+	return v, err
+}
+
 // FetchAlerts polls all members in parallel and returns the deduplicated,
 // enriched alert set for this cluster (see mergeAlerts). Returns an error
 // only when ALL members failed — a single member's failure does not fail the
@@ -46,17 +60,12 @@ func (c *Cluster) FetchAlerts(ctx context.Context, onDuration FetchDurationFunc)
 		go func(idx int, m *Member) {
 			defer wg.Done()
 			start := time.Now()
-			alerts, err := m.Client.GetAlerts(ctx)
-			if err != nil && ctx.Err() == nil && isRetryableUpstreamError(err) {
-				// A single transient upstream blip is common and self-heals
-				// immediately — one retry avoids logging/alerting on it as a
-				// poll failure (see CreateSilence/DeleteSilence, which apply
-				// the same retry-once policy on the write side). onDuration
-				// deliberately reports the total including the retry: the
-				// metric reflects this member's contribution to poll latency.
-				sleepCtx(ctx, fetchRetryDelay)
-				alerts, err = m.Client.GetAlerts(ctx)
-			}
+			// onDuration deliberately reports the total including a retry:
+			// the metric reflects this member's true contribution to poll
+			// latency.
+			alerts, err := fetchWithRetry(ctx, func() ([]alertmanager.GettableAlert, error) {
+				return m.Client.GetAlerts(ctx)
+			})
 			if onDuration != nil {
 				onDuration(m.Name, time.Since(start).Seconds())
 			}
@@ -115,11 +124,9 @@ func (c *Cluster) FetchSilences(ctx context.Context, onDuration FetchDurationFun
 		go func(idx int, m *Member) {
 			defer wg.Done()
 			start := time.Now()
-			silences, err := m.Client.GetSilences(ctx)
-			if err != nil && ctx.Err() == nil && isRetryableUpstreamError(err) {
-				sleepCtx(ctx, fetchRetryDelay)
-				silences, err = m.Client.GetSilences(ctx)
-			}
+			silences, err := fetchWithRetry(ctx, func() ([]alertmanager.GettableSilence, error) {
+				return m.Client.GetSilences(ctx)
+			})
 			if onDuration != nil {
 				onDuration(m.Name, time.Since(start).Seconds())
 			}

--- a/backend/internal/cluster/poll.go
+++ b/backend/internal/cluster/poll.go
@@ -15,6 +15,15 @@ import (
 // used by the caller to record a per-member fetch-duration metric. May be nil.
 type FetchDurationFunc func(member string, seconds float64)
 
+// fetchRetryDelay is the pause before the single retry FetchAlerts and
+// FetchSilences make on a retryable per-member error — long enough to let a
+// one-off transient reset (e.g. a service-mesh sidecar tearing down a
+// connection) clear. The retry is a second, independent request with its own
+// 10s client timeout, so the worst case for a hard-down member roughly
+// doubles (≈20s per poll instead of ≈10s); polls run sequentially and never
+// overlap, a slow poll just delays the next tick.
+const fetchRetryDelay = 250 * time.Millisecond
+
 // FetchAlerts polls all members in parallel and returns the deduplicated,
 // enriched alert set for this cluster (see mergeAlerts). Returns an error
 // only when ALL members failed — a single member's failure does not fail the
@@ -38,6 +47,16 @@ func (c *Cluster) FetchAlerts(ctx context.Context, onDuration FetchDurationFunc)
 			defer wg.Done()
 			start := time.Now()
 			alerts, err := m.Client.GetAlerts(ctx)
+			if err != nil && ctx.Err() == nil && isRetryableUpstreamError(err) {
+				// A single transient upstream blip is common and self-heals
+				// immediately — one retry avoids logging/alerting on it as a
+				// poll failure (see CreateSilence/DeleteSilence, which apply
+				// the same retry-once policy on the write side). onDuration
+				// deliberately reports the total including the retry: the
+				// metric reflects this member's contribution to poll latency.
+				sleepCtx(ctx, fetchRetryDelay)
+				alerts, err = m.Client.GetAlerts(ctx)
+			}
 			if onDuration != nil {
 				onDuration(m.Name, time.Since(start).Seconds())
 			}
@@ -97,6 +116,10 @@ func (c *Cluster) FetchSilences(ctx context.Context, onDuration FetchDurationFun
 			defer wg.Done()
 			start := time.Now()
 			silences, err := m.Client.GetSilences(ctx)
+			if err != nil && ctx.Err() == nil && isRetryableUpstreamError(err) {
+				sleepCtx(ctx, fetchRetryDelay)
+				silences, err = m.Client.GetSilences(ctx)
+			}
 			if onDuration != nil {
 				onDuration(m.Name, time.Since(start).Seconds())
 			}
@@ -128,7 +151,7 @@ func (c *Cluster) FetchSilences(ctx context.Context, onDuration FetchDurationFun
 // order); on transport failure or a 5xx response, retries once against the
 // next healthy member. Never sent to all members — gossip replicates
 // silences between real HA members, so posting to every member would create
-// duplicates. Does NOT retry a 4xx response (see isRetryableWriteError) — the
+// duplicates. Does NOT retry a 4xx response (see isRetryableUpstreamError) — the
 // request reached Alertmanager and was rejected on its merits (invalid
 // matcher, bad ID, …); a second member will reject it identically, so
 // retrying only adds latency and (for a non-idempotent create) risks a
@@ -146,7 +169,7 @@ func (c *Cluster) CreateSilence(ctx context.Context, s alertmanager.PostableSile
 			return id, nil
 		}
 		lastErr = err
-		if !isRetryableWriteError(err) {
+		if !isRetryableUpstreamError(err) {
 			return "", err
 		}
 	}
@@ -166,24 +189,35 @@ func (c *Cluster) DeleteSilence(ctx context.Context, id string) error {
 			return nil
 		}
 		lastErr = err
-		if !isRetryableWriteError(err) {
+		if !isRetryableUpstreamError(err) {
 			return err
 		}
 	}
 	return lastErr
 }
 
-// isRetryableWriteError reports whether a failed write is worth retrying
-// against another member: true for transport/network errors and 5xx
-// responses, false for a 4xx *alertmanager.AMError — Alertmanager received
-// and rejected the request on its merits, and every member enforces the
-// same validation.
-func isRetryableWriteError(err error) bool {
+// isRetryableUpstreamError reports whether a failed request (read or write)
+// is worth retrying: true for transport/network errors and 5xx responses,
+// false for a 4xx *alertmanager.AMError — Alertmanager received and
+// rejected the request on its merits, and a retry (against the same or
+// another member, both enforce identical validation) would get the same
+// answer.
+func isRetryableUpstreamError(err error) bool {
 	var amErr *alertmanager.AMError
 	if errors.As(err, &amErr) {
 		return amErr.StatusCode >= 500
 	}
 	return true
+}
+
+// sleepCtx sleeps for d or returns early if ctx is cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
 }
 
 // attemptCount caps write retries at 2: the first healthy member, plus one retry.

--- a/backend/internal/cluster/poll_test.go
+++ b/backend/internal/cluster/poll_test.go
@@ -51,6 +51,95 @@ func twoMemberCluster(name string, urls ...string) *Cluster {
 	return buildCluster(config.ClusterConfig{Name: name, Members: members})
 }
 
+// countingServer serves the standard alerts/silences endpoints but answers
+// the first `failures` requests to failPath with failStatus. The returned
+// func reports how many requests a path has received — used to assert the
+// exact number of fetch attempts (retry-once semantics).
+func countingServer(t *testing.T, failPath string, failStatus, failures int, alerts []alertmanager.GettableAlert) (*httptest.Server, func(string) int) {
+	t.Helper()
+	var mu sync.Mutex
+	counts := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		counts[r.URL.Path]++
+		n := counts[r.URL.Path]
+		mu.Unlock()
+		if r.URL.Path == failPath && n <= failures {
+			http.Error(w, "transient", failStatus)
+			return
+		}
+		switch r.URL.Path {
+		case "/api/v2/alerts":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(alerts)
+		case "/api/v2/silences":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]alertmanager.GettableSilence{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	requests := func(path string) int { mu.Lock(); defer mu.Unlock(); return counts[path] }
+	return srv, requests
+}
+
+func TestFetchAlerts_TransientMemberError_RetriedOnce(t *testing.T) {
+	srv, requests := countingServer(t, "/api/v2/alerts", http.StatusServiceUnavailable, 1,
+		[]alertmanager.GettableAlert{{Fingerprint: "fp1"}})
+	cl := twoMemberCluster("prod", srv.URL)
+
+	alerts, err := cl.FetchAlerts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchAlerts: %v (a single transient 5xx must be absorbed by the retry)", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("len(alerts) = %d, want 1", len(alerts))
+	}
+	if got := requests("/api/v2/alerts"); got != 2 {
+		t.Errorf("alert requests = %d, want 2 (initial + one retry)", got)
+	}
+	if !cl.MemberUpStates()[config.DeriveMemberName(srv.URL)] {
+		t.Error("member must be marked up after the retry succeeded")
+	}
+}
+
+func TestFetchSilences_TransientMemberError_RetriedOnce(t *testing.T) {
+	srv, requests := countingServer(t, "/api/v2/silences", http.StatusServiceUnavailable, 1, nil)
+	cl := twoMemberCluster("prod", srv.URL)
+
+	if _, err := cl.FetchSilences(context.Background(), nil); err != nil {
+		t.Fatalf("FetchSilences: %v (a single transient 5xx must be absorbed by the retry)", err)
+	}
+	if got := requests("/api/v2/silences"); got != 2 {
+		t.Errorf("silence requests = %d, want 2 (initial + one retry)", got)
+	}
+}
+
+func TestFetchAlerts_PersistentMemberError_ExactlyOneRetry(t *testing.T) {
+	srv, requests := countingServer(t, "/api/v2/alerts", http.StatusInternalServerError, 1000, nil)
+	cl := twoMemberCluster("prod", srv.URL)
+
+	if _, err := cl.FetchAlerts(context.Background(), nil); err == nil {
+		t.Fatal("expected error when the member keeps failing")
+	}
+	if got := requests("/api/v2/alerts"); got != 2 {
+		t.Errorf("alert requests = %d, want 2 (retry capped at one)", got)
+	}
+}
+
+func TestFetchAlerts_4xxNotRetried(t *testing.T) {
+	srv, requests := countingServer(t, "/api/v2/alerts", http.StatusForbidden, 1000, nil)
+	cl := twoMemberCluster("prod", srv.URL)
+
+	if _, err := cl.FetchAlerts(context.Background(), nil); err == nil {
+		t.Fatal("expected error on a 4xx response")
+	}
+	if got := requests("/api/v2/alerts"); got != 1 {
+		t.Errorf("alert requests = %d, want 1 (4xx is a definitive answer, not retryable)", got)
+	}
+}
+
 func TestFetchAlerts_MemberDown_OtherMemberStillServesAlerts(t *testing.T) {
 	up := alertsServer(t, []alertmanager.GettableAlert{{Fingerprint: "fp1", Status: alertmanager.GettableAlertStatus{State: "active"}}})
 	down := downServer(t)

--- a/backend/internal/fanout/postgres.go
+++ b/backend/internal/fanout/postgres.go
@@ -132,7 +132,11 @@ func (f *PGFanout) consume(ctx context.Context, conn *pgx.Conn, onMessage func([
 			if ctx.Err() != nil {
 				return
 			}
-			f.logger.Warn("fanout: connection lost, reconnecting", "err", err)
+			// Info, not Warn: the Run loop immediately redials and re-LISTENs
+			// (see below) — an occasional drop here (e.g. a pooler/proxy
+			// recycling long-lived connections on a fixed lifetime) is
+			// expected and self-healing, not an operator-actionable failure.
+			f.logger.Info("fanout: connection lost, reconnecting", "err", err)
 			return
 		}
 		var env envelope

--- a/backend/internal/history/recorder_snapshot.go
+++ b/backend/internal/history/recorder_snapshot.go
@@ -219,7 +219,11 @@ func (r *Recorder) consumeNotifications(ctx context.Context, conn *pgx.Conn, res
 				}
 				continue
 			}
-			r.logger.Warn("listen: connection lost, reconnecting", "err", err)
+			// Info, not Warn: listenLoop immediately redials and re-LISTENs
+			// (see below) — an occasional drop here (e.g. a pooler/proxy
+			// recycling long-lived connections on a fixed lifetime) is
+			// expected and self-healing, not an operator-actionable failure.
+			r.logger.Info("listen: connection lost, reconnecting", "err", err)
 			return
 		}
 		onNotify(n.Payload)


### PR DESCRIPTION
## Summary
- Production logs (2-replica, PostgreSQL) showed hourly `fanout: connection lost, reconnecting` / `listen: connection lost, reconnecting` and occasional `fetch silences failed ... 503` for one cluster — both self-healing (immediate redial; last-good-snapshot fallback) but logged loud enough to trip infra error-count alerting.
- Downgrade the reconnect log lines (WS fanout + snapshot/trigger listener) from `Warn` to `Info` — never operator-actionable, the loop already redials and re-`LISTEN`s right away.
- Give `FetchAlerts`/`FetchSilences` the same retry-once policy `CreateSilence`/`DeleteSilence` already had on the write side, so a single transient 5xx/transport blip (e.g. a mesh sidecar resetting the connection) self-heals silently instead of logging a poll failure. Renamed `isRetryableWriteError` → `isRetryableUpstreamError` since it now guards both reads and writes.
- Fixed a latent bug found while adding this: `alertmanager.Client.get` returned a plain formatted error instead of `*AMError` for non-2xx responses, so the read path could never actually distinguish a definitive 4xx from a retryable 5xx — every read error (including permanent ones like a bad URL or broken auth) would have been retried.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full backend suite)
- [x] New tests in `internal/cluster/poll_test.go`: transient 503 retried once and absorbed (alerts + silences), retry capped at exactly one attempt on persistent failure, 4xx never retried
- [x] `.agents/architecture.md` and `.agents/lessons.md` updated in the same commit (retry policy, renamed function, root-cause analysis of the hourly reconnect cadence)