### PR TITLE
feat(silences): creation time, fixed Created sort, direction toggle & "by" filter

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -855,7 +855,13 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
 │   │                            hasUnevaluableRegexMatcher, silenceMatchesAlert,
 │   │                            getEffectiveAlertState, getSilenceState (both consider ALL active
 │   │                            silences in silencedBy, not just the first), getExpiredSilence,
-│   │                            filterSilences, pickIdentifierLabel, formatSilenceDuration,
+│   │                            filterSilences (4th arg `createdBy`: exact-match "by" filter,
+│   │                            silences page only), silenceCreators (distinct sorted `createdBy`
+│   │                            values → the "By:" dropdown), sortSilences + defaultSilenceSortDir
+│   │                            ("expires" → `endsAt`/asc default, "created" → `updatedAt`/desc
+│   │                            default; explicit sort beats the active→pending→expired order,
+│   │                            which is only a timestamp-tie breaker then `id`),
+│   │                            pickIdentifierLabel, formatSilenceDuration,
 │   │                            formatTime, severityOrder, formatAckDuration, buildAckSilenceBody,
 │   │                            computeGroupLabelValues (only labels present on EVERY alert in the
 │   │                            group — a partial label is dropped, never partially OR-matched),
@@ -1083,11 +1089,13 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
     │       emphasis in a legacy comment is accepted)
     ├── silences/
     │   ├── SilencesPage.tsx   → dedicated page: card|list, fullscreen, show/hide expired,
-    │   │                        sort (expires/created), matcher-chip filter
-    │   ├── SilenceCard.tsx    → status, matchers, expiry, expired info box, re-create
+    │   │                        sort (expires/created + asc/desc toggle), creator-filter
+    │   │                        dropdown (person-icon, silences only), matcher-chip filter
+    │   ├── SilenceCard.tsx    → status, matchers, created + expiry boxes, expired info box, re-create
     │   ├── SilenceGroupCard.tsx → grouped identical silences (count + summed affected)
-    │   ├── SilenceListView.tsx → table view
-    │   ├── SilenceExpiry.tsx  → "expired X ago" / "expires in X" / "starts in X"
+    │   ├── SilenceListView.tsx → table view (created timestamp on the "by" line)
+    │   ├── SilenceExpiry.tsx  → "expired X ago" / "expires in X" / "starts in X"; exports ExactDate/DATE_FMT
+    │   ├── SilenceCreated.tsx → creation timestamp (Silence.updatedAt) + "X ago", shares ExactDate
     │   ├── SilenceExpireModal.tsx → expire/extend confirmation (silence-ID link → AM)
     │   ├── SilenceForm.tsx    → 3 steps: form (matchers, clusters, duration, live match count,
     │   │                        overlap/zero-match/unevaluable-regex warnings) → preview → per-cluster results

--- a/.agents/lessons.md
+++ b/.agents/lessons.md
@@ -9,6 +9,24 @@ instead of duplicating.
 
 ---
 
+## A silence's "created" time is `updatedAt`, never `startsAt`
+
+**Symptom**: Sorting the silences page by "Created" produced a confusing
+order — a just-created silence landed in the middle of the list, not at the
+top.
+**Cause**: The sort read `Silence.startsAt`. In Alertmanager `startsAt` is
+the *schedule start* of the mute window — it can be set well into the future
+(pending silences) or slightly in the past, and is unrelated to when the
+silence was actually submitted. Alertmanager exposes no dedicated created-at
+field; `updatedAt` is the create-and-last-edit timestamp (editing a silence
+in AM rewrites it, and also mints a new silence ID).
+**Rule**: `sortSilences` in `lib/alertUtils.ts` sorts "created" by
+`updatedAt`. Treat `updatedAt` as the creation time everywhere in the UI
+(`SilenceCreated.tsx`); only use `startsAt`/`endsAt` for the active mute
+window. The explicit sort also takes precedence over the
+active→pending→expired lifecycle order now (that order is only a
+timestamp-tie breaker) — users sorting by a date expect that date to win.
+
 ## Bumping the pinned Go version: pick a patch govulncheck considers clean
 
 **Symptom**: Raising CI's `go-version` from `1.25.13` to `1.26.5` (forced by

--- a/docs/testing-e2e.md
+++ b/docs/testing-e2e.md
@@ -240,7 +240,7 @@ Quick reference: which spec file covers what. Use this to find the right place f
 | `detail-panel.spec.ts` | D1–D2, D5–D11, G2 | Open/close/URL param, labels/annotations, stats & timeline, claim set/release, comments add/delete, claim note edit, AI prompt, section collapse, extend controls |
 | `detail-panel-extended.spec.ts` | D4, D12–D14 | Runbook/URL links, AI prompt tab copy, section collapse/expand, silence from detail panel |
 | `cluster-scoping.spec.ts` | X1–X3 | Cross-cluster isolation for identical fingerprint: stats/history, comments, claims |
-| `silences-page.spec.ts` | E1–E7, G1, G3 | List view persist, grouping, show/hide expired, sort, matcher filter, expiry status, re-create, expire single/group |
+| `silences-page.spec.ts` | E1–E7, E4b, G1, G3 | List view persist, grouping, show/hide expired, sort (expires/created + asc/desc direction), "By:" creator filter, matcher filter, expiry status, re-create, expire single/group |
 | `silences-form-extended.spec.ts` | F3–F16 | Operator switch, regex tags+escaping, live match count, overlap warning, zero-match warning, duration presets, spinner normalisation, inline calendar, Now/Reset, end-after-start validation, author editability, reason required, preview summary, results step |
 | `silences-form-templates.spec.ts` | F1–F2, F14–F15, F17, G4–G8 | Form open/close (Cancel/ESC/backdrop), cluster guard, templates CRUD (create/apply/edit/delete) |
 | `silence-matching-semantics.spec.ts` | — | Differential tests against the real Alertmanager instance: form preview's affected-alerts count and actual post-submit suppression must agree — anchored `=~`/`!~` regex (not substring), regex-OR matcher escaping with metacharacter label values |

--- a/frontend/e2e/functional/none/silences-page.spec.ts
+++ b/frontend/e2e/functional/none/silences-page.spec.ts
@@ -157,26 +157,26 @@ test('E3 show/hide expired toggles expired silences visibility', async ({ page, 
   await expect(page.getByText(expiredComment).first()).toBeVisible()
 })
 
-test('E4 sort toggle switches ordering between expires and created', async ({ page, jarvis }) => {
+test('E4 sort toggle and asc/desc direction reorder by expiry vs creation time', async ({ page, jarvis }) => {
   await dismissNoAuthNotice(page)
   await resetPersistedUIState(page)
   await clearAllAMSilences()
   await jarvis.poll()
 
   const now = Date.now()
-  const earlyExpiryComment = 'e4-early-expiry'
-  const oldCreatedComment = 'e4-old-created'
 
-  await jarvis.createSilence('e2e', [{ name: 'alertname', value: 'E4OldCreated', isRegex: false, isEqual: true }], {
-    startsAt: new Date(now - 2 * 60 * 60 * 1000),
-    endsAt: new Date(now + 2 * 60 * 60 * 1000),
-    comment: oldCreatedComment,
-    createdBy: 'e2e-tester',
-  })
+  // Created first (oldest updatedAt), expires soonest.
   await jarvis.createSilence('e2e', [{ name: 'alertname', value: 'E4EarlyExpiry', isRegex: false, isEqual: true }], {
     startsAt: new Date(now - 30 * 60 * 1000),
     endsAt: new Date(now + 30 * 60 * 1000),
-    comment: earlyExpiryComment,
+    comment: 'e4-early-expiry',
+    createdBy: 'e2e-tester',
+  })
+  // Created last (newest updatedAt), expires latest.
+  await jarvis.createSilence('e2e', [{ name: 'alertname', value: 'E4LateExpiry', isRegex: false, isEqual: true }], {
+    startsAt: new Date(now - 30 * 60 * 1000),
+    endsAt: new Date(now + 4 * 60 * 60 * 1000),
+    comment: 'e4-late-expiry',
     createdBy: 'e2e-tester',
   })
   await waitForSilences(JARVIS_BASE_URL, 2)
@@ -185,13 +185,50 @@ test('E4 sort toggle switches ordering between expires and created', async ({ pa
   await ensureSilencesPage(page)
   const e4Matchers = page.locator('span.font-mono.text-xs').filter({ hasText: 'alertname=E4' })
   await expect(e4Matchers).toHaveCount(2)
+
+  // Default: Expires ascending → soonest first.
   await expect(e4Matchers.first()).toContainText('E4EarlyExpiry')
 
+  // Direction toggle flips it → latest expiry first.
+  await page.getByRole('button', { name: 'Toggle sort direction' }).click()
+  await expect(e4Matchers.first()).toContainText('E4LateExpiry')
+
+  // Created → defaults back to descending (newest first).
   await page.getByRole('button', { name: 'Created' }).click()
-  await expect(e4Matchers.first()).toContainText('E4OldCreated')
+  await expect(e4Matchers.first()).toContainText('E4LateExpiry')
 
-  await page.getByRole('button', { name: 'Expires' }).click()
+  // Created ascending → oldest creation first.
+  await page.getByRole('button', { name: 'Toggle sort direction' }).click()
   await expect(e4Matchers.first()).toContainText('E4EarlyExpiry')
+})
+
+test('E4b "By:" dropdown filters silences to a single creator', async ({ page, jarvis }) => {
+  await dismissNoAuthNotice(page)
+  await resetPersistedUIState(page)
+  await clearAllAMSilences()
+  await jarvis.poll()
+
+  await jarvis.createSilence('e2e', [{ name: 'alertname', value: 'E4bAlice', isRegex: false, isEqual: true }], {
+    comment: 'e4b-alice',
+    createdBy: 'alice',
+  })
+  await jarvis.createSilence('e2e', [{ name: 'alertname', value: 'E4bBob', isRegex: false, isEqual: true }], {
+    comment: 'e4b-bob',
+    createdBy: 'bob',
+  })
+  await waitForSilences(JARVIS_BASE_URL, 2)
+
+  await page.goto('/')
+  await ensureSilencesPage(page)
+  const e4bMatchers = page.locator('span.font-mono.text-xs').filter({ hasText: 'alertname=E4b' })
+  await expect(e4bMatchers).toHaveCount(2)
+
+  await page.getByRole('combobox', { name: 'Filter by silence creator' }).selectOption('alice')
+  await expect(e4bMatchers).toHaveCount(1)
+  await expect(e4bMatchers.first()).toContainText('E4bAlice')
+
+  await page.getByRole('combobox', { name: 'Filter by silence creator' }).selectOption('')
+  await expect(e4bMatchers).toHaveCount(2)
 })
 
 test('E5 matcher filter narrows visible silences', async ({ page, jarvis }) => {

--- a/frontend/src/components/silences/SilenceCard.tsx
+++ b/frontend/src/components/silences/SilenceCard.tsx
@@ -2,6 +2,7 @@ import { BellMinus, Loader2, RotateCcw } from 'lucide-react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { SilenceExpiry } from './SilenceExpiry'
+import { SilenceCreated } from './SilenceCreated'
 import { labelColorStyle } from '@/lib/alertUtils'
 import { TruncatableChip } from '@/components/ui/truncatable-chip'
 import { useSettingsStore } from '@/store/useSettingsStore'
@@ -93,9 +94,15 @@ export function SilenceCard({ silence, alerts, onEdit, onExpire, isDeleting = fa
       </CardHeader>
 
       <CardContent className="space-y-3">
-        <div className="rounded-md border border-border/70 bg-inherit p-2.5">
-          <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">Expires</div>
-          <SilenceExpiry silence={silence} />
+        <div className="grid grid-cols-2 gap-2">
+          <div className="rounded-md border border-border/70 bg-inherit p-2.5">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">Created</div>
+            <SilenceCreated silence={silence} />
+          </div>
+          <div className="rounded-md border border-border/70 bg-inherit p-2.5">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">Expires</div>
+            <SilenceExpiry silence={silence} />
+          </div>
         </div>
 
         <div className="rounded-md border border-border/70 bg-inherit p-2.5">

--- a/frontend/src/components/silences/SilenceCreated.tsx
+++ b/frontend/src/components/silences/SilenceCreated.tsx
@@ -1,0 +1,24 @@
+import { cn, formatDuration } from '@/lib/utils'
+import { ExactDate } from './SilenceExpiry'
+import type { Silence } from '@/types'
+
+interface SilenceCreatedProps {
+  silence: Silence
+  className?: string
+}
+
+/**
+ * When the silence was created (Alertmanager's `updatedAt` — also its
+ * last-edit time, since editing a silence in AM rewrites this field).
+ * Rendered next to `SilenceExpiry` in the card and list views.
+ */
+export function SilenceCreated({ silence, className }: SilenceCreatedProps) {
+  const ago = Date.now() - new Date(silence.updatedAt).getTime()
+
+  return (
+    <div className={cn('flex flex-col gap-0.5', className)}>
+      <ExactDate value={silence.updatedAt} />
+      <span className="text-xs text-muted-foreground">{formatDuration(ago)} ago</span>
+    </div>
+  )
+}

--- a/frontend/src/components/silences/SilenceExpiry.tsx
+++ b/frontend/src/components/silences/SilenceExpiry.tsx
@@ -9,9 +9,9 @@ interface SilenceExpiryProps {
   className?: string
 }
 
-const DATE_FMT = 'MMM d, yyyy HH:mm'
+export const DATE_FMT = 'MMM d, yyyy HH:mm'
 
-function ExactDate({ value }: { value: string }) {
+export function ExactDate({ value }: { value: string }) {
   return (
     <span className="text-xs font-medium text-foreground">
       {format(new Date(value), DATE_FMT, { locale: enUS })} {tzAbbr}

--- a/frontend/src/components/silences/SilenceGroupCard.tsx
+++ b/frontend/src/components/silences/SilenceGroupCard.tsx
@@ -2,6 +2,7 @@ import { BellMinus, Layers3, Loader2, RotateCcw } from 'lucide-react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { SilenceExpiry } from './SilenceExpiry'
+import { SilenceCreated } from './SilenceCreated'
 import { labelColorStyle } from '@/lib/alertUtils'
 import { TruncatableChip } from '@/components/ui/truncatable-chip'
 import { useSettingsStore } from '@/store/useSettingsStore'
@@ -163,9 +164,15 @@ export function SilenceGroupCard({ group, alerts, onEditGroup, onExpireGroup, de
           </div>
         </div>
 
-        <div className="rounded-md border border-border/70 p-2.5">
-          <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">Expires</div>
-          <SilenceExpiry silence={rep} />
+        <div className="grid grid-cols-2 gap-2">
+          <div className="rounded-md border border-border/70 p-2.5">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">Created</div>
+            <SilenceCreated silence={rep} />
+          </div>
+          <div className="rounded-md border border-border/70 p-2.5">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">Expires</div>
+            <SilenceExpiry silence={rep} />
+          </div>
         </div>
 
         {rep.comment && (

--- a/frontend/src/components/silences/SilenceListView.tsx
+++ b/frontend/src/components/silences/SilenceListView.tsx
@@ -1,7 +1,9 @@
 import { BellMinus, Loader2, RotateCcw } from 'lucide-react'
+import { format } from 'date-fns'
+import { enUS } from 'date-fns/locale'
 import { Button } from '@/components/ui/button'
-import { SilenceExpiry } from './SilenceExpiry'
-import { labelColorStyle } from '@/lib/alertUtils'
+import { SilenceExpiry, DATE_FMT } from './SilenceExpiry'
+import { labelColorStyle, tzAbbr } from '@/lib/alertUtils'
 import { useSettingsStore } from '@/store/useSettingsStore'
 import { TruncatableChip } from '@/components/ui/truncatable-chip'
 import type { Silence, EnrichedAlert } from '@/types'
@@ -111,6 +113,10 @@ export function SilenceListView({ groups, alerts, onEditGroup, onExpireGroup, de
                   )}
                   <span className="text-muted-foreground/60">•</span>
                   <span className="truncate text-muted-foreground/80">by {rep.createdBy}</span>
+                  <span className="text-muted-foreground/60">•</span>
+                  <span className="whitespace-nowrap text-muted-foreground/70">
+                    created {format(new Date(rep.updatedAt), DATE_FMT, { locale: enUS })} {tzAbbr}
+                  </span>
                 </div>
 
                 <div className="mb-1 flex flex-wrap items-center gap-1">

--- a/frontend/src/components/silences/SilencesPage.tsx
+++ b/frontend/src/components/silences/SilencesPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
-import { Loader2, X, ArrowUpDown, Search, Maximize2 } from 'lucide-react'
+import { Loader2, X, ArrowUpDown, ArrowUp, ArrowDown, Search, Maximize2, User } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
 import { SilenceCard } from './SilenceCard'
 import { SilenceGroupCard } from './SilenceGroupCard'
 import { SilenceListView } from './SilenceListView'
@@ -16,14 +17,20 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchClusters } from '@/api/client'
 import { useUIStore } from '@/store/uiStore'
 import { MatcherChipsBar } from '@/components/layout/MatcherChipsBar'
-import { filterSilences } from '@/lib/alertUtils'
+import {
+  filterSilences,
+  sortSilences,
+  silenceCreators,
+  defaultSilenceSortDir,
+  type SilenceSortBy,
+  type SilenceSortDir,
+} from '@/lib/alertUtils'
 import { useLoginGuard } from '@/hooks/useLoginGuard'
 import { LoginModal } from '@/components/auth/LoginModal'
 import type { Silence } from '@/types'
 import type { SilenceGroup } from './SilenceGroupCard'
 
 type SheetTab = 'silence' | 'templates'
-type SortBy = 'expires' | 'created'
 
 function silenceGroupKey(s: Silence): string {
   const matchers = [...s.matchers]
@@ -54,8 +61,17 @@ export function SilencesPage() {
 
   const { guard, loginModalOpen, onLoginSuccess, onLoginClose } = useLoginGuard()
   const { silencesViewMode: viewMode, setSilencesViewMode, filters, setFilter, isFullscreen, setIsFullscreen } = useUIStore()
-  const [sortBy, setSortBy] = useState<SortBy>('expires')
+  const [sortBy, setSortByState] = useState<SilenceSortBy>('expires')
+  const [sortDir, setSortDir] = useState<SilenceSortDir>(() => defaultSilenceSortDir('expires'))
+  const [createdByFilter, setCreatedByFilter] = useState('')
   const [showExpired, setShowExpired] = useState(false)
+
+  // Switching the sort key resets to that key's natural direction (soonest
+  // expiry first / newest creation first); the arrow toggle overrides it.
+  function setSortBy(next: SilenceSortBy) {
+    setSortByState(next)
+    setSortDir(defaultSilenceSortDir(next))
+  }
   const [formOpen, setFormOpen] = useState(false)
   const [activeTab, setActiveTab] = useState<SheetTab>('silence')
   const [editSilence, setEditSilence] = useState<Silence | null>(null)
@@ -101,17 +117,13 @@ export function SilencesPage() {
 
   const clusterNames = clusters.map((c) => c.name)
 
-  const base = showExpired ? silences : silences.filter((s) => s.status.state !== 'expired')
-  const filtered = filterSilences(base, filters.search, filters.labelMatchers)
+  const creators = silenceCreators(silences)
+  // Ignore a stale "by" selection whose creator no longer has any silence.
+  const effectiveCreatedBy = creators.includes(createdByFilter) ? createdByFilter : ''
 
-  const sorted = [...filtered].sort((a, b) => {
-    const stateOrder = { active: 0, pending: 1, expired: 2 }
-    const stateDiff = (stateOrder[a.status.state] ?? 3) - (stateOrder[b.status.state] ?? 3)
-    if (stateDiff !== 0) return stateDiff
-    const dateA = sortBy === 'expires' ? new Date(a.endsAt).getTime() : new Date(a.startsAt).getTime()
-    const dateB = sortBy === 'expires' ? new Date(b.endsAt).getTime() : new Date(b.startsAt).getTime()
-    return dateA - dateB
-  })
+  const base = showExpired ? silences : silences.filter((s) => s.status.state !== 'expired')
+  const filtered = filterSilences(base, filters.search, filters.labelMatchers, effectiveCreatedBy)
+  const sorted = sortSilences(filtered, sortBy, sortDir)
 
   const groups = buildGroups(sorted)
 
@@ -178,8 +190,34 @@ export function SilencesPage() {
               >
                 Created
               </button>
+              <button
+                onClick={() => setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
+                className="cursor-pointer flex items-center justify-center h-7 w-7 border-l border-border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                title={sortDir === 'asc' ? 'Ascending — click for descending' : 'Descending — click for ascending'}
+                aria-label="Toggle sort direction"
+              >
+                {sortDir === 'asc' ? <ArrowUp className="h-3.5 w-3.5" /> : <ArrowDown className="h-3.5 w-3.5" />}
+              </button>
             </div>
           </div>
+          {creators.length > 0 && (
+            <div className="flex items-center gap-1">
+              <User className="h-3 w-3 shrink-0 text-muted-foreground" />
+              <Select
+                value={effectiveCreatedBy}
+                onChange={(e) => setCreatedByFilter(e.target.value)}
+                className="h-7 w-28"
+                selectClassName="h-7 py-0 text-xs"
+                placeholder="Anyone"
+                title="Filter by silence creator"
+                aria-label="Filter by silence creator"
+              >
+                {creators.map((c) => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </Select>
+            </div>
+          )}
           <ViewToggle value={viewMode} onChange={setSilencesViewMode} />
           <Button
             variant="outline"

--- a/frontend/src/lib/alertUtils.test.ts
+++ b/frontend/src/lib/alertUtils.test.ts
@@ -23,6 +23,9 @@ import {
   computeGroupLabelValues,
   buildGroupAckSilenceBody,
   filterSilences,
+  silenceCreators,
+  sortSilences,
+  defaultSilenceSortDir,
   getExpiredSilence,
   labelColorStyle,
   unescapeRegex,
@@ -932,6 +935,20 @@ describe('filterSilences', () => {
     expect(filterSilences(silences, 'bob', []).map((s) => s.id)).toEqual(['s2'])
   })
 
+  it('filters by exact createdBy when the "by" argument is set', () => {
+    expect(filterSilences(silences, '', [], 'alice').map((s) => s.id)).toEqual(['s1'])
+    expect(filterSilences(silences, '', [], 'bob').map((s) => s.id)).toEqual(['s2'])
+  })
+
+  it('ignores an empty "by" argument', () => {
+    expect(filterSilences(silences, '', [], '')).toEqual(silences)
+  })
+
+  it('combines the "by" argument with search and label matchers', () => {
+    expect(filterSilences(silences, 'planned', [], 'alice').map((s) => s.id)).toEqual(['s1'])
+    expect(filterSilences(silences, 'planned', [], 'bob')).toEqual([])
+  })
+
   it('filters by matcher name or value substring', () => {
     expect(filterSilences(silences, 'web1', []).map((s) => s.id)).toEqual(['s2'])
   })
@@ -977,6 +994,65 @@ describe('filterSilences', () => {
   it('combines search and label matchers with AND', () => {
     const fm: LabelMatcher = { id: '1', name: '@cluster', operator: '=', value: 'cluster-a' }
     expect(filterSilences(silences, 'web1', [fm])).toEqual([])
+  })
+})
+
+describe('defaultSilenceSortDir', () => {
+  it('defaults expires ascending and created descending', () => {
+    expect(defaultSilenceSortDir('expires')).toBe('asc')
+    expect(defaultSilenceSortDir('created')).toBe('desc')
+  })
+})
+
+describe('sortSilences', () => {
+  const a = makeSilence({ id: 'a', status: { state: 'active' }, updatedAt: '2026-01-01T10:00:00Z', endsAt: '2026-02-01T00:00:00Z' })
+  const b = makeSilence({ id: 'b', status: { state: 'expired' }, updatedAt: '2026-01-03T10:00:00Z', endsAt: '2026-01-04T00:00:00Z' })
+  const c = makeSilence({ id: 'c', status: { state: 'pending' }, updatedAt: '2026-01-02T10:00:00Z', endsAt: '2026-03-01T00:00:00Z' })
+
+  it('sorts by creation time, newest first (created/desc) regardless of lifecycle state', () => {
+    expect(sortSilences([a, b, c], 'created', 'desc').map((s) => s.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('sorts by creation time, oldest first (created/asc)', () => {
+    expect(sortSilences([a, b, c], 'created', 'asc').map((s) => s.id)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('sorts by expiry time (expires/asc = soonest first)', () => {
+    expect(sortSilences([a, b, c], 'expires', 'asc').map((s) => s.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('sorts by expiry time (expires/desc = latest first)', () => {
+    expect(sortSilences([a, b, c], 'expires', 'desc').map((s) => s.id)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('breaks exact timestamp ties by lifecycle state then id', () => {
+    const x = makeSilence({ id: 'x', status: { state: 'expired' }, updatedAt: '2026-01-01T00:00:00Z' })
+    const y = makeSilence({ id: 'y', status: { state: 'active' }, updatedAt: '2026-01-01T00:00:00Z' })
+    const z = makeSilence({ id: 'z', status: { state: 'active' }, updatedAt: '2026-01-01T00:00:00Z' })
+    expect(sortSilences([x, y, z], 'created', 'desc').map((s) => s.id)).toEqual(['y', 'z', 'x'])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [a, b, c]
+    sortSilences(input, 'created', 'desc')
+    expect(input.map((s) => s.id)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('silenceCreators', () => {
+  it('returns distinct creators sorted alphabetically', () => {
+    const silences = [
+      makeSilence({ id: 's1', createdBy: 'charlie' }),
+      makeSilence({ id: 's2', createdBy: 'alice' }),
+      makeSilence({ id: 's3', createdBy: 'charlie' }),
+      makeSilence({ id: 's4', createdBy: 'bob' }),
+    ]
+    expect(silenceCreators(silences)).toEqual(['alice', 'bob', 'charlie'])
+  })
+
+  it('skips blank creators and returns [] for an empty list', () => {
+    expect(silenceCreators([])).toEqual([])
+    expect(silenceCreators([makeSilence({ createdBy: '' })])).toEqual([])
   })
 })
 

--- a/frontend/src/lib/alertUtils.ts
+++ b/frontend/src/lib/alertUtils.ts
@@ -250,12 +250,30 @@ export function silenceWouldMatchAlert(matchers: LabelMatcher[], alert: Enriched
 
 // ── Silence filtering ─────────────────────────────────────────────────────
 
+/**
+ * Distinct, alphabetically sorted `createdBy` values across the given
+ * silences — feeds the silences-only "by" filter dropdown. Blank creators
+ * are skipped.
+ */
+export function silenceCreators(silences: Silence[]): string[] {
+  const set = new Set<string>()
+  for (const s of silences) {
+    if (s.createdBy) set.add(s.createdBy)
+  }
+  return Array.from(set).sort((a, b) => a.localeCompare(b))
+}
+
 export function filterSilences(
   silences: Silence[],
   search: string,
   labelMatchers: LabelMatcher[],
+  createdBy?: string,
 ): Silence[] {
   let result = silences
+
+  if (createdBy) {
+    result = result.filter((s) => s.createdBy === createdBy)
+  }
 
   if (search) {
     const q = search.toLowerCase()
@@ -294,6 +312,42 @@ export function filterSilences(
   }
 
   return result
+}
+
+// ── Silence sorting ───────────────────────────────────────────────────────
+
+export type SilenceSortBy = 'expires' | 'created'
+export type SilenceSortDir = 'asc' | 'desc'
+
+/** Natural default direction per sort key: soonest expiry first, newest creation first. */
+export function defaultSilenceSortDir(sortBy: SilenceSortBy): SilenceSortDir {
+  return sortBy === 'expires' ? 'asc' : 'desc'
+}
+
+/**
+ * Sorts silences by the chosen timestamp and direction. The explicit sort
+ * takes precedence over the active/pending/expired lifecycle order — that
+ * only breaks exact timestamp ties (then `id`, for a stable total order).
+ * "created" sorts by `updatedAt` (Alertmanager's create/last-edit time),
+ * never `startsAt` — a silence scheduled to start in the future was still
+ * created now.
+ */
+export function sortSilences(
+  silences: Silence[],
+  sortBy: SilenceSortBy,
+  dir: SilenceSortDir,
+): Silence[] {
+  const stateOrder: Record<Silence['status']['state'], number> = { active: 0, pending: 1, expired: 2 }
+  const factor = dir === 'asc' ? 1 : -1
+  const ts = (s: Silence) =>
+    new Date(sortBy === 'expires' ? s.endsAt : s.updatedAt).getTime()
+  return [...silences].sort((a, b) => {
+    const diff = ts(a) - ts(b)
+    if (diff !== 0) return diff * factor
+    const stateDiff = stateOrder[a.status.state] - stateOrder[b.status.state]
+    if (stateDiff !== 0) return stateDiff
+    return a.id.localeCompare(b.id)
+  })
 }
 
 // ── Effective alert state ─────────────────────────────────────────────────


### PR DESCRIPTION
## Silences tab

**a) Creation timestamp** — each silence now shows when it was created (Alertmanager's `updatedAt`, i.e. the create/last-edit time — AM has no dedicated created-at field) next to the expiry, in the card, group card and list views (`SilenceCreated` component).

**b) "Created" sort fix** — it sorted by `startsAt`, which is the mute-window *schedule start* and can be set into the future (pending silences) or the past, so a freshly created silence landed mid-list. `sortSilences()` in `lib/alertUtils.ts` now sorts "Created" by `updatedAt`. The explicit sort also takes precedence over the active→pending→expired lifecycle order (that order is only a timestamp-tie breaker now), so sorting by a date puts that date's newest/oldest entry where you expect it.

**c) ASC/DESC toggle** — arrow button next to the Expires/Created buttons. Switching the sort key resets to its natural default (expires ascending, created descending); the arrow overrides.

**d) "By" filter** — a creator dropdown in the silences toolbar only (person icon, fixed width). `silenceCreators()` + a 4th exact-match arg on `filterSilences()`.

## Tests / docs

- `alertUtils.test.ts`: `sortSilences`, `defaultSilenceSortDir`, `silenceCreators`, `filterSilences` by-arg (100% coverage gate green)
- E2E `silences-page.spec.ts`: E4 rewritten (sort key + direction), new E4b (creator dropdown)
- Synced `.agents/architecture.md`, `.agents/lessons.md`, `docs/testing-e2e.md`

## Verification

`pnpm test:unit:coverage`, `pnpm build`, `pnpm lint`, `pnpm duplication`, and the `none` E2E functional suite (134 passed) all green locally.