### PR TITLE
feat(frontend): settings colophon + narrower sheet

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1122,7 +1122,8 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
     │   └── SilenceTemplateTab.tsx → template CRUD + apply-to-form
     ├── settings/
     │   └── SettingsSheet.tsx  → time format, default view, resolved page size, default filters,
-    │                            default silence duration, creator name, claim animation, theme
+    │                            default silence duration, creator name, claim animation, theme;
+    │                            brand footer at the bottom (centred /logo.png + version from useVersion)
     ├── auth/
     │   ├── LoginModal.tsx     → on-demand login (write_protect)
     │   ├── LoginPage.tsx      → full-page login (full_protect)

--- a/docs/testing-e2e.md
+++ b/docs/testing-e2e.md
@@ -244,7 +244,7 @@ Quick reference: which spec file covers what. Use this to find the right place f
 | `silences-form-extended.spec.ts` | F3–F16 | Operator switch, regex tags+escaping, live match count, overlap warning, zero-match warning, duration presets, spinner normalisation, inline calendar, Now/Reset, end-after-start validation, author editability, reason required, preview summary, results step |
 | `silences-form-templates.spec.ts` | F1–F2, F14–F15, F17, G4–G8 | Form open/close (Cancel/ESC/backdrop), cluster guard, templates CRUD (create/apply/edit/delete) |
 | `silence-matching-semantics.spec.ts` | — | Differential tests against the real Alertmanager instance: form preview's affected-alerts count and actual post-submit suppression must agree — anchored `=~`/`!~` regex (not substring), regex-OR matcher escaping with metacharacter label values |
-| `settings.spec.ts` | H1–H11 (H8 removed) | All settings: timeFormat, defaultViewMode, resolvedPageSize, defaultFilters, silenceDuration, defaultCreatorName, claimAnimation, reset defaults, persistence |
+| `settings.spec.ts` | H1–H11 (H8 removed), H1b | All settings: timeFormat, defaultViewMode, resolvedPageSize, defaultFilters, silenceDuration, defaultCreatorName, claimAnimation, reset defaults, persistence; brand footer (logo + version) |
 | `no-auth-notice.spec.ts` | I1 | NoAuth notice appears and dismiss persists |
 | `websocket.spec.ts` | J1–J4 | Reconnect indicator (force-close via patched WebSocket), `alerts_update` / `claim_set` / `claim_released` / `comment_added` live events |
 

--- a/frontend/e2e/functional/none/settings.spec.ts
+++ b/frontend/e2e/functional/none/settings.spec.ts
@@ -21,6 +21,20 @@ test('H1 settings panel opens via gear icon and shows Settings heading', async (
   await expect(dialog.getByText('Silences')).toBeVisible()
 })
 
+test('H1b settings footer shows the Jarvis logo and version', async ({ page }) => {
+  await dismissNoAuthNotice(page)
+  await page.route('**/api/v1/info', (route) =>
+    route.fulfill({ json: { version: 'v9.9.9' } }),
+  )
+  await page.goto('/')
+
+  const dialog = await openSettings(page)
+  const logo = dialog.getByRole('img', { name: 'Jarvis' })
+  await logo.scrollIntoViewIfNeeded()
+  await expect(logo).toBeVisible()
+  await expect(dialog.getByText('v9.9.9')).toBeVisible()
+})
+
 test('H2 timeFormat toggle switches between Relative and Absolute', async ({ page }) => {
   await dismissNoAuthNotice(page)
   await page.addInitScript(() => {

--- a/frontend/src/components/settings/SettingsSheet.tsx
+++ b/frontend/src/components/settings/SettingsSheet.tsx
@@ -264,18 +264,10 @@ export function SettingsSheet({ open, onClose }: SettingsSheetProps) {
   }
 
   return (
-    <Sheet open={open} onClose={onClose} className="sm:max-w-sm" ariaLabel="Settings">
-      <div className="p-5 pt-10 space-y-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold">Settings</h2>
-          {version && (
-            <span className="text-[10px] font-mono text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-              {version}
-            </span>
-          )}
-        </div>
-
-        <>
+    <Sheet open={open} onClose={onClose} className="sm:max-w-lg lg:max-w-lg" ariaLabel="Settings">
+      <div className="flex min-h-full flex-col p-5 pt-10">
+        <div className="space-y-6">
+        <h2 className="text-base font-semibold">Settings</h2>
 
         {/* ── Display ── */}
         <Section title="Display">
@@ -457,22 +449,44 @@ export function SettingsSheet({ open, onClose }: SettingsSheetProps) {
 
         <div className="h-px bg-border" />
 
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleReset}
+          className={cn(
+            'w-full text-xs gap-1.5',
+            confirmReset && 'border-destructive text-destructive hover:bg-destructive/10',
+          )}
+        >
+          <RotateCcw className="h-3 w-3" />
+          {confirmReset ? 'Click again to confirm reset' : 'Reset to defaults'}
+        </Button>
+        </div>
 
-        {/* ── Footer ── */}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleReset}
-            className={cn(
-              'w-full text-xs gap-1.5',
-              confirmReset && 'border-destructive text-destructive hover:bg-destructive/10',
-            )}
+        {/* ── Colophon ── */}
+        <footer className="mt-auto flex flex-col items-center gap-3 border-t border-border/60 pt-8 text-center">
+          <a
+            href="https://github.com/kj187/jarvis"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex flex-col items-center gap-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <RotateCcw className="h-3 w-3" />
-            {confirmReset ? 'Click again to confirm reset' : 'Reset to defaults'}
-          </Button>
-        </>
+            <img
+              src="/logo.png"
+              alt="Jarvis"
+              width={120}
+              height={120}
+              className="h-28 w-28 select-none opacity-80 transition-opacity group-hover:opacity-100"
+              draggable={false}
+            />
+            <span className="text-sm font-semibold tracking-tight text-foreground/90">Jarvis</span>
+          </a>
+          <div className="space-y-0.5 text-[11px] leading-relaxed text-muted-foreground/70">
+            <p className="font-mono">{version ?? 'dev'} · Apache-2.0</p>
+            <p>© 2026 Julian Kleinhans</p>
+          </div>
+        </footer>
       </div>
     </Sheet>
   )


### PR DESCRIPTION
## Settings sheet

- **Brand colophon** pinned to the bottom of the panel: Jarvis logo + wordmark (links to the GitHub repo), then `<version> · Apache-2.0` and `© 2026 Julian Kleinhans` — the copyright line already declared in `NOTICE`.
- The version badge that sat next to the "Settings" heading is removed (now in the colophon).
- **Width** cut from the inherited `lg:max-w-4xl` (~896px — half the screen) to `max-w-lg` (512px).
- Cleaned up a stray `<>` fragment in the JSX.

## Tests / docs

- `settings.spec.ts` **H1b** — asserts the footer logo (`role=img` "Jarvis") and version render in the dialog.
- `.agents/architecture.md`, `docs/testing-e2e.md` synced.

## Verification

`pnpm build` + `pnpm lint` green locally (0 errors). E2E via CI.