### PR TITLE
chore(release): prepare v1.11.0

### DIFF
--- a/.github/release-notes/v1.11.0.md
+++ b/.github/release-notes/v1.11.0.md
@@ -1,0 +1,45 @@
+## What's changed
+
+A reworked Silences tab and a round of PostgreSQL multi-replica reliability fixes.
+
+### Added
+
+- **Silences card & list redesign.** Silence tiles now have a clear
+  hierarchy: a compact identity zone (urgency dot, cluster, by/affected line,
+  quiet matcher chips, comment as a short quote) over a lifetime bar that
+  tracks the `startsAt → endsAt` window with a remaining-time label. The list
+  view switched to dense rows — roughly a third of the previous height, so
+  many more silences fit on screen.
+- **Silence creation time everywhere.** The create / last-edit timestamp
+  (Alertmanager's `updatedAt`) is now shown next to expiry in the card, group
+  card and list views.
+- **Silences sorting controls.** An ASC/DESC direction toggle next to the
+  Expires/Created buttons, and explicit sort now takes precedence over the
+  active/pending/expired lifecycle ordering, so sorting by a date puts that
+  date's newest/oldest entry where you expect it.
+- **"By:" creator filter** in the silences toolbar to narrow the list to a
+  single silence author.
+- **Brand colophon in Settings.** The version badge moved into a pinned
+  footer with the Jarvis logo/wordmark, version, licence and copyright line;
+  the settings sheet is now a sensible 512px wide instead of half the screen.
+
+### Fixed
+
+- **Claim banner flicker on multi-replica PostgreSQL.** Claiming an alert
+  briefly showed the banner, then lost it until the next poll cycle — a
+  follower's snapshot rebuild overwrote the just-applied claim. Followers now
+  re-read active claims from the shared database on every snapshot rebuild.
+- **"Created" sort for silences** read the schedule start (`startsAt`, which
+  can be in the future for pending silences), landing fresh silences
+  mid-list. It now sorts by `updatedAt`.
+- **Deterministic alert snapshot ordering** — `GET /api/v1/alerts`,
+  `/api/v1/alerts/groups` and the WS `alerts_update` broadcast now return
+  alerts in a stable order (`startsAt` desc, then fingerprint, then cluster),
+  so alert rows inside a group no longer flicker on each refresh.
+
+### Changed
+
+- **Go toolchain upgraded to 1.26** (`golang.org/x/crypto` v0.56.0 requires
+  it); CI, CodeQL and the container images move to Go 1.26 as well.
+
+**Full diff:** [v1.10.1...v1.11.0](https://github.com/kj187/jarvis/compare/v1.10.1...v1.11.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+<a name="v1.11.0"></a>
+## [v1.11.0](https://github.com/kj187/jarvis/compare/v1.10.1...v1.11.0) (2026-09-09)
+
+### Bug Fixes
+
+* **alerts:** return alert snapshot in a deterministic order ([#170](https://github.com/kj187/jarvis/issues/170))
+* **claims:** re-hydrate active claims on follower snapshot rebuild ([#176](https://github.com/kj187/jarvis/issues/176))
+* **db:** isolate leader advisory lock per test, acquire it immediately ([#181](https://github.com/kj187/jarvis/issues/181))
+
+### Chores
+
+* **deps:** bump pnpm/action-setup from 6.0.10 to 6.1.0 ([#175](https://github.com/kj187/jarvis/issues/175))
+* **deps:** bump golang.org/x/time from 0.15.0 to 0.16.0 in /backend ([#172](https://github.com/kj187/jarvis/issues/172))
+* **deps:** bump golang.org/x/oauth2 from 0.36.0 to 0.37.0 in /backend ([#173](https://github.com/kj187/jarvis/issues/173))
+* **deps:** upgrade Go toolchain to 1.26, bump golang.org/x/crypto to v0.56.0 ([#171](https://github.com/kj187/jarvis/issues/171))
+* **deps:** bump the minor-patch group in /frontend with 5 updates ([#165](https://github.com/kj187/jarvis/issues/165))
+* **deps:** bump anchore/sbom-action/download-syft ([#169](https://github.com/kj187/jarvis/issues/169))
+* **deps:** bump docker/setup-qemu-action from 4.2.0 to 4.3.0 ([#168](https://github.com/kj187/jarvis/issues/168))
+* **deps:** bump docker/setup-buildx-action from 4.2.0 to 4.3.0 ([#167](https://github.com/kj187/jarvis/issues/167))
+* **deps:** bump the codeql-action group with 4 updates ([#166](https://github.com/kj187/jarvis/issues/166))
+* **deps:** bump github.com/coreos/go-oidc/v3 in /backend ([#164](https://github.com/kj187/jarvis/issues/164))
+* **deps-dev:** bump [@playwright](https://github.com/playwright)/test from 1.62.1 to 1.63.0 in /frontend in the minor-patch group ([#174](https://github.com/kj187/jarvis/issues/174))
+
+### Documentation
+
+* regenerate settings-panel screenshot for the new colophon ([#180](https://github.com/kj187/jarvis/issues/180))
+
+### Features
+
+* **frontend:** add brand colophon to settings, narrow the sheet ([#179](https://github.com/kj187/jarvis/issues/179))
+* **silences:** redesign card (lifetime bar) and list (dense rows) ([#178](https://github.com/kj187/jarvis/issues/178))
+* **silences:** show creation time, fix Created sort, add direction toggle & "by" filter ([#177](https://github.com/kj187/jarvis/issues/177))
+
 <a name="v1.10.1"></a>
 ## [v1.10.1](https://github.com/kj187/jarvis/compare/v1.10.0...v1.10.1) (2026-09-05)
 
@@ -11,6 +44,7 @@
 * **deps:** bump actions/attest-build-provenance from 4.1.1 to 4.2.2 ([#146](https://github.com/kj187/jarvis/issues/146))
 * **deps:** bump the codeql-action group with 4 updates ([#145](https://github.com/kj187/jarvis/issues/145))
 * **deps:** bump pnpm/action-setup from 6.0.9 to 6.0.10 ([#150](https://github.com/kj187/jarvis/issues/150))
+* **release:** prepare v1.10.1
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All you need is Podman or Docker — no installation, no build step. Create a `c
 ```yaml
 services:
   jarvis:
-    image: ghcr.io/kj187/jarvis:1.10.1
+    image: ghcr.io/kj187/jarvis:1.11.0
     ports:
       - "8080:8080"
     volumes:
@@ -99,7 +99,7 @@ Now open http://localhost:8080
 
 ```bash
 helm install jarvis oci://ghcr.io/kj187/charts/jarvis \
-  --version 1.10.1 \
+  --version 1.11.0 \
   --set clusters[0].name=dev \
   --set clusters[0].alertmanagerUrl=http://alertmanager:9093 \
   --set database.dsn='postgres://jarvis:secret@postgres.monitoring.svc:5432/jarvis?sslmode=require'

--- a/charts/jarvis/Chart.yaml
+++ b/charts/jarvis/Chart.yaml
@@ -4,10 +4,10 @@ description: Web frontend for Prometheus Alertmanager with persistent alert hist
 type: application
 # Chart version — decoupled from the app version. Bump it manually in the same
 # commit as any chart change; a push to main publishes it (chart-release.yml).
-version: 1.7.5
+version: 1.7.6
 # App version — the image tag deployed by default. Bumped as part of the app
 # release process (see .agents/release.md).
-appVersion: "1.10.1"
+appVersion: "1.11.0"
 keywords:
   - alertmanager
   - prometheus


### PR DESCRIPTION
Release preparation for v1.11.0 (changelog, release notes, README, chart bump).