### PR TITLE
docs(release): forbid hard-wrapping release-notes prose

### DIFF
--- a/.agents/release.md
+++ b/.agents/release.md
@@ -128,6 +128,12 @@ Write the notes file in English, derived from the CHANGELOG section and the
 actual commits (read them — don't just reformat commit subjects). No
 artifact/verify sections — the workflow appends those.
 
+**Do not hard-wrap prose.** One paragraph or bullet = one physical line, no
+matter how long. GitHub reflows release bodies to the reader's viewport;
+manual line breaks (or a fixed ~72/80-column fill) render as a cramped,
+ragged narrow column on the release page. This applies to the blurb,
+`### Added`/`### Fixed`/… bullets, and every other line of prose in the file.
+
 **Template A — Initial / major release (v1.0.0, v2.0.0, …)**
 
 ```markdown


### PR DESCRIPTION
## What

Adds a rule to the "Release-Notes Templates" section of `.agents/release.md`: release-notes prose must not be hard-wrapped — one physical line per paragraph/bullet.

## Why

GitHub reflows the release body to the reader's viewport. The v1.11.0 notes were filled to ~72 columns, so the manual line breaks rendered as a cramped, ragged narrow column on the release page (visibly worse than v1.10.1, which was full-width).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)