### PR TITLE
fix(config): bump CI Go toolchain pin to 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
 
       - name: Download dependencies
         run: go mod download


### PR DESCRIPTION
## Summary
- `govulncheck` in the Backend CI job flags 6 known Go stdlib vulnerabilities (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-6088, GO-2026-5972, GO-2026-5026) present in Go 1.25.12, all fixed in 1.25.13
- This currently blocks the Backend check on every open PR (e.g. #141)
- Bumps the `actions/setup-go` `go-version` pin in `ci.yml` from `1.25.12` to `1.25.13`

## Test plan
- [x] CI (Backend job incl. govulncheck) passes on this PR