### PR TITLE
fix(config): add codecov.yml with thresholds to stop flaky coverage checks

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -304,7 +304,10 @@ backend:
   - go test -v -race -coverprofile=coverage.out ./... | go-junit-report → report.xml
   - Coverage summary → GITHUB_STEP_SUMMARY (go tool cover -func)
   - dorny/test-reporter uploads report.xml as "Backend Test Results"
-  - upload-artifact: coverage.out + report.xml; coverage upload to Codecov
+  - upload-artifact: coverage.out + report.xml; coverage upload to Codecov (flag `backend`;
+    backend-only by design — frontend vitest coverage measures only lib/alertUtils.ts and would
+    misrepresent frontend coverage. Status checks configured in codecov.yml: project auto ±1%,
+    patch 70% ±5% — thresholds absorb goroutine-timing coverage noise from -race runs)
   - govulncheck ./...
   - golangci-lint run   # includes gosec (enabled in .golangci.yml)
   - fuzz targets, 20s each (FuzzRedactDSN, FuzzParseNullableTimeString, FuzzParseSecretKey,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecov-yaml
+#
+# Only backend coverage is uploaded (flag `backend` in ci.yml). Frontend
+# coverage is deliberately NOT uploaded: vitest coverage is scoped to
+# `src/lib/alertUtils.ts` only (E2E-only test strategy, see
+# frontend/vitest.config.ts) — uploading a single 100%-covered file would
+# misrepresent frontend coverage.
+#
+# Thresholds exist because Go coverage of concurrent code (recorder, poller,
+# WS) is slightly nondeterministic under -race: goroutine timing decides which
+# branches run, so identical code can measure ±<1% between runs. Without a
+# threshold the default (target: auto, threshold: 0%) turns that noise into
+# red codecov/project checks.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+
+comment:
+  require_changes: true


### PR DESCRIPTION
## Problem

`codecov/project` and `codecov/patch` fail regularly on PRs (e.g. #111, #112, #117, #120) without any real coverage regression. There is no `codecov.yml`, so Codecov runs on its defaults: `target: auto, threshold: 0%` — any drop, however small, turns the check red. Go coverage of concurrent code (recorder, poller, WS) is slightly nondeterministic under `-race` because goroutine timing decides which branches run, so identical code measures ±<1% between runs and that noise reads as a coverage drop.

## Change

Add a `codecov.yml` (validated against the Codecov validator API):

- `project`: `target: auto` with `threshold: 1%` — real regressions >1% still fail, measurement noise doesn't
- `patch`: `target: 70%` with `threshold: 5%` — new code needs reasonable coverage without demanding project-level coverage on hard-to-test code
- `comment: require_changes: true` — Codecov only comments on PRs when coverage actually changes

Frontend coverage stays deliberately un-uploaded: vitest coverage is scoped to `src/lib/alertUtils.ts` only (E2E-only test strategy, see `frontend/vitest.config.ts`), so uploading it would misrepresent frontend coverage as a single 100%-covered file. Documented as a comment in `codecov.yml` and in `.agents/testing.md`.