### PR TITLE
feat(alerts): multi-column card grid, recency sort, columns setting

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -970,9 +970,24 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
     │                            promoted from draft to a committed filter chip
     ├── alerts/
     │   ├── AlertsPage.tsx     → useWebSocket, filter/search, card|list + detail panel, fullscreen, pagination
-    │   ├── AlertCardGrid.tsx  → grouped by settings `groupByLabel` (default severity), responsive
-    │   │                        column binning, per-group pagination, drag-and-drop section
-    │   │                        reordering (persisted: 'jarvis-card-section-order:<label>')
+    │   ├── AlertCardGrid.tsx  → grouped by settings `groupByLabel` (default severity), per-group
+    │   │                        pagination, drag-and-drop section reordering (persisted:
+    │   │                        'jarvis-card-section-order:<label>'). Within a section, groups sort
+    │   │                        by freshness (most recently fired first, `latestStartsAt`) — not
+    │   │                        alphabetically — same convention as the backend's flat alert list
+    │   │                        (AlertStore.Get(), startsAt desc). Cards lay out via CSS multi-column
+    │   │                        (`columnCount` inline style, `useColumns()` for the responsive
+    │   │                        1/2/3/4 breakpoint, `break-inside-avoid` per card) instead of a
+    │   │                        hand-rolled height-estimate bin-packer — the browser balances by real
+    │   │                        rendered height (collapsed state, claim notes, pagination, all of it)
+    │   │                        with no estimate to keep in sync. `useColumns()` returns
+    │   │                        `settings.cardColumns` directly when it's a fixed number (1-6),
+    │   │                        overriding the responsive breakpoint on every screen size — only
+    │   │                        'auto' (the default) uses the breakpoint. Either way `columnCount` is
+    │   │                        then capped to `min(that value, group count)` — same for the ungrouped
+    │   │                        flat grid's own column count — so a section with fewer groups than
+    │   │                        columns doesn't squeeze its cards into a fraction width with empty space next
+    │   │                        to them; a lone group gets the full row.
     │   ├── AlertCard.tsx      → card + claim info + count badge + silence/detail actions + Fast-Silence (hover);
     │   │                        common labels (shared by the whole group) render as a `muted`
     │   │                        LabelChip strip above the entries; multi-alert groups: each entry
@@ -1204,11 +1219,19 @@ App.tsx               → auth-gated shell: SetupPage / LoginPage (full_protect)
     │   ├── MatcherEditor.tsx  → matcher rows: operators + tag multi-value + suggestions
     │   └── SilenceTemplateTab.tsx → template CRUD + apply-to-form
     ├── settings/
-    │   └── SettingsSheet.tsx  → time format, default view, resolved page size, default filters,
-    │                            default silence duration, creator name, claim animation. No brand
-    │                            footer — logo/version/copyright live in the header's info popover
-    │                            (layout/Header.tsx) instead. Theme lives in useSettingsStore but is
-    │                            only toggled from the header's user menu, not from this sheet.
+    │   └── SettingsSheet.tsx  → Display: time format, default view, card columns, group-by label,
+    │                            claim animation. Default Filter: add/remove locked header chips.
+    │                            Silences: default duration only. `resolvedPageSize` and
+    │                            `defaultCreatorName` live in the same useSettingsStore but are NOT
+    │                            editable here — resolvedPageSize is set via the "Per page" buttons in
+    │                            AlertListView.tsx's resolved view; defaultCreatorName has no writer
+    │                            anywhere in the frontend (only ever read as a fallback in
+    │                            SilenceForm.tsx / useSilences.ts, always resolves to its default ''
+    │                            unless set directly in localStorage) — dead settings-store field, not
+    │                            wired to any UI. No brand footer — logo/version/copyright live in the
+    │                            header's info popover (layout/Header.tsx) instead. Theme lives in
+    │                            useSettingsStore but is only toggled from the header's user menu, not
+    │                            from this sheet.
     ├── auth/
     │   ├── LoginModal.tsx     → on-demand login (write_protect)
     │   ├── LoginPage.tsx      → full-page login (full_protect)
@@ -1260,6 +1283,8 @@ interface UserSettings {
   timeFormat: 'relative' | 'absolute'           // default 'relative'
   defaultViewMode: 'card' | 'list'              // default 'card'
   groupByLabel: string                          // card/list grouping label; default 'severity'
+  cardColumns: 'auto' | 1 | 2 | 3 | 4 | 5 | 6    // Card view column count override; default 'auto'
+                                                 // (responsive 1/2/3/4 breakpoint, AlertCardGrid.tsx useColumns())
   defaultFilters: DefaultFilter[]               // locked header chips; default []
   resolvedPageSize: 10 | 25 | 50 | 100          // default 25
   defaultSilenceDurationMinutes: number         // default 60; ALLOWED_SILENCE_DURATIONS = [15,30,60,240,480,1440,4320]

--- a/frontend/e2e/functional/none/alerts-views-extended.spec.ts
+++ b/frontend/e2e/functional/none/alerts-views-extended.spec.ts
@@ -11,10 +11,12 @@ test('B7 responsive column binning: 2 columns at sm width', async ({ page, am, j
   await page.goto('/?state=active')
   await expect(page.getByTestId('alert-card').first()).toBeVisible()
 
-  // Grid renders sections with `.flex.gap-3` column containers.
-  // Count direct `.flex-1` children of the first column container.
-  const firstColumnRow = page.locator('.flex.gap-3').first()
-  await expect(firstColumnRow.locator('> .flex-1')).toHaveCount(2)
+  // Sections lay out cards via CSS multi-column (`columnCount` inline
+  // style) instead of `.flex-1` column divs. The first section (CRITICAL)
+  // has more groups than any breakpoint's column count, so its columnCount
+  // reflects the responsive breakpoint, not the per-section group-count cap.
+  const columns = page.getByTestId('card-grid-columns').first()
+  await expect(columns).toHaveCSS('column-count', '2')
 })
 
 test('B7 responsive column binning: 1 column at xs width', async ({ page, am, jarvis }) => {
@@ -26,8 +28,8 @@ test('B7 responsive column binning: 1 column at xs width', async ({ page, am, ja
   await page.goto('/?state=active')
   await expect(page.getByTestId('alert-card').first()).toBeVisible()
 
-  const firstColumnRow = page.locator('.flex.gap-3').first()
-  await expect(firstColumnRow.locator('> .flex-1')).toHaveCount(1)
+  const columns = page.getByTestId('card-grid-columns').first()
+  await expect(columns).toHaveCSS('column-count', '1')
 })
 
 test('B8 empty state icon shown when no alerts', async ({ page }) => {

--- a/frontend/src/components/alerts/AlertCardGrid.tsx
+++ b/frontend/src/components/alerts/AlertCardGrid.tsx
@@ -421,7 +421,7 @@ export function AlertCardGrid({
               // browser balances by real rendered height (collapsed cards,
               // "show more" state, claim notes and all), not a height
               // estimate that has to be kept in sync with every card change.
-              <div className="gap-3" style={{ columnCount: sectionCols }}>
+              <div data-testid="card-grid-columns" className="gap-3" style={{ columnCount: sectionCols }}>
                 {sectionGroups.map((group) => (
                   <div key={`${group.groupValue}:${group.alertname}`} className="mb-3 break-inside-avoid">
                     <AlertCard

--- a/frontend/src/components/alerts/AlertCardGrid.tsx
+++ b/frontend/src/components/alerts/AlertCardGrid.tsx
@@ -42,66 +42,32 @@ const SEVERITY_DOT: Record<string, string> = {
   none: 'bg-slate-500',
 }
 
-const PAGE_SIZE = 3
+function computeAutoColumns(): number {
+  const w = window.innerWidth
+  if (w >= 1536) return 4
+  if (w >= 1280) return 3
+  if (w >= 640) return 2
+  return 1
+}
 
+// Settings' `cardColumns` overrides the responsive breakpoint on every
+// screen size when set to a fixed number; 'auto' (the default) keeps the
+// existing 1/2/3/4 behavior.
 function useColumns(): number {
-  const [cols, setCols] = useState(() => {
-    const w = window.innerWidth
-    if (w >= 1536) return 4
-    if (w >= 1280) return 3
-    if (w >= 640) return 2
-    return 1
-  })
+  const cardColumns = useSettingsStore((s) => s.cardColumns)
+  const [autoCols, setAutoCols] = useState(computeAutoColumns)
   useEffect(() => {
-    const update = () => {
-      const w = window.innerWidth
-      if (w >= 1536) setCols(4)
-      else if (w >= 1280) setCols(3)
-      else if (w >= 640) setCols(2)
-      else setCols(1)
-    }
+    const update = () => setAutoCols(computeAutoColumns())
     window.addEventListener('resize', update)
     return () => window.removeEventListener('resize', update)
   }, [])
-  return cols
+  return cardColumns === 'auto' ? autoCols : cardColumns
 }
 
-// Rough height estimate in pixels for bin-packing.
-// Avoids DOM measurement; good enough for balanced distribution.
-function estimateHeight(group: CardGroup, silences: Silence[]): number {
-  const visibleEntries = Math.min(group.alerts.length, PAGE_SIZE)
-  let h = 40 // card header
-  for (let i = 0; i < visibleEntries; i++) {
-    const alert = group.alerts[i]
-    h += 20 // timestamp row
-    // silence banner
-    const silenced = alert.status.silencedBy.some((id) =>
-      silences.find((s) => s.id === id && s.status.state !== 'expired'),
-    )
-    if (silenced) h += 48
-    const labelCount = Object.keys(alert.labels).length
-    h += Math.ceil(labelCount / 4) * 22 // label chips (wrap estimate)
-    if (alert.annotations['summary']) h += 18
-    if (alert.annotations['description']) h += 18
-    h += 8 // entry padding + gap
-  }
-  if (group.alerts.length > PAGE_SIZE) h += 44 // pagination bar
-  return h
-}
-
-// Greedy bin-packing that preserves incoming order.
-function distributeColumns(groups: CardGroup[], silences: Silence[], numCols: number): CardGroup[][] {
-  const cols: CardGroup[][] = Array.from({ length: numCols }, () => [])
-  const heights = Array(numCols).fill(0)
-  for (const group of groups) {
-    let minIdx = 0
-    for (let i = 1; i < numCols; i++) {
-      if (heights[i] < heights[minIdx]) minIdx = i
-    }
-    cols[minIdx].push(group)
-    heights[minIdx] += estimateHeight(group, silences)
-  }
-  return cols
+// Most recent `startsAt` across a group's alerts — used to sort groups within
+// a section by freshness instead of alphabetically (see the group sort below).
+function latestStartsAt(group: CardGroup): number {
+  return Math.max(...group.alerts.map((a) => new Date(a.startsAt).getTime()))
 }
 
 function loadStoredArray(key: string): string[] {
@@ -213,8 +179,10 @@ export function AlertCardGrid({
     if (flatAlerts.length === 0) {
       return <EmptyState />
     }
-    const cols: EnrichedAlert[][] = Array.from({ length: numCols }, () => [])
-    flatAlerts.forEach((alert, i) => cols[i % numCols].push(alert))
+    // Never more columns than alerts — same reasoning as the grouped view.
+    const flatCols = Math.max(1, Math.min(numCols, flatAlerts.length))
+    const cols: EnrichedAlert[][] = Array.from({ length: flatCols }, () => [])
+    flatAlerts.forEach((alert, i) => cols[i % flatCols].push(alert))
     return (
       <>
         <div className="flex gap-3">
@@ -265,7 +233,11 @@ export function AlertCardGrid({
     }
   }
 
-  // Sort groups by configured label, then alertname
+  // Sort groups by configured label, then by freshness (most recently fired
+  // group first) — alphabetical order put the oldest and newest problems
+  // next to each other for no reason; recency is what actually matters when
+  // scanning for what to triage first. Same convention the backend already
+  // uses for the flat alert list (AlertStore.Get(), startsAt desc).
   const groups = Array.from(groupMap.values()).sort((a, b) => {
     if (groupByLabel === 'severity') {
       const severityDiff = severityOrder(a.groupValue) - severityOrder(b.groupValue)
@@ -274,6 +246,8 @@ export function AlertCardGrid({
       const labelDiff = a.groupValue.localeCompare(b.groupValue)
       if (labelDiff !== 0) return labelDiff
     }
+    const recencyDiff = latestStartsAt(b) - latestStartsAt(a)
+    if (recencyDiff !== 0) return recencyDiff
     return a.alertname.localeCompare(b.alertname)
   })
 
@@ -396,7 +370,9 @@ export function AlertCardGrid({
       )}
       {orderedGroupValues.map((groupValue, sectionIdx) => {
         const sectionGroups = byGroupValue.get(groupValue) ?? []
-        const distributed = distributeColumns(sectionGroups, silences, numCols)
+        // Never more columns than groups — a lone CRITICAL card shouldn't be
+        // squeezed into 1/4 width with 3/4 of the row empty next to it.
+        const sectionCols = Math.max(1, Math.min(numCols, sectionGroups.length))
         const isCollapsed = collapsedSections.has(groupValue)
         const sectionAlertCount = sectionGroups.reduce((sum, g) => sum + g.alerts.length, 0)
         return (
@@ -441,20 +417,21 @@ export function AlertCardGrid({
               )}
             </div>
             {!isCollapsed && (
-              <div className="flex gap-3">
-                {distributed.map((colGroups, colIdx) => (
-                  <div key={colIdx} className="flex min-w-0 flex-1 flex-col gap-3">
-                    {colGroups.map((group) => (
-                      <AlertCard
-                        key={`${group.groupValue}:${group.alertname}`}
-                        alerts={group.alerts}
-                        silences={silences}
-                        onClick={onSelectAlert}
-                        selectedFingerprint={selectedFingerprint}
-                        onCreateSilence={setSilenceAlerts}
-                        showSeverityBadge={groupByLabel !== 'severity'}
-                      />
-                    ))}
+              // CSS multi-column instead of hand-rolled bin-packing: the
+              // browser balances by real rendered height (collapsed cards,
+              // "show more" state, claim notes and all), not a height
+              // estimate that has to be kept in sync with every card change.
+              <div className="gap-3" style={{ columnCount: sectionCols }}>
+                {sectionGroups.map((group) => (
+                  <div key={`${group.groupValue}:${group.alertname}`} className="mb-3 break-inside-avoid">
+                    <AlertCard
+                      alerts={group.alerts}
+                      silences={silences}
+                      onClick={onSelectAlert}
+                      selectedFingerprint={selectedFingerprint}
+                      onCreateSilence={setSilenceAlerts}
+                      showSeverityBadge={groupByLabel !== 'severity'}
+                    />
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/settings/SettingsSheet.tsx
+++ b/frontend/src/components/settings/SettingsSheet.tsx
@@ -10,7 +10,9 @@ import { formatTime } from '@/lib/alertUtils'
 import {
   useSettingsStore,
   ALLOWED_SILENCE_DURATIONS,
+  CARD_COLUMN_OPTIONS,
 } from '@/store/useSettingsStore'
+import type { CardColumns } from '@/store/useSettingsStore'
 import type { DefaultFilter } from '@/store/useSettingsStore'
 import type { LabelMatcherOperator } from '@/types'
 import { useAlerts } from '@/hooks/useAlerts'
@@ -301,6 +303,30 @@ export function SettingsSheet({ open, onClose }: SettingsSheetProps) {
                 { value: 'list', label: 'List' },
               ]}
             />
+          </SettingRow>
+
+          <SettingRow
+            label="Card columns"
+            info="Number of columns in the Card view grid. Auto adapts to your window width (up to 4); a fixed number overrides that on every screen size."
+          >
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min={0}
+                max={CARD_COLUMN_OPTIONS.length}
+                step={1}
+                value={settings.cardColumns === 'auto' ? 0 : settings.cardColumns}
+                onChange={(e) => {
+                  const v = Number(e.target.value)
+                  update({ cardColumns: (v === 0 ? 'auto' : v) as CardColumns })
+                }}
+                className="h-1.5 w-28 cursor-pointer accent-primary"
+                aria-label="Card columns"
+              />
+              <span className="w-10 text-right text-xs font-medium tabular-nums">
+                {settings.cardColumns === 'auto' ? 'Auto' : settings.cardColumns}
+              </span>
+            </div>
           </SettingRow>
 
           <SettingRow

--- a/frontend/src/store/useSettingsStore.ts
+++ b/frontend/src/store/useSettingsStore.ts
@@ -8,12 +8,18 @@ export interface DefaultFilter {
   value: string
 }
 
+export const CARD_COLUMN_OPTIONS = [1, 2, 3, 4, 5, 6] as const
+export type CardColumns = 'auto' | (typeof CARD_COLUMN_OPTIONS)[number]
+
 export interface UserSettings {
   // Display
   theme: 'dark' | 'light'
   timeFormat: 'relative' | 'absolute'
   defaultViewMode: 'card' | 'list'
   groupByLabel: string
+  // Card view column count. 'auto' keeps the responsive 1/2/3/4 breakpoint
+  // behavior; a fixed number overrides it regardless of window width.
+  cardColumns: CardColumns
 
   // Default filter (locked, always present in header)
   defaultFilters: DefaultFilter[]
@@ -39,6 +45,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   timeFormat: 'relative',
   defaultViewMode: 'card',
   groupByLabel: 'severity',
+  cardColumns: 'auto',
   defaultFilters: [],
   resolvedPageSize: 25,
   defaultSilenceDurationMinutes: 60,


### PR DESCRIPTION
## Summary
- Replaced the hand-rolled height-estimate bin-packer in `AlertCardGrid.tsx` (`estimateHeight`/`distributeColumns`) with CSS multi-column layout (`columnCount` + `break-inside-avoid`). The estimate had already drifted out of sync with several card-content variants (collapsed state, pagination, claim notes); the browser now balances by real rendered height instead.
- Column count is capped to `min(columns, group count)` per section (and for the flat/ungrouped grid) — a section with fewer groups than columns no longer squeezes its cards into a fraction of the row width with empty space next to them.
- Groups within a section now sort by freshness (most recently fired first) instead of alphabetically, matching the backend's flat-list convention (`AlertStore.Get()`, `startsAt desc`).
- New "Card columns" setting (Settings → Display): a slider (Auto/1-6) overriding the responsive 1/2/3/4 breakpoint on every screen size. Default is Auto, so existing behavior is unchanged unless a user opts in.
- Corrected a pre-existing `architecture.md` inaccuracy found while updating the `SettingsSheet.tsx` doc entry: `resolvedPageSize` and `defaultCreatorName` were documented as settings-sheet fields but neither is actually editable there.

## Test plan
- [x] `pnpm build`, `pnpm run lint`, `pnpm run test:unit` — all green
- [x] Manual verification in the running dev stack (screenshots) for the grid layout at various group counts (1, 3, many) and the columns slider (2/6/Auto)
- [ ] Full containerized e2e suite not run in this session — recommend running in CI before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)